### PR TITLE
Fix for handling bearings in unscented transform.

### DIFF
--- a/stonesoup/functions.py
+++ b/stonesoup/functions.py
@@ -4,6 +4,7 @@
 import numpy as np
 
 from .types.numeric import Probability
+from .types.array import CovarianceMatrix
 
 
 def tria(matrix):
@@ -223,6 +224,7 @@ def unscented_transform(sigma_points, mean_weights, covar_weights,
         sigma_points_t = np.asarray(
             [fun(sigma_points[:, i:i+1], points_noise[:, i:i+1])
              for i in range(n_points)]).squeeze(2).T
+    sigma_points_t = CovarianceMatrix(sigma_points_t)
 
     # Calculate mean and covariance approximation
     mean, covar = sigma2gauss(

--- a/stonesoup/types/array.py
+++ b/stonesoup/types/array.py
@@ -19,7 +19,7 @@ class StateVector(np.ndarray):
         return array.view(cls)
 
     def __array_wrap__(self, array):
-        return np.asarray(array)
+        return StateVector._cast(np.asarray(array))
 
     def __matmul__(self, other):
         out = np.matmul(np.asfarray(self), np.asfarray(other))
@@ -28,6 +28,34 @@ class StateVector(np.ndarray):
     def __rmatmul__(self, other):
         out = np.matmul(np.asfarray(other), np.asfarray(self))
         return out.view(type=type(other))
+
+    @classmethod
+    def _cast(cls, val):
+        # This tries to cast the result as either a StateVector or
+        # CovarianceMatrix if applicable.
+        if val.ndim == 2:
+            if val.shape[1] == 1:
+                return cls(val)
+            else:
+                return CovarianceMatrix(val)
+        else:
+            return val
+
+    def __sub__(self, other):
+        tmp = super().__sub__(other)
+        return StateVector._cast(tmp)
+
+    def __rsub__(self, other):
+        tmp = super().__rsub__(other)
+        return StateVector._cast(tmp)
+
+    def __add__(self, other):
+        tmp = super().__add__(other)
+        return StateVector._cast(tmp)
+
+    def __radd__(self, other):
+        tmp = super().__radd__(other)
+        return StateVector._cast(tmp)
 
 
 class CovarianceMatrix(np.ndarray):
@@ -46,12 +74,24 @@ class CovarianceMatrix(np.ndarray):
         return array.view(cls)
 
     def __array_wrap__(self, array):
-        return np.asarray(array)
+        return StateVector._cast(np.asarray(array))
 
     def __matmul__(self, other):
-        out = np.matmul(self, np.asfarray(other))
+        out = np.matmul(np.asfarray(self), np.asfarray(other))
         return out.view(type=type(self))
 
     def __rmatmul__(self, other):
-        out = np.matmul(np.asfarray(other), self)
+        out = np.matmul(np.asfarray(other), np.asfarray(self))
         return out.view(type=type(other))
+
+    def __sub__(self, other):
+        return type(self)(super().__sub__(other))
+
+    def __rsub__(self, other):
+        return type(self)(super().__rsub__(other))
+
+    def __add__(self, other):
+        return type(self)(super().__add__(other))
+
+    def __radd__(self, other):
+        return type(self)(super().__radd__(other))

--- a/stonesoup/types/tests/test_array.py
+++ b/stonesoup/types/tests/test_array.py
@@ -48,3 +48,44 @@ def test_multiplication():
     assert type(state_vector.T@array.T) == type(state_vector)
     assert type(covar@vector) == type(covar)
     assert type(vector.T@covar.T) == type(vector)
+
+
+def test_array_ops():
+    vector = np.array([[1, 1, 1, 1]]).T
+    vector2 = vector + 2.
+    sv = StateVector(vector)
+    array = np.array([[1., 2., 3., 4.], [2., 3., 4., 5.]]).T
+    covar = CovarianceMatrix(array)
+    Mtype = type(covar)
+    Vtype = type(sv)
+
+    assert np.array_equal(covar - vector, array - vector)
+    assert type(covar-vector) == Mtype
+    assert np.array_equal(covar + vector, array + vector)
+    assert type(covar+vector) == Mtype
+    assert np.array_equal(vector - covar, vector - array)
+    assert type(vector - covar) == Mtype
+    assert np.array_equal(vector + covar, vector + array)
+    assert type(vector + covar) == Mtype
+
+    assert np.array_equal(vector2 - sv, vector2 - vector)
+    assert type(vector2 - sv) == Vtype
+    assert np.array_equal(sv - vector2, vector - vector2)
+    assert type(sv - vector2) == Vtype
+    assert np.array_equal(vector2 + sv, vector2 + vector)
+    assert type(vector2 + sv) == Vtype
+    assert np.array_equal(sv + vector2, vector + vector2)
+    assert type(sv + vector2) == Vtype
+    assert type(sv+2.) == Vtype
+    assert type(sv*2.) == Vtype
+
+    assert np.array_equal(array - sv, array - vector)
+    assert type(array - sv) == Mtype
+    assert np.array_equal(sv - array, vector - array)
+    assert type(sv - array) == Mtype
+    assert np.array_equal(array + sv, array + vector)
+    assert type(array + sv) == Mtype
+    assert np.array_equal(sv + array, vector + array)
+    assert type(sv + array) == Mtype
+    assert type(covar+2.) == Mtype
+    assert type(covar*2.) == Mtype


### PR DESCRIPTION
Fix casting of output of array operations. These changes fix the casting of the output of StoneSoup array operations. This should allow the Unscented filters to work .