### PR TITLE
Move all rvs and pdf methods to GaussianModel class

### DIFF
--- a/stonesoup/models/base.py
+++ b/stonesoup/models/base.py
@@ -1,8 +1,12 @@
 # -*- coding: utf-8 -*-
 from abc import abstractmethod
 
+import numpy as np
+from scipy.stats import multivariate_normal
+
 from ..base import Base
 from ..functions import jacobian as compute_jac
+from ..types.numeric import Probability
 
 
 class Model(Base):
@@ -10,18 +14,24 @@ class Model(Base):
 
     Base/Abstract class for all models."""
 
+    @property
     @abstractmethod
-    def function(self):
+    def ndim(self):
+        """Number of dimensions of model"""
+        pass
+
+    @abstractmethod
+    def function(self, state_vector, noise=None):
         """ Model function"""
         pass
 
     @abstractmethod
-    def rvs(self):
+    def rvs(self, num_samples=1):
         """Model noise/sample generation method"""
         pass
 
     @abstractmethod
-    def pdf(self):
+    def pdf(self, state_vector1, state_vector2):
         """Model pdf/likelihood evaluator method"""
         pass
 
@@ -150,6 +160,69 @@ class GaussianModel(Model):
 
     Base/Abstract class for all Gaussian models"""
 
+    def rvs(self, num_samples=1, **kwargs):
+        r"""Model noise/sample generation function
+
+        Generates noise samples from the model.
+
+        In mathematical terms, this can be written as:
+
+        .. math::
+
+            v_t \sim \mathcal{N}(0,Q)
+
+        where :math:`v_t =` ``noise`` and :math:`Q` = :attr:`covar`.
+
+        Parameters
+        ----------
+        num_samples: scalar, optional
+            The number of samples to be generated (the default is 1)
+
+        Returns
+        -------
+        noise : 2-D array of shape (:attr:`~.ndim`, ``num_samples``)
+            A set of Np samples, generated from the model's noise
+            distribution.
+        """
+
+        noise = multivariate_normal.rvs(
+            np.zeros(self.ndim), self.covar(**kwargs), num_samples)
+
+        return np.atleast_2d(noise).T
+
+    def pdf(self, state_vector1, state_vector2, **kwargs):
+        r"""Model pdf/likelihood evaluation function
+
+        Evaluates the pdf/likelihood of ``state_vector1``, given the state
+        ``state_vector2`` which is passed to :meth:`~.function`.
+
+        In mathematical terms, this can be written as:
+
+        .. math::
+
+            p = p(y_t | x_t) = \mathcal{N}(y_t; x_t, Q)
+
+        where :math:`y_t` = ``state_vector1``, :math:`x_t` = ``state_vector2``
+        and :math:`Q` = :attr:`covar`.
+
+        Parameters
+        ----------
+        state_vector1 : :class:`~.StateVector`
+        state_vector2 : :class:`~.StateVector`
+
+        Returns
+        -------
+        : :class:`~.Probability`
+            The likelihood of ``state_vector1``, given ``state_vector2``
+        """
+
+        likelihood = multivariate_normal.logpdf(
+            state_vector1.T,
+            mean=self.function(state_vector2, noise=0, **kwargs).ravel(),
+            cov=self.covar(**kwargs)
+        )
+        return Probability(likelihood, log_value=True)
+
     @abstractmethod
     def covar(self):
-        """Model covariance getter"""
+        """Model covariance"""

--- a/stonesoup/models/control/linear.py
+++ b/stonesoup/models/control/linear.py
@@ -33,6 +33,10 @@ class LinearControlModel(ControlModel, LinearModel):
         doc="Control input noise covariance at time :math:`k`")
 
     @property
+    def ndim(self):
+        return self.ndim_ctrl
+
+    @property
     def ndim_ctrl(self):
         return self.control_vector.shape[0]
 

--- a/stonesoup/models/measurement/base.py
+++ b/stonesoup/models/measurement/base.py
@@ -15,6 +15,10 @@ class MeasurementModel(Model):
         sp.ndarray, doc="Mapping between measurement and state dims")
 
     @property
+    def ndim(self):
+        return self.ndim_meas
+
+    @property
     @abstractmethod
     def ndim_meas(self):
         """Number of measurement dimensions"""

--- a/stonesoup/models/measurement/linear.py
+++ b/stonesoup/models/measurement/linear.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 import scipy as sp
-from scipy.stats import multivariate_normal
 
 from ...base import Property
 from ...types.array import CovarianceMatrix
@@ -89,68 +88,3 @@ class LinearGaussian(MeasurementModel, LinearModel, GaussianModel):
         """
 
         return self.noise_covar
-
-    def rvs(self, num_samples=1, **kwargs):
-        r""" Model noise/sample generation function
-
-        Generates noise samples from the measurement model.
-
-        In mathematical terms, this can be written as:
-
-        .. math::
-
-            v_t \sim \mathcal{N}(0,R_t)
-
-        where :math:`v_t =` ``noise``.
-
-        Parameters
-        ----------
-        num_samples: scalar, optional
-            The number of samples to be generated (the default is 1)
-
-        Returns
-        -------
-        noise : 2-D array of shape (:py:attr:`~ndim_meas`, ``num_samples``)
-            A set of Np samples, generated from the model's noise
-            distribution.
-        """
-
-        noise = multivariate_normal.rvs(
-            sp.zeros(self.ndim_meas), self.covar(), num_samples)
-
-        if num_samples == 1:
-            return noise.reshape((-1, 1))
-        else:
-            return noise.T
-
-    def pdf(self, meas_vec, state_vec, **kwargs):
-        r""" Measurement pdf/likelihood evaluation function
-
-        Evaluates the pdf/likelihood of the (set of) measurement vector(s)
-        ``meas_vec``, given the (set of) state vector(s) ``state_vec``.
-
-        In mathematical terms, this can be written as:
-
-        .. math::
-
-            p(y_t | x_t) = \mathcal{N}(y_t; x_t, R_t)
-
-        Parameters
-        ----------
-        meas_vec : :class:`~.StateVector`
-            A measurement
-        state_vec : :class:`~.StateVector`
-            A state
-
-        Returns
-        -------
-        :class:`float`
-            The likelihood of ``meas``, given ``state``
-        """
-
-        likelihood = multivariate_normal.pdf(
-            meas_vec.T,
-            mean=(self.matrix()@state_vec).ravel(),
-            cov=self.covar()
-        )
-        return likelihood

--- a/stonesoup/models/measurement/nonlinear.py
+++ b/stonesoup/models/measurement/nonlinear.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 import scipy as sp
-from scipy.stats import multivariate_normal
 from numpy.linalg import inv
 
 from ...base import Property
@@ -42,69 +41,6 @@ class NonLinearGaussianMeasurement(MeasurementModel,
         """
 
         return self.noise_covar
-
-    def pdf(self, meas_vec, state_vec, **kwargs):
-        r""" Measurement pdf/likelihood evaluation function
-
-        Evaluates the pdf/likelihood of the (set of) measurement vector(s)
-        ``meas_vec``, given the (set of) state vector(s) ``state_vec``.
-
-        In mathematical terms, this can be written as:
-
-        .. math::
-
-            p(\vec{y}_t | \vec{x}_t) = \mathcal{N}(\vec{y}_t; \vec{x}_t, R)
-
-        Parameters
-        ----------
-        meas_vec : :class:`~.StateVector`
-            A measurement
-        state_vec : :class:`~.StateVector`
-            A state
-
-        Returns
-        -------
-        :class:`float`
-            The likelihood of ``meas``, given ``state``
-        """
-
-        likelihood = multivariate_normal.pdf(
-            meas_vec.T,
-            mean=(self.function(state_vec, 0)).ravel(),
-            cov=self.covar()
-        )
-        return likelihood
-
-    def rvs(self, num_samples=1, **kwargs):
-        r""" Model noise/sample generation function
-
-        Generates noise samples from the measurement model.
-
-        In mathematical terms, this can be written as:
-
-        .. math::
-
-            \vec{v}_t \sim \mathcal{N}(0,R)
-
-        Parameters
-        ----------
-        num_samples: scalar, optional
-            The number of samples to be generated (the default is 1)
-
-        Returns
-        -------
-        2-D array of shape (:py:attr:`~ndim_meas`, ``num_samples``)
-            A set of Np samples, generated from the model's noise
-            distribution.
-        """
-
-        noise = multivariate_normal.rvs(
-            sp.zeros(self.ndim_meas), self.covar(), num_samples)
-
-        if num_samples == 1:
-            return noise.reshape((-1, 1))
-        else:
-            return noise.T
 
     @property
     def _rotation_matrix(self):

--- a/stonesoup/models/measurement/tests/test_lg.py
+++ b/stonesoup/models/measurement/tests/test_lg.py
@@ -1,5 +1,6 @@
 # coding: utf-8
 import pytest
+from pytest import approx
 import numpy as np
 from scipy.stats import multivariate_normal
 
@@ -55,10 +56,10 @@ def test_lgmodel(H, R, ndim_state, mapping):
     # Evaluate the likelihood of the predicted measurement, given the state
     # (without noise)
     prob = lg.pdf(meas_pred_wo_noise, state_vec)
-    assert np.array_equal(prob, multivariate_normal.pdf(
+    assert approx(prob), multivariate_normal.pdf(
         meas_pred_wo_noise.T,
         mean=np.array(H@state_vec).ravel(),
-        cov=R).T)
+        cov=R)
 
     # Propagate a state vector through the model
     # (with internal noise)
@@ -68,10 +69,10 @@ def test_lgmodel(H, R, ndim_state, mapping):
     # Evaluate the likelihood of the predicted state, given the prior
     # (with noise)
     prob = lg.pdf(meas_pred_w_inoise, state_vec)
-    assert np.array_equal(prob, multivariate_normal.pdf(
+    assert approx(prob) == multivariate_normal.pdf(
         meas_pred_w_inoise.T,
         mean=np.array(H@state_vec).ravel(),
-        cov=R).T)
+        cov=R)
 
     # Propagate a state vector through the model
     # (with external noise)
@@ -83,7 +84,7 @@ def test_lgmodel(H, R, ndim_state, mapping):
     # Evaluate the likelihood of the predicted state, given the prior
     # (with noise)
     prob = lg.pdf(meas_pred_w_enoise, state_vec)
-    assert np.array_equal(prob, multivariate_normal.pdf(
+    assert approx(prob) == multivariate_normal.pdf(
         meas_pred_w_enoise.T,
         mean=np.array(H@state_vec).ravel(),
-        cov=R).T)
+        cov=R)

--- a/stonesoup/models/measurement/tests/test_models.py
+++ b/stonesoup/models/measurement/tests/test_models.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import pytest
+from pytest import approx
 import numpy as np
 from scipy.stats import multivariate_normal
 
@@ -210,12 +211,12 @@ def test_models(h, ModelClass, state_vec, R,
     # Evaluate the likelihood of the predicted measurement, given the state
     # (without noise)
     prob = model.pdf(meas_pred_wo_noise, state_vec)
-    assert np.array_equal(prob, multivariate_normal.pdf(
+    assert approx(prob) == multivariate_normal.pdf(
         meas_pred_wo_noise.T,
         mean=np.array(h(state_vec,
                         model.translation_offset,
                         model.rotation_offset)).ravel(),
-        cov=R).T)
+        cov=R)
 
     # Propagate a state vector through the model
     # (with internal noise)
@@ -227,12 +228,12 @@ def test_models(h, ModelClass, state_vec, R,
     # Evaluate the likelihood of the predicted state, given the prior
     # (with noise)
     prob = model.pdf(meas_pred_w_inoise, state_vec)
-    assert np.array_equal(prob, multivariate_normal.pdf(
+    assert approx(prob) == multivariate_normal.pdf(
         meas_pred_w_inoise.T,
         mean=np.array(h(state_vec,
                         model.translation_offset,
                         model.rotation_offset)).ravel(),
-        cov=R).T)
+        cov=R)
 
     # Propagate a state vector throught the model
     # (with external noise)
@@ -245,9 +246,9 @@ def test_models(h, ModelClass, state_vec, R,
     # Evaluate the likelihood of the predicted state, given the prior
     # (with noise)
     prob = model.pdf(meas_pred_w_enoise, state_vec)
-    assert np.array_equal(prob, multivariate_normal.pdf(
+    assert approx(prob) == multivariate_normal.pdf(
         meas_pred_w_enoise.T,
         mean=np.array(h(state_vec,
                         model.translation_offset,
                         model.rotation_offset)).ravel(),
-        cov=R).T)
+        cov=R)

--- a/stonesoup/models/transition/base.py
+++ b/stonesoup/models/transition/base.py
@@ -8,6 +8,10 @@ class TransitionModel(Model):
     """Transition Model base class"""
 
     @property
+    def ndim(self):
+        return self.ndim_state
+
+    @property
     @abstractmethod
     def ndim_state(self):
         """Number of state dimensions"""

--- a/stonesoup/models/transition/linear.py
+++ b/stonesoup/models/transition/linear.py
@@ -3,7 +3,6 @@ import math
 from functools import lru_cache
 
 import scipy as sp
-from scipy.stats import multivariate_normal
 from scipy.linalg import block_diag
 from scipy.integrate import quad
 
@@ -28,76 +27,6 @@ class LinearGaussianTransitionModel(
         """
 
         return self.matrix().shape[0]
-
-    def rvs(self, num_samples=1, **kwargs):
-        r""" Model noise/sample generation function
-
-        Generates noisy samples from the transition model.
-
-        In mathematical terms, this can be written as:
-
-        .. math::
-
-            w_t \sim \mathcal{N}(0,Q)
-
-        where :math:`w_t =` ``noise``.
-
-        Parameters
-        ----------
-        num_samples: :class:`int`, optional
-            The number of samples to be generated (the default is 1)
-
-        Returns
-        -------
-        noise : :class:`numpy.ndarray` of shape\
-        (:py:attr:`~ndim_state`, ``num_samples``)
-            A set of Np samples, generated from the model's noise distribution.
-        """
-
-        noise = sp.array([multivariate_normal.rvs(
-            sp.zeros(self.ndim_state),
-            self.covar(**kwargs),
-            num_samples)])
-
-        if num_samples == 1:
-            return noise.reshape((-1, 1))
-        else:
-            return noise.T
-
-    def pdf(self, state_vector_post, state_vector_prior, **kwargs):
-        r""" Model pdf/likelihood evaluation function
-
-        Evaluates the pdf/likelihood of the transformed state ``state_post``,
-        given the prior state ``state_prior``.
-
-        In mathematical terms, this can be written as:
-
-        .. math::
-
-            p = p(x_t | x_{t-1}) = \mathcal{N}(x_t; x_{t-1}, Q)
-
-        where :math:`x_t` = ``state_post``, :math:`x_{t-1}` = ``state_prior``
-        and :math:`Q` = :py:attr:`~covar`.
-
-        Parameters
-        ----------
-        state_vector_post : :class:`~.StateVector`
-            A predicted/posterior state
-        state_vector_prior : :class:`~.StateVector`
-            A prior state
-
-        Returns
-        -------
-        : :class:`float`
-            The likelihood of ``state_vec_post``, given ``state_vec_prior``
-        """
-
-        likelihood = multivariate_normal.pdf(
-            state_vector_post.T,
-            mean=self.function(state_vector_prior, noise=0, **kwargs).ravel(),
-            cov=self.covar(**kwargs)
-        )
-        return likelihood
 
 
 class CombinedLinearGaussianTransitionModel(LinearGaussianTransitionModel):

--- a/stonesoup/models/transition/tests/test_ca.py
+++ b/stonesoup/models/transition/tests/test_ca.py
@@ -2,6 +2,7 @@
 
 import datetime
 
+from pytest import approx
 import scipy as sp
 from scipy.stats import multivariate_normal
 
@@ -97,10 +98,10 @@ def base(state_vec, noise_diff_coeffs):
                          state_vec,
                          timestamp=new_timestamp,
                          time_interval=time_interval)
-    assert sp.array_equal(prob, multivariate_normal.pdf(
+    assert approx(prob) == multivariate_normal.pdf(
         new_state_vec_wo_noise.T,
         mean=sp.array(F@state_vec).ravel(),
-        cov=Q).T)
+        cov=Q)
 
     # Propagate a state vector throughout the model
     # (with internal noise)
@@ -116,10 +117,10 @@ def base(state_vec, noise_diff_coeffs):
                          state_vec,
                          timestamp=new_timestamp,
                          time_interval=time_interval)
-    assert sp.array_equal(prob, multivariate_normal.pdf(
+    assert approx(prob) == multivariate_normal.pdf(
         new_state_vec_w_inoise.T,
         mean=sp.array(F@state_vec).ravel(),
-        cov=Q).T)
+        cov=Q)
 
     # Propagate a state vector through the model
     # (with external noise)
@@ -135,7 +136,7 @@ def base(state_vec, noise_diff_coeffs):
     # (with noise)
     prob = model_obj.pdf(new_state_vec_w_enoise, state_vec,
                          timestamp=new_timestamp, time_interval=time_interval)
-    assert sp.array_equal(prob, multivariate_normal.pdf(
+    assert approx(prob) == multivariate_normal.pdf(
         new_state_vec_w_enoise.T,
         mean=sp.array(F@state_vec).ravel(),
-        cov=Q).T)
+        cov=Q)

--- a/stonesoup/models/transition/tests/test_combined.py
+++ b/stonesoup/models/transition/tests/test_combined.py
@@ -1,5 +1,6 @@
 # coding: utf-8
 import datetime
+from numbers import Real
 
 import numpy as np
 
@@ -33,4 +34,4 @@ def test_combined():
         x_prior, noise=np.random.randn(DIM, 1), time_interval=t_delta).shape
     assert (DIM, 1) == combined_model.rvs(time_interval=t_delta).shape
     assert isinstance(
-        combined_model.pdf(x_post, x_prior, time_interval=t_delta), np.float64)
+        combined_model.pdf(x_post, x_prior, time_interval=t_delta), Real)

--- a/stonesoup/models/transition/tests/test_ct.py
+++ b/stonesoup/models/transition/tests/test_ct.py
@@ -1,6 +1,7 @@
 # coding: utf-8
 import datetime
 
+from pytest import approx
 import scipy as sp
 from scipy.stats import multivariate_normal
 
@@ -85,10 +86,10 @@ def base(model, state_vec, noise_diff_coeffs, turn_rate):
                          state_vec,
                          timestamp=new_timestamp,
                          time_interval=time_interval)
-    assert sp.array_equal(prob, multivariate_normal.pdf(
+    assert approx(prob) == multivariate_normal.pdf(
         new_state_vec_wo_noise.T,
         mean=sp.array(F@state_vec).ravel(),
-        cov=Q).T)
+        cov=Q)
 
     # Propagate a state vector throughout the model
     # (with internal noise)
@@ -104,10 +105,10 @@ def base(model, state_vec, noise_diff_coeffs, turn_rate):
                          state_vec,
                          timestamp=new_timestamp,
                          time_interval=time_interval)
-    assert sp.array_equal(prob, multivariate_normal.pdf(
+    assert approx(prob) == multivariate_normal.pdf(
         new_state_vec_w_inoise.T,
         mean=sp.array(F@state_vec).ravel(),
-        cov=Q).T)
+        cov=Q)
 
     # Propagate a state vector through the model
     # (with external noise)
@@ -123,7 +124,7 @@ def base(model, state_vec, noise_diff_coeffs, turn_rate):
     # (with noise)
     prob = model_obj.pdf(new_state_vec_w_enoise, state_vec,
                          timestamp=new_timestamp, time_interval=time_interval)
-    assert sp.array_equal(prob, multivariate_normal.pdf(
+    assert approx(prob) == multivariate_normal.pdf(
         new_state_vec_w_enoise.T,
         mean=sp.array(F@state_vec).ravel(),
-        cov=Q).T)
+        cov=Q)

--- a/stonesoup/models/transition/tests/test_cv.py
+++ b/stonesoup/models/transition/tests/test_cv.py
@@ -1,6 +1,7 @@
 # coding: utf-8
 import datetime
 
+from pytest import approx
 import scipy as sp
 from scipy.stats import multivariate_normal
 
@@ -51,10 +52,10 @@ def test_cvmodel():
                   state_vec,
                   timestamp=new_timestamp,
                   time_interval=time_interval)
-    assert sp.array_equal(prob, multivariate_normal.pdf(
+    assert approx(prob) == multivariate_normal.pdf(
         new_state_vec_wo_noise.T,
         mean=sp.array(F@state_vec).ravel(),
-        cov=Q).T)
+        cov=Q)
 
     # Propagate a state vector throught the model
     # (with internal noise)
@@ -70,10 +71,10 @@ def test_cvmodel():
                   state_vec,
                   timestamp=new_timestamp,
                   time_interval=time_interval)
-    assert sp.array_equal(prob, multivariate_normal.pdf(
+    assert approx(prob) == multivariate_normal.pdf(
         new_state_vec_w_inoise.T,
         mean=sp.array(F@state_vec).ravel(),
-        cov=Q).T)
+        cov=Q)
 
     # Propagate a state vector throught the model
     # (with external noise)
@@ -89,7 +90,7 @@ def test_cvmodel():
     # (with noise)
     prob = cv.pdf(new_state_vec_w_enoise, state_vec,
                   timestamp=new_timestamp, time_interval=time_interval)
-    assert sp.array_equal(prob, multivariate_normal.pdf(
+    assert approx(prob) == multivariate_normal.pdf(
         new_state_vec_w_enoise.T,
         mean=sp.array(F@state_vec).ravel(),
-        cov=Q).T)
+        cov=Q)

--- a/stonesoup/models/transition/tests/test_ou.py
+++ b/stonesoup/models/transition/tests/test_ou.py
@@ -2,6 +2,7 @@
 
 import datetime
 
+from pytest import approx
 import scipy as sp
 from scipy.stats import multivariate_normal
 
@@ -63,10 +64,10 @@ def test_oumodel():
                   state_vec,
                   timestamp=new_timestamp,
                   time_interval=time_interval)
-    assert sp.allclose(prob, multivariate_normal.pdf(
+    assert approx(prob) == multivariate_normal.pdf(
         new_state_vec_wo_noise.T,
         mean=sp.array(F @ state_vec).ravel(),
-        cov=Q).T, rtol=1e-10)
+        cov=Q)
 
     # Propagate a state vector throught the model
     # (with internal noise)
@@ -82,10 +83,10 @@ def test_oumodel():
                   state_vec,
                   timestamp=new_timestamp,
                   time_interval=time_interval)
-    assert sp.allclose(prob, multivariate_normal.pdf(
+    assert approx(prob) == multivariate_normal.pdf(
         new_state_vec_w_inoise.T,
         mean=sp.array(F @ state_vec).ravel(),
-        cov=Q).T, rtol=1e-10)
+        cov=Q)
 
     # Propagate a state vector throught the model
     # (with external noise)
@@ -102,7 +103,7 @@ def test_oumodel():
     # (with noise)
     prob = ou.pdf(new_state_vec_w_enoise, state_vec,
                   timestamp=new_timestamp, time_interval=time_interval)
-    assert sp.allclose(prob, multivariate_normal.pdf(
+    assert approx(prob) == multivariate_normal.pdf(
         new_state_vec_w_enoise.T,
         mean=sp.array(F @ state_vec).ravel(),
-        cov=Q).T, rtol=1e-10)
+        cov=Q)

--- a/stonesoup/models/transition/tests/test_rw.py
+++ b/stonesoup/models/transition/tests/test_rw.py
@@ -1,6 +1,7 @@
 # coding: utf-8
 import datetime
 
+from pytest import approx
 import scipy as sp
 from scipy.stats import multivariate_normal
 
@@ -48,10 +49,10 @@ def test_rwodel():
                   state_vec,
                   timestamp=new_timestamp,
                   time_interval=time_interval)
-    assert sp.array_equal(prob, multivariate_normal.pdf(
+    assert approx(prob) == multivariate_normal.pdf(
         new_state_vec_wo_noise.T,
         mean=sp.array(F@state_vec).ravel(),
-        cov=Q).T)
+        cov=Q)
 
     # Propagate a state vector throught the model
     # (with internal noise)
@@ -67,10 +68,10 @@ def test_rwodel():
                   state_vec,
                   timestamp=new_timestamp,
                   time_interval=time_interval)
-    assert sp.array_equal(prob, multivariate_normal.pdf(
+    assert approx(prob) == multivariate_normal.pdf(
         new_state_vec_w_inoise.T,
         mean=sp.array(F@state_vec).ravel(),
-        cov=Q).T)
+        cov=Q)
 
     # Propagate a state vector throught the model
     # (with external noise)
@@ -86,7 +87,7 @@ def test_rwodel():
     # (with noise)
     prob = rw.pdf(new_state_vec_w_enoise, state_vec,
                   timestamp=new_timestamp, time_interval=time_interval)
-    assert sp.array_equal(prob, multivariate_normal.pdf(
+    assert approx(prob) == multivariate_normal.pdf(
         new_state_vec_w_enoise.T,
         mean=sp.array(F@state_vec).ravel(),
-        cov=Q).T)
+        cov=Q)

--- a/stonesoup/models/transition/tests/test_singer.py
+++ b/stonesoup/models/transition/tests/test_singer.py
@@ -1,6 +1,7 @@
 # coding: utf-8
 import datetime
 
+from pytest import approx
 import scipy as sp
 from scipy.stats import multivariate_normal
 
@@ -131,10 +132,10 @@ def base(state_vec, noise_diff_coeffs, damping_coeffs, timediff=1.0):
                          state_vec,
                          timestamp=new_timestamp,
                          time_interval=time_interval)
-    assert sp.allclose(prob, multivariate_normal.pdf(
+    assert approx(prob) == multivariate_normal.pdf(
         new_state_vec_wo_noise.T,
         mean=sp.array(F@state_vec).ravel(),
-        cov=Q).T, rtol=1e-6)
+        cov=Q)
 
     # Propagate a state vector throughout the model
     # (with internal noise)
@@ -151,10 +152,10 @@ def base(state_vec, noise_diff_coeffs, damping_coeffs, timediff=1.0):
                          state_vec,
                          timestamp=new_timestamp,
                          time_interval=time_interval)
-    assert sp.allclose(prob, multivariate_normal.pdf(
+    assert approx(prob) == multivariate_normal.pdf(
         new_state_vec_w_inoise.T,
         mean=sp.array(F@state_vec).ravel(),
-        cov=Q).T, rtol=1e-6)
+        cov=Q)
 
     # Propagate a state vector throught the model
     # (with external noise)
@@ -170,7 +171,7 @@ def base(state_vec, noise_diff_coeffs, damping_coeffs, timediff=1.0):
     # (with noise)
     prob = model_obj.pdf(new_state_vec_w_enoise, state_vec,
                          timestamp=new_timestamp, time_interval=time_interval)
-    assert sp.allclose(prob, multivariate_normal.pdf(
+    assert approx(prob) == multivariate_normal.pdf(
         new_state_vec_w_enoise.T,
         mean=sp.array(F@state_vec).ravel(),
-        cov=Q).T, rtol=1e-6)
+        cov=Q)

--- a/stonesoup/models/transition/tests/test_singer_approximate.py
+++ b/stonesoup/models/transition/tests/test_singer_approximate.py
@@ -1,6 +1,7 @@
 # coding: utf-8
 import datetime
 
+from pytest import approx
 import scipy as sp
 from scipy.stats import multivariate_normal
 
@@ -118,10 +119,10 @@ def base(state_vec, noise_diff_coeffs, damping_coeffs, timediff=1.0):
                          state_vec,
                          timestamp=new_timestamp,
                          time_interval=time_interval)
-    assert sp.allclose(prob, multivariate_normal.pdf(
+    assert approx(prob) == multivariate_normal.pdf(
         new_state_vec_wo_noise.T,
         mean=sp.array(F@state_vec).ravel(),
-        cov=Q).T, rtol=1e-8)
+        cov=Q)
 
     # Propagate a state vector throughout the model
     # (with internal noise)
@@ -137,10 +138,10 @@ def base(state_vec, noise_diff_coeffs, damping_coeffs, timediff=1.0):
                          state_vec,
                          timestamp=new_timestamp,
                          time_interval=time_interval)
-    assert sp.allclose(prob, multivariate_normal.pdf(
+    assert approx(prob) == multivariate_normal.pdf(
         new_state_vec_w_inoise.T,
         mean=sp.array(F@state_vec).ravel(),
-        cov=Q).T, rtol=1e-10)
+        cov=Q)
 
     # Propagate a state vector through the model
     # (with external noise)
@@ -156,7 +157,7 @@ def base(state_vec, noise_diff_coeffs, damping_coeffs, timediff=1.0):
     # (with noise)
     prob = model_obj.pdf(new_state_vec_w_enoise, state_vec,
                          timestamp=new_timestamp, time_interval=time_interval)
-    assert sp.allclose(prob, multivariate_normal.pdf(
+    assert approx(prob) == multivariate_normal.pdf(
         new_state_vec_w_enoise.T,
         mean=sp.array(F@state_vec).ravel(),
-        cov=Q).T, rtol=1e-10)
+        cov=Q)

--- a/stonesoup/models/transition/tests/test_time_invariant.py
+++ b/stonesoup/models/transition/tests/test_time_invariant.py
@@ -1,4 +1,6 @@
 # coding: utf-8
+from numbers import Real
+
 import numpy as np
 
 from ..linear import LinearGaussianTimeInvariantTransitionModel
@@ -18,4 +20,4 @@ def test_linear_gaussian():
     assert np.array_equal(Q, model.covar())
     assert np.array_equal(x_2, model.function(x_1, noise=np.zeros([3, 1])))
     assert isinstance(model.rvs(), np.ndarray)
-    assert isinstance(model.pdf(x_2, x_1), np.float64)
+    assert isinstance(model.pdf(x_2, x_1), Real)


### PR DESCRIPTION
This removes repeated code and standardises use of probability distribution, which could be more easily be extend for different probability distributions in future.

The pdf method now also returns _Probability_ type.