### PR TITLE
Added 2D Raster Radar Scan to /sensor/radar.py

### DIFF
--- a/stonesoup/sensor/radar.py
+++ b/stonesoup/sensor/radar.py
@@ -208,3 +208,68 @@ class RadarRotatingRangeBearing(RadarRangeBearing):
                           + duration.total_seconds()*rps*2*np.pi]]),
             timestamp
         )
+
+
+class RadarRasterScanRangeBearing(RadarRotatingRangeBearing):
+    """A simple raster scan radar, with set field-of-regard (FoR) angle, \
+     field-of-view (FoV) angle, range and rotations per minute (RPM), that \
+     generates measurements of targets, using a \
+     :class:`~.RangeBearingGaussianToCartesian` model, relative to its position
+
+     This is a simple extension of the RadarRotatingRangeBearing class with \
+     the rotate function changed to restrict the  dwell-center to within the \
+     field of regard.
+     It's important to note that this only works (has  been tested) in an 2D \
+     environment
+
+    Note
+    ----
+    * The current implementation of this class assumes a 3D Cartesian plane.
+
+    """
+
+    for_angle = Property(
+        float, doc="The radar field of regard (FoR) angle (in radians).")
+
+    def __init__(self, position, orientation, ndim_state, mapping, noise_covar,
+                 dwell_center, rpm, max_range, fov_angle, for_angle, *args,
+                 **kwargs):
+
+        super().__init__(position, orientation, ndim_state, mapping,
+                         noise_covar, dwell_center, rpm, max_range,
+                         fov_angle, for_angle, *args, **kwargs)
+
+    def rotate(self, timestamp):
+        """Rotate the sensor's antenna
+
+        This method computes and updates the sensor's `dwell_center` property.
+
+        Parameters
+        ----------
+        timestamp: :class:`datetime.datetime`
+            A timestamp signifying when the rotation completes
+        """
+
+        super().rotate(timestamp)
+
+        dwell_center_max = self.for_angle / 2.0 - self.fov_angle / 2.0
+        dwell_center_min = -self.for_angle / 2.0 + self.fov_angle / 2.0
+
+        # If the FoV is outside of the FoR:
+        #   Correct the dwell_center
+        #   Reverse the direction of the scan pattern
+        if self.dwell_center.state_vector[0, 0] > dwell_center_max:
+            self.dwell_center = State(
+                StateVector([[(2.0 * dwell_center_max) -
+                              self.dwell_center.state_vector[0, 0]
+                              ]]), timestamp)
+
+            self.rpm = -self.rpm
+
+        elif self.dwell_center.state_vector[0, 0] < dwell_center_min:
+            self.dwell_center = State(
+                StateVector([[(2.0 * dwell_center_min) -
+                              self.dwell_center.state_vector[0, 0]
+                              ]]), timestamp)
+
+            self.rpm = -self.rpm

--- a/stonesoup/sensor/tests/test_radar.py
+++ b/stonesoup/sensor/tests/test_radar.py
@@ -7,11 +7,11 @@ from ...functions import cart2pol
 from ...types.angle import Bearing
 from ...types.array import StateVector, CovarianceMatrix
 from ...types.state import State
-from ..radar import RadarRangeBearing, RadarRotatingRangeBearing
+from ..radar import RadarRangeBearing, RadarRotatingRangeBearing, \
+    RadarRasterScanRangeBearing
 
 
 def h2d(state_vector, translation_offset, rotation_offset):
-
     xyz = [[state_vector[0, 0] - translation_offset[0, 0]],
            [state_vector[1, 0] - translation_offset[1, 0]],
            [0]]
@@ -35,21 +35,20 @@ def h2d(state_vector, translation_offset, rotation_offset):
                       [0, cos_x, -sin_x],
                       [0, sin_x, cos_x]])
 
-    rotation_matrix = rot_z@rot_y@rot_x
+    rotation_matrix = rot_z @ rot_y @ rot_x
 
     xyz_rot = rotation_matrix @ xyz
     x = xyz_rot[0, 0]
     y = xyz_rot[1, 0]
     # z = 0  # xyz_rot[2, 0]
 
-    rho = np.sqrt(x**2 + y**2)
+    rho = np.sqrt(x ** 2 + y ** 2)
     phi = np.arctan2(y, x)
 
     return np.array([[Bearing(phi)], [rho]])
 
 
 def test_simple_radar():
-
     # Input arguments
     # TODO: pytest parametarization
     noise_covar = CovarianceMatrix(np.array([[0.015, 0],
@@ -71,9 +70,9 @@ def test_simple_radar():
         noise_covar=noise_covar)
 
     # Assert that the object has been correctly initialised
-    assert(np.equal(radar.position, radar_position).all())
-    assert(np.equal(radar.measurement_model.translation_offset,
-                    radar_position).all())
+    assert (np.equal(radar.position, radar_position).all())
+    assert (np.equal(radar.measurement_model.translation_offset,
+                     radar_position).all())
 
     # Generate a noiseless measurement for the given target
     measurement = radar.gen_measurement(target_state, noise=0)
@@ -83,13 +82,12 @@ def test_simple_radar():
                         - radar_position[1, 0])
 
     # Assert correction of generated measurement
-    assert(measurement.timestamp == target_state.timestamp)
-    assert(np.equal(measurement.state_vector,
-                    StateVector(np.array([[phi], [rho]]))).all())
+    assert (measurement.timestamp == target_state.timestamp)
+    assert (np.equal(measurement.state_vector,
+                     StateVector(np.array([[phi], [rho]]))).all())
 
 
 def test_rotating_radar():
-
     # Input arguments
     # TODO: pytest parametarization
     timestamp = datetime.datetime.now()
@@ -104,9 +102,9 @@ def test_rotating_radar():
     # The radar antenna is facing opposite the radar orientation
     dwell_center = State(StateVector([[-np.pi]]),
                          timestamp=timestamp)
-    rpm = 20            # 20 Rotations Per Minute
-    max_range = 100     # Max range of 100m
-    fov_angle = np.pi/3       # FOV angle of pi/3
+    rpm = 20  # 20 Rotations Per Minute
+    max_range = 100  # Max range of 100m
+    fov_angle = np.pi / 3  # FOV angle of pi/3
 
     target_state = State(radar_position +
                          np.array([[5], [5]]),
@@ -126,15 +124,15 @@ def test_rotating_radar():
         fov_angle=fov_angle)
 
     # Assert that the object has been correctly initialised
-    assert(np.equal(radar.position, radar_position).all())
-    assert(np.equal(radar.measurement_model.translation_offset,
-                    radar_position).all())
+    assert (np.equal(radar.position, radar_position).all())
+    assert (np.equal(radar.measurement_model.translation_offset,
+                     radar_position).all())
 
     # Generate a noiseless measurement for the given target
     measurement = radar.gen_measurement(target_state, noise=0)
 
     # Assert measurement is None since target is not in FOV
-    assert(measurement is None)
+    assert (measurement is None)
 
     # Rotate radar such that the target is in FOV
     timestamp = timestamp + datetime.timedelta(seconds=0.5)
@@ -144,10 +142,87 @@ def test_rotating_radar():
     measurement = radar.gen_measurement(target_state, noise=0)
     eval_m = h2d(target_state.state_vector,
                  radar.position,
-                 radar.orientation+[[0],
-                                    [0],
-                                    [radar.dwell_center.state_vector[0, 0]]])
+                 radar.orientation + [[0],
+                                      [0],
+                                      [radar.dwell_center.state_vector[0, 0]]])
 
     # Assert correction of generated measurement
-    assert(measurement.timestamp == target_state.timestamp)
-    assert(np.equal(measurement.state_vector, eval_m).all())
+    assert (measurement.timestamp == target_state.timestamp)
+    assert (np.equal(measurement.state_vector, eval_m).all())
+
+
+def test_raster_scan_radar():
+    # Input arguments
+    # TODO: pytest parametarization
+    timestamp = datetime.datetime.now()
+    noise_covar = CovarianceMatrix(np.array([[0.015, 0],
+                                             [0, 0.1]]))
+
+    # The radar is positioned at (1,1)
+    radar_position = StateVector(
+        np.array(([[1], [1]])))
+    # The radar is facing left/east
+    radar_orientation = StateVector([[0], [0], [np.pi]])
+    # The radar antenna is facing opposite the radar orientation
+    dwell_center = State(StateVector([[np.pi / 4]]),
+                         timestamp=timestamp)
+    rpm = 20  # 20 Rotations Per Minute Counter-clockwise
+    max_range = 100  # Max range of 100m
+    fov_angle = np.pi / 12  # FOV angle of pi/12 (15 degrees)
+    for_angle = np.pi + fov_angle  # FOR angle of pi*(13/12) (195 degrees)
+    # This will be mean the dwell center will reach at the limits -pi/2 and
+    # pi/2. As the edge of the beam will reach the full FOV
+
+    target_state = State(radar_position +
+                         np.array([[-5], [5]]),
+                         timestamp=timestamp)
+    measurement_mapping = np.array([0, 1])
+
+    # Create a radar object
+    radar = RadarRasterScanRangeBearing(
+        position=radar_position,
+        orientation=radar_orientation,
+        ndim_state=2,
+        mapping=measurement_mapping,
+        noise_covar=noise_covar,
+        dwell_center=dwell_center,
+        rpm=rpm,
+        max_range=max_range,
+        fov_angle=fov_angle,
+        for_angle=for_angle)
+
+    # Assert that the object has been correctly initialised
+    assert (np.equal(radar.position, radar_position).all())
+    assert (np.equal(radar.measurement_model.translation_offset,
+                     radar_position).all())
+
+    # Generate a noiseless measurement for the given target
+    measurement = radar.gen_measurement(target_state, noise=0)
+
+    # Assert measurement is None since target is not in FOV
+    assert (measurement is None)
+
+    # Rotate radar
+    timestamp = timestamp + datetime.timedelta(seconds=0.5)
+    target_state = State(radar_position +
+                         np.array([[-5], [5]]),
+                         timestamp=timestamp)
+    measurement = radar.gen_measurement(target_state, noise=0)
+    # Assert measurement is None since target is not in FOV
+    assert (measurement is None)
+
+    # Rotate radar such that the target is in FOV
+    timestamp = timestamp + datetime.timedelta(seconds=1.0)
+    target_state = State(radar_position +
+                         np.array([[-5], [5]]),
+                         timestamp=timestamp)
+    measurement = radar.gen_measurement(target_state, noise=0)
+    eval_m = h2d(target_state.state_vector,
+                 radar.position,
+                 radar.orientation + [[0],
+                                      [0],
+                                      [radar.dwell_center.state_vector[0, 0]]])
+
+    # Assert correction of generated measurement
+    assert (measurement.timestamp == target_state.timestamp)
+    assert (np.equal(measurement.state_vector, eval_m).all())


### PR DESCRIPTION
This is a simple extension of the RadarRotatingRangeBearing class to limit the FoR (field of regard) of the radar. Once the rotating radar's field of view reaches the limit of the FoR the direction of the radar rotation is changed.