### PR TITLE
Update StateVector and Array classes. Add convenience handling for StateVector

### DIFF
--- a/stonesoup/functions.py
+++ b/stonesoup/functions.py
@@ -4,6 +4,7 @@
 import numpy as np
 
 from .types.numeric import Probability
+from .types.array import Matrix
 
 
 def tria(matrix):
@@ -223,6 +224,7 @@ def unscented_transform(sigma_points, mean_weights, covar_weights,
         sigma_points_t = np.asarray(
             [fun(sigma_points[:, i:i+1], points_noise[:, i:i+1])
              for i in range(n_points)]).squeeze(2).T
+    sigma_points_t = sigma_points_t.view(Matrix)
 
     # Calculate mean and covariance approximation
     mean, covar = sigma2gauss(

--- a/stonesoup/types/tests/test_array.py
+++ b/stonesoup/types/tests/test_array.py
@@ -2,17 +2,22 @@
 import numpy as np
 import pytest
 
-from ..array import StateVector, CovarianceMatrix
+from ..array import Matrix, StateVector, CovarianceMatrix
 
 
 def test_statevector():
     with pytest.raises(ValueError):
-        StateVector(np.array([0]))
+        StateVector([[0, 1], [1, 2]])
+
+    with pytest.raises(ValueError):
+        StateVector([[[0, 1], [1, 2]]])
 
     state_vector_array = np.array([[1], [2], [3], [4]])
     state_vector = StateVector(state_vector_array)
 
     assert np.array_equal(state_vector, state_vector_array)
+    assert np.array_equal(StateVector([1, 2, 3, 4]), state_vector_array)
+    assert np.array_equal(StateVector([[1, 2, 3, 4]]), state_vector_array)
 
 
 def test_covariancematrix():
@@ -30,12 +35,26 @@ def test_covariancematrix():
     assert(np.array_equal(covar_matrix, covar_nparray))
 
 
+def test_matrix():
+    """ Matrix Type test """
+
+    covar_nparray = np.array([[2.2128, 0, 0, 0],
+                              [0.0002, 2.2130, 0, 0],
+                              [0.3897, -0.00004, 0.0128, 0],
+                              [0, 0.3897, 0.0013, 0.0135]]) * 1e3
+
+    matrix = Matrix(covar_nparray)
+    assert(np.array_equal(matrix, covar_nparray))
+
+
 def test_multiplication():
     vector = np.array([[1, 1, 1, 1]]).T
     state_vector = StateVector(vector)
     array = np.array([[1., 2., 3., 4.],
                       [5., 6., 7., 8.]])
     covar = CovarianceMatrix(array)
+    Mtype = Matrix
+    Vtype = StateVector
 
     assert np.array_equal(covar@state_vector, array@vector)
     assert np.array_equal(covar@vector, array@vector)
@@ -44,7 +63,48 @@ def test_multiplication():
     assert np.array_equal(vector.T@covar.T, vector.T@array.T)
     assert np.array_equal(state_vector.T@array.T, vector.T@array.T)
 
-    assert type(array@state_vector) == type(array)
-    assert type(state_vector.T@array.T) == type(state_vector)
-    assert type(covar@vector) == type(covar)
-    assert type(vector.T@covar.T) == type(vector)
+    assert type(array@state_vector) == Vtype
+    assert type(state_vector.T@array.T) == Mtype
+    assert type(covar@vector) == Vtype
+    assert type(vector.T@covar.T) == Mtype
+
+
+def test_array_ops():
+    vector = np.array([[1, 1, 1, 1]]).T
+    vector2 = vector + 2.
+    sv = StateVector(vector)
+    array = np.array([[1., 2., 3., 4.], [2., 3., 4., 5.]]).T
+    covar = CovarianceMatrix(array)
+    Mtype = Matrix
+    Vtype = type(sv)
+
+    assert np.array_equal(covar - vector, array - vector)
+    assert type(covar-vector) == Mtype
+    assert np.array_equal(covar + vector, array + vector)
+    assert type(covar+vector) == Mtype
+    assert np.array_equal(vector - covar, vector - array)
+    assert type(vector - covar) == Mtype
+    assert np.array_equal(vector + covar, vector + array)
+    assert type(vector + covar) == Mtype
+
+    assert np.array_equal(vector2 - sv, vector2 - vector)
+    assert type(vector2 - sv) == Vtype
+    assert np.array_equal(sv - vector2, vector - vector2)
+    assert type(sv - vector2) == Vtype
+    assert np.array_equal(vector2 + sv, vector2 + vector)
+    assert type(vector2 + sv) == Vtype
+    assert np.array_equal(sv + vector2, vector + vector2)
+    assert type(sv + vector2) == Vtype
+    assert type(sv+2.) == Vtype
+    assert type(sv*2.) == Vtype
+
+    assert np.array_equal(array - sv, array - vector)
+    assert type(array - sv) == Mtype
+    assert np.array_equal(sv - array, vector - array)
+    assert type(sv - array) == Mtype
+    assert np.array_equal(array + sv, array + vector)
+    assert type(array + sv) == Mtype
+    assert np.array_equal(sv + array, vector + array)
+    assert type(sv + array) == Mtype
+    assert type(covar+2.) == Mtype
+    assert type(covar*2.) == Mtype

--- a/stonesoup/types/tests/test_state.py
+++ b/stonesoup/types/tests/test_state.py
@@ -27,7 +27,7 @@ def test_state():
 
 def test_state_invalid_vector():
     with pytest.raises(ValueError):
-        State(np.array([1, 2, 3, 4]))
+        State(np.array([[[1, 2, 3, 4]]]))
 
 
 def test_gaussianstate():


### PR DESCRIPTION
This creates a proper Matrix base class which inherits from Numpy's ndarray, StateVector, and Covariance Matrix are now subtypes of this Matrix class.  The output from mixed operations such as CovarianceMatrix*ndarray returns a StoneSoup type. This is most likely the desired behaviour, and allows the code to handle matrix operations involving Bearing or Elevation types properly.

Also added convenience functions for the creation a StateVector. StateVector returns a Nx1 matrix, so if the passed in data can be easily converted to this, then the conversion is done. For example
StateVector([1, 2, 3]) = StateVector([[1, 2, 3]] = StateVector([[1], [2], [3]]). These statements all create the same 3x1 StateVector.