### PR TITLE
Fixed bug in gm_reduce_single

### DIFF
--- a/stonesoup/functions.py
+++ b/stonesoup/functions.py
@@ -493,7 +493,7 @@ def gm_reduce_single(means, covars, weights):
     covar = np.zeros((num_dims, num_dims))
     for i in range(num_components):
         v = means[i, :] - mean
-        a = np.add(covars[i], v@v.T)
+        a = np.add(covars[i], v.T@v)
         b = weights[i]
         covar = np.add(covar, b*a)
 

--- a/stonesoup/tests/test_functions.py
+++ b/stonesoup/tests/test_functions.py
@@ -74,7 +74,8 @@ def test_gm_reduce_single():
     mean, covar = gm_reduce_single(means, covars, weights)
 
     assert np.allclose(mean, np.array([[4], [5]]))
-    assert np.allclose(covar, np.array([[5.675, 5.35], [5.2, 5.3375]]))
+    assert np.allclose(covar, np.array([[3.675, 3.35],
+                                        [3.2, 3.3375]]))
 
 
 def test_bearing():


### PR DESCRIPTION
Changed v@v.T to v.T@v since v is a row vector not a column vector. This was causing the merged covariance to be calculated incorrectly.