### PR TITLE
Track metadata handling update

### DIFF
--- a/stonesoup/types/state.py
+++ b/stonesoup/types/state.py
@@ -61,6 +61,9 @@ class StateMutableSequence(Type, MutableSequence):
     def __init__(self, states=None, *args, **kwargs):
         if states is None:
             states = []
+        elif not isinstance(states, list):
+            # Ensure states is a list
+            states = [states]
         super().__init__(states, *args, **kwargs)
 
     def __len__(self):

--- a/stonesoup/types/track.py
+++ b/stonesoup/types/track.py
@@ -2,6 +2,7 @@
 import uuid
 
 from ..base import Property
+from .multihypothesis import MultipleHypothesis
 from .state import State, StateMutableSequence
 from .update import Update
 
@@ -25,8 +26,22 @@ class Track(StateMutableSequence):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        # Initialise metadata
+        self._metadata = {}
+        for state in self.states:
+            self._update_metadata_from_state(state)
         if self.id is None:
             self.id = str(uuid.uuid4())
+
+    def __setitem__(self, index, value):
+        # Update metadata
+        self._update_metadata_from_state(value)
+        return super().__setitem__(index, value)
+
+    def insert(self, index, value):
+        # Update metadata
+        self._update_metadata_from_state(value)
+        return super().insert(index, value)
 
     @property
     def metadata(self):
@@ -42,11 +57,33 @@ class Track(StateMutableSequence):
             All metadata associate with this track.
         """
 
-        metadata = {}
+        return self._metadata
 
-        for state in self:
-            if isinstance(state, Update) \
-                    and state.hypothesis.measurement.metadata is not None:
-                metadata.update(state.hypothesis.measurement.metadata)
+    def _update_metadata_from_state(self, state):
+        """ Extract and update track metadata, given a state
 
-        return metadata
+        Parameters
+        ----------
+        state: State
+            A state object from which to extract metadata. Metadata can only
+            be extracted from Update (or subclassed) objects. Calling this
+            method with a non-Update (subclass) object will NOT return an
+            error, but will have no effect on the metadata.
+
+        """
+
+        if isinstance(state, Update):
+            if isinstance(state.hypothesis, MultipleHypothesis):
+                # Sort and iterate through multiple hypotheses such that most
+                # likely hypothesis comes last. This ensures that metadata
+                # from all hypotheses are retained, but more likely
+                # hypotheses will over-write the metadata set by less likely
+                # ones.
+                for hypothesis in sorted(state.hypothesis, reverse=True):
+                    if hypothesis \
+                            and hypothesis.measurement.metadata is not None:
+                        self._metadata.update(hypothesis.measurement.metadata)
+            else:
+                hypothesis = state.hypothesis
+                if hypothesis and hypothesis.measurement.metadata is not None:
+                    self._metadata.update(hypothesis.measurement.metadata)


### PR DESCRIPTION
Following discussions with @sdhiscocks during Fusion in relation to #118, this pull request aims to solve the performance issues relating to reading metadata as follows:

- Track objects will now maintain a copy of what should be the most up-to-date metadata at each time. Thus, reading metadata should be more efficient, at the expense of the additional memory required to store the metadata and a small computational overhead when new states are added to a track.
- Metadata is updated automatically every time a new state is added to a track. This assumes (as we have done so far) that the last state in the list of states is also the latest one, i.e. the proposed approach will "fail" if states are added in an out-of-sequence manner.
- Although not implemented here, this approach can be extended to allow users to edit and/or add to the track metadata (e.g. by implementing a `Track.metadata()` setter method).

As part of the above, a small correction has also been applied to `StateMutableSequence` to ensure that the `states` property is always a list after initialisation, even if a single `State` object is passed. Previously, a statement of the form ```track = Track(states=State(np.array([[1]]), timestamp=datetime.datetime.now())``` would cause `track.states` to be a `State` object, rather than a list of length 1.