### PR TITLE
Ensure measurement models are used in updaters

### DIFF
--- a/stonesoup/dataassociator/tests/conftest.py
+++ b/stonesoup/dataassociator/tests/conftest.py
@@ -44,7 +44,8 @@ def probability_predictor():
 @pytest.fixture()
 def probability_updater():
     class TestGaussianUpdater:
-        def get_measurement_prediction(self, state_prediction, **kwargs):
+        def get_measurement_prediction(self, state_prediction,
+                                       measurement_model=None, **kwargs):
             return GaussianMeasurementPrediction(state_prediction.state_vector,
                                                  state_prediction.covar,
                                                  state_prediction.timestamp)

--- a/stonesoup/hypothesiser/distance.py
+++ b/stonesoup/hypothesiser/distance.py
@@ -38,7 +38,7 @@ class DistanceHypothesiser(Hypothesiser):
             prediction = self.predictor.predict(
                 track.state, timestamp=detection.timestamp)
             measurement_prediction = self.updater.get_measurement_prediction(
-                prediction)
+                prediction, detection.measurement_model)
             distance = self.measure(measurement_prediction, detection)
 
             hypotheses.append(

--- a/stonesoup/hypothesiser/probability.py
+++ b/stonesoup/hypothesiser/probability.py
@@ -115,6 +115,8 @@ class PDAHypothesiser(Hypothesiser):
                 probability=probability))
 
         for detection in detections:
+            measurement_prediction = self.updater.get_measurement_prediction(
+                prediction, detection.measurement_model)
 
             # hypothesis that track and given detection are associated
             log_pdf = mn.logpdf(detection.state_vector.ravel(),

--- a/stonesoup/hypothesiser/tests/conftest.py
+++ b/stonesoup/hypothesiser/tests/conftest.py
@@ -16,7 +16,8 @@ def predictor():
 @pytest.fixture()
 def updater():
     class TestGaussianUpdater:
-        def get_measurement_prediction(self, state_prediction, **kwargs):
+        def get_measurement_prediction(self, state_prediction,
+                                       measurement_model=None, **kwargs):
             return GaussianMeasurementPrediction(state_prediction.state_vector,
                                                  state_prediction.covar,
                                                  state_prediction.timestamp)

--- a/stonesoup/initiator/simple.py
+++ b/stonesoup/initiator/simple.py
@@ -35,11 +35,11 @@ class SinglePointInitiator(GaussianInitiator):
         """
 
         updater = KalmanUpdater(self.measurement_model)
-        measurement_prediction = updater.get_measurement_prediction(
-            self.prior_state)
 
         tracks = set()
         for detection in unassociated_detections:
+            measurement_prediction = updater.get_measurement_prediction(
+                self.prior_state, detection.measurement_model)
             track_state = updater.update(SingleHypothesis(
                 self.prior_state, detection, measurement_prediction))
             track = Track([track_state])

--- a/stonesoup/updater/base.py
+++ b/stonesoup/updater/base.py
@@ -15,13 +15,21 @@ class Updater(Base):
     measurement_model = Property(MeasurementModel, doc="measurement model")
 
     @abstractmethod
-    def get_measurement_prediction(self, state_prediction, **kwargs):
+    def get_measurement_prediction(
+            self, state_prediction, measurement_model=None, **kwargs):
         """Get measurement prediction from state prediction
 
         Parameters
         ----------
         state_prediction : :class:`~.StatePrediction`
             The state prediction
+        measurement_model: :class:`~.MeasurementModel`, optional
+            The measurement model used to generate the measurement prediction.
+            Should be used in cases where the measurement model is dependent
+            on the received measurement. The default is `None`, in which case
+            the updater will use the measurement model specified on
+            initialisation
+
 
         Returns
         -------


### PR DESCRIPTION
This resolves an issue where per-measurement measurement models weren't
being used in updaters `get_measurement_prediction` method