### PR TITLE
Fix double "https://" in README link to utm Lib

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Stone Soup uses the following dependencies:
 | [matplotlib](https://matplotlib.org/) | [PSF/BSD-compatible](https://matplotlib.org/users/license.html) |
 | [ruamel.yaml](https://yaml.readthedocs.io/) | MIT |
 | [pymap3d](https://github.com/scivision/pymap3d) | MIT |
-| [utm](https://https://github.com/Turbo87/utm) | MIT |
+| [utm](https://github.com/Turbo87/utm) | MIT |
 
 ### Development
 For development the following libraries are also recommended:


### PR DESCRIPTION
This commit aims to fix an error in the README file. In the section about "Dependencies" the protocol in the link to the utm library was defined twice. It is a minor bug, but it may lead to inconvenience for users trying to explore if the stonesoup project is a good option for them.