### PR TITLE
Detection Feeders

### DIFF
--- a/stonesoup/feeder/tests/conftest.py
+++ b/stonesoup/feeder/tests/conftest.py
@@ -14,51 +14,51 @@ def detector():
             time_step = datetime.timedelta(seconds=1)
 
             yield time, {
-                Detection([[0], [0]], timestamp=time,
+                Detection([[50], [0]], timestamp=time,
                           metadata={'colour': 'red'}),
-                Detection([[0], [0]], timestamp=time,
+                Detection([[20], [5]], timestamp=time,
+                          metadata={'colour': 'green'}),
+                Detection([[1], [1]], timestamp=time,
+                          metadata={'colour': 'blue'}),
+            }
+
+            time += time_step
+            yield time, {
+                Detection([[-5], [4]], timestamp=time,
+                          metadata={'colour': 'red'}),
+                Detection([[11], [200]], timestamp=time,
                           metadata={'colour': 'green'}),
                 Detection([[0], [0]], timestamp=time,
-                          metadata={'colour': 'blue'}),
-            }
-
-            time += time_step
-            yield time, {
-                Detection([[0], [0]], timestamp=time,
-                          metadata={'colour': 'red'}),
-                Detection([[0], [0]], timestamp=time,
                           metadata={'colour': 'green'}),
-                Detection([[0], [0]], timestamp=time,
-                          metadata={'colour': 'green'}),
-                Detection([[0], [0]], timestamp=time,
+                Detection([[-43], [-10]], timestamp=time,
                           metadata={'colour': 'blue'}),
             }
 
             time += time_step
             yield time, {
-                Detection([[0], [0]], timestamp=time,
+                Detection([[561], [10]], timestamp=time,
                           metadata={'colour': 'red'}),
-                Detection([[0], [0]], timestamp=time - time_step/2,
+                Detection([[1], [-10]], timestamp=time - time_step/2,
                           metadata={'colour': 'red'}),
-                Detection([[0], [0]], timestamp=time,
+                Detection([[-11], [-50]], timestamp=time,
                           metadata={'colour': 'blue'}),
             }
 
             time += time_step
             yield time, {
-                Detection([[0], [0]], timestamp=time,
+                Detection([[1], [-5]], timestamp=time,
                           metadata={'colour': 'red'}),
-                Detection([[0], [0]], timestamp=time,
+                Detection([[1], [-5]], timestamp=time,
                           metadata={'colour': 'blue'}),
             }
 
             time += time_step
             yield time, {
-                Detection([[0], [0]], timestamp=time,
+                Detection([[-11], [5]], timestamp=time,
                           metadata={'colour': 'red'}),
-                Detection([[0], [0]], timestamp=time,
+                Detection([[13], [654]], timestamp=time,
                           metadata={'colour': 'blue'}),
-                Detection([[0], [0]], timestamp=time,
+                Detection([[-3], [6]], timestamp=time,
                           metadata={}),
             }
 
@@ -74,11 +74,11 @@ def detector():
                           metadata={}),
             }
 
-            time -= time_step*1
+            time -= time_step
             yield time, {
-                Detection([[0], [0]], timestamp=time,
+                Detection([[5], [-6]], timestamp=time,
                           metadata={'colour': 'red'}),
-                Detection([[0], [0]], timestamp=time,
+                Detection([[10], [0]], timestamp=time,
                           metadata={'colour': 'blue'}),
             }
 

--- a/stonesoup/feeder/tests/conftest.py
+++ b/stonesoup/feeder/tests/conftest.py
@@ -15,49 +15,62 @@ def detector():
 
             yield time, {
                 Detection([[50], [0]], timestamp=time,
-                          metadata={'colour': 'red'}),
+                          metadata={'colour': 'red',
+                                    'score': 0}),
                 Detection([[20], [5]], timestamp=time,
-                          metadata={'colour': 'green'}),
+                          metadata={'colour': 'green',
+                                    'score': 0.5}),
                 Detection([[1], [1]], timestamp=time,
-                          metadata={'colour': 'blue'}),
+                          metadata={'colour': 'blue',
+                                    'score': 0.1}),
             }
 
             time += time_step
             yield time, {
                 Detection([[-5], [4]], timestamp=time,
-                          metadata={'colour': 'red'}),
+                          metadata={'colour': 'red',
+                                    'score': 0.4}),
                 Detection([[11], [200]], timestamp=time,
                           metadata={'colour': 'green'}),
                 Detection([[0], [0]], timestamp=time,
-                          metadata={'colour': 'green'}),
+                          metadata={'colour': 'green',
+                                    'score': 0.2}),
                 Detection([[-43], [-10]], timestamp=time,
-                          metadata={'colour': 'blue'}),
+                          metadata={'colour': 'blue',
+                                    'score': 0.326}),
             }
 
             time += time_step
             yield time, {
                 Detection([[561], [10]], timestamp=time,
-                          metadata={'colour': 'red'}),
+                          metadata={'colour': 'red',
+                                    'score': 0.745}),
                 Detection([[1], [-10]], timestamp=time - time_step/2,
-                          metadata={'colour': 'red'}),
+                          metadata={'colour': 'red',
+                                    'score': 0}),
                 Detection([[-11], [-50]], timestamp=time,
-                          metadata={'colour': 'blue'}),
+                          metadata={'colour': 'blue',
+                                    'score': 2}),
             }
 
             time += time_step
             yield time, {
                 Detection([[1], [-5]], timestamp=time,
-                          metadata={'colour': 'red'}),
+                          metadata={'colour': 'red',
+                                    'score': 0.3412}),
                 Detection([[1], [-5]], timestamp=time,
-                          metadata={'colour': 'blue'}),
+                          metadata={'colour': 'blue',
+                                    'score': 0.214}),
             }
 
             time += time_step
             yield time, {
                 Detection([[-11], [5]], timestamp=time,
-                          metadata={'colour': 'red'}),
+                          metadata={'colour': 'red',
+                                    'score': 0.5}),
                 Detection([[13], [654]], timestamp=time,
-                          metadata={'colour': 'blue'}),
+                          metadata={'colour': 'blue',
+                                    'score': 0}),
                 Detection([[-3], [6]], timestamp=time,
                           metadata={}),
             }
@@ -65,11 +78,13 @@ def detector():
             time += time_step*2
             yield time, {
                 Detection([[0], [0]], timestamp=time,
-                          metadata={'colour': 'red'}),
+                          metadata={'colour': 'red',
+                                    'score': 1}),
                 Detection([[0], [0]], timestamp=time,
-                          metadata={'colour': 'blue'}),
+                          metadata={'colour': 'blue',
+                                    'score': 0.612}),
                 Detection([[0], [0]], timestamp=time,
-                          metadata={}),
+                          metadata={'score': 0}),
                 Detection([[0], [0]], timestamp=time,
                           metadata={}),
             }
@@ -77,7 +92,8 @@ def detector():
             time -= time_step
             yield time, {
                 Detection([[5], [-6]], timestamp=time,
-                          metadata={'colour': 'red'}),
+                          metadata={'colour': 'red',
+                                    'score': 0.2}),
                 Detection([[10], [0]], timestamp=time,
                           metadata={'colour': 'blue'}),
             }

--- a/stonesoup/feeder/tests/test_filter.py
+++ b/stonesoup/feeder/tests/test_filter.py
@@ -38,7 +38,7 @@ def test_metadata_reducer(detector):
 def test_metadata_value_filter(detector):
     feeder = MetadataValueFilter(detector,
                                  metadata_field="score",
-                                 operator=lambda x: operator.ge(x, 0.1))
+                                 operator=lambda x: x >= 0.1)
     # Discard unmatched
     nones = False
     for time, detections in feeder.detections_gen():
@@ -60,7 +60,6 @@ def test_metadata_value_filter(detector):
     for time, detections in feeder.detections_gen():
         all_scores = [detection.metadata.get('score')
                       for detection in detections]
-        print(all_scores)
         nones = nones | (len([score for score in all_scores
                               if score is None]) > 0)
         scores = [score for score in all_scores if score is not None]

--- a/stonesoup/feeder/tests/test_filter.py
+++ b/stonesoup/feeder/tests/test_filter.py
@@ -1,7 +1,12 @@
 # -*- coding: utf-8 -*-
 import datetime
+import numpy as np
 
-from ..filter import MetadataReducer
+import pytest
+
+from ..filter import (MetadataReducer,
+                      MetadataValueFilter,
+                      BoundingBoxDetectionReducer)
 
 
 def test_metadata_reducer(detector):
@@ -28,3 +33,83 @@ def test_metadata_reducer(detector):
         assert all(time == detection.timestamp for detection in detections)
 
     assert multi_none
+
+
+def test_metadata_value_filter(detector):
+    feeder = MetadataValueFilter(detector,
+                                 metadata_field="score",
+                                 operator=lambda x: operator.ge(x, 0.1))
+    # Discard unmatched
+    nones = False
+    for time, detections in feeder.detections_gen():
+        all_scores = [detection.metadata.get('score')
+                      for detection in detections]
+        nones = nones | (len([score for score in all_scores
+                              if score is None]) > 0)
+        scores = [score for score in all_scores if score is not None]
+        assert len(scores) == len(set(scores))
+        assert 0 not in scores
+        if time < datetime.datetime(2019, 4, 1, 14, 0, 2):
+            assert all([score <= 0.5 for score in scores])
+        assert all(time == detection.timestamp for detection in detections)
+    assert not nones
+
+    # Keep unmatched
+    feeder.keep_unmatched = True
+    nones = False
+    for time, detections in feeder.detections_gen():
+        all_scores = [detection.metadata.get('score')
+                      for detection in detections]
+        print(all_scores)
+        nones = nones | (len([score for score in all_scores
+                              if score is None]) > 0)
+        scores = [score for score in all_scores if score is not None]
+        assert len(scores) == len(set(scores))
+        assert 0 not in scores
+        if time < datetime.datetime(2019, 4, 1, 14, 0, 2):
+            assert all([score <= 0.5 for score in scores])
+        assert all(time == detection.timestamp for detection in detections)
+    assert nones
+
+
+def test_boundingbox_reducer(detector):
+
+    # Simple 2D rectangle/bounding box
+    limits = np.array([[-1, 1],
+                       [-2, 2]])
+    mapping = [1, 0]
+
+    # Confirm errors raised on improper instantiation attempt
+    with pytest.raises(TypeError):
+        BoundingBoxDetectionReducer()
+    with pytest.raises(TypeError):
+        BoundingBoxDetectionReducer(detector)
+    with pytest.raises(TypeError):
+        BoundingBoxDetectionReducer(detector, limits)
+
+    feeder = BoundingBoxDetectionReducer(detector, limits, mapping)
+
+    # Assert correct constructor assignments
+    assert np.array_equal(limits, feeder.limits)
+    assert np.array_equal(mapping, feeder.mapping)
+
+    # Ensure only measurements within box are returned
+    multi_check = True
+    for time, detections in feeder.detections_gen():
+
+        for detection in detections:
+            num_dims = len(limits)
+            for i in range(num_dims):
+                min = limits[i, 0]
+                max = limits[i, 1]
+                value = detection.state_vector[mapping[i]]
+                multi_check &= not (value < min or value > max)
+
+        if time < datetime.datetime(2019, 4, 1, 14, 0, 2):
+            assert len(detections) == 1
+        elif time == datetime.datetime(2019, 4, 1, 14, 0, 7):
+            assert not (len(detections))
+
+        assert all(time == detection.timestamp for detection in detections)
+
+    assert multi_check


### PR DESCRIPTION
This pull request includes 2 new `DetectionFeeder` objects, which may be of interest:

1. The `MetadataValueFilter` class aims to provide a simple, yet relatively flexible scheme for filtering/removing unwanted detections based on the value of some metadata field (e.g. MMSI, SNR, size, etc.). Being a subclass of `MetadataReducer`, this feeder inherits the `metadata_field` property, which it uses to store the field name of the meta value of interest. For any given detection, assuming that the meta field exists, the feeder passes the extracted meta value `x` through a user-defined unary operator/function of the form `b=f(x)`, whose handle is stored in the `operator` class property, and must be configured to return `True` if the detection should be allowed through the filter (i.e. yielded) and `False` if the detection should be dropped/filtered out. An optional `keep_unmatched` class property is defined that dictates whether detections lacking the meta field should be dropped (default) or yielded.

2. The `BoundingBoxDetectionReducer`  allows users to reduce/limit the amount of detections to a subset that falls within the limits of a given n-dimensional bounding box. The bounding box is defined as a sequence of min/max coordinate pairs, one for each box dimension, based on which the feeder then applies a filter to the incoming detections, allowing to pass through only those that fall within the specified limits, and dropping the ones that do not.   

More information about the classes can be found in the code.