### PR TITLE
fix-ConstantAcceleration transition model

### DIFF
--- a/stonesoup/models/transition/linear.py
+++ b/stonesoup/models/transition/linear.py
@@ -369,7 +369,7 @@ class ConstantAcceleration(LinearGaussianTransitionModel, TimeVariantModel):
         time_interval_sec = time_interval.total_seconds()
 
         return sp.array(
-                    [[1, time_interval_sec, sp.power(time_interval_sec, 2)],
+                    [[1, time_interval_sec, sp.power(time_interval_sec, 2) / 2],
                      [0, 1, time_interval_sec],
                      [0, 0, 1]])
 

--- a/stonesoup/models/transition/tests/test_ca.py
+++ b/stonesoup/models/transition/tests/test_ca.py
@@ -55,7 +55,7 @@ def base(state_vec, noise_diff_coeffs):
 
     # Model-related components
     noise_diff_coeffs = noise_diff_coeffs  # m/s^3
-    base_mat = sp.array([[1, timediff, sp.power(timediff, 2)],
+    base_mat = sp.array([[1, timediff, sp.power(timediff, 2) / 2],
                          [0, 1, timediff],
                          [0, 0, 1]])
     mat_list = [base_mat for num in range(0, dim)]


### PR DESCRIPTION
Fix the mistake of constant acceleration model. The third term is divided by 2, namely 'sp.power(time_interval_sec, 2) / 2' in 'Stone-Soup/stonesoup/models/transition/linear.py' and 'sp.power(timediff, 2) / 2' in 'Stone-Soup/stonesoup/models/transition/tests/test_ca.py'