### PR TITLE
Add Multi-detector Feeder class

### DIFF
--- a/docs/source/stonesoup.feeder.rst
+++ b/docs/source/stonesoup.feeder.rst
@@ -19,6 +19,12 @@ Geo
 .. automodule:: stonesoup.feeder.geo
     :show-inheritance:
 
+Multi
+-----
+
+.. automodule:: stonesoup.feeder.multi
+    :show-inheritance:
+
 Time Based
 ----------
 

--- a/stonesoup/feeder/multi.py
+++ b/stonesoup/feeder/multi.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+from .base import Feeder
+from ..base import Property
+from ..buffered_generator import BufferedGenerator
+from ..detector import Detector
+
+
+class MultiDetectorFeeder(Feeder):
+    """Multi-detector Feeder
+
+    This returns detections from multiple detectors as a single stream,
+    yielding from the detector yielding the lowest timestamp first.
+    """
+    detector = None
+    detectors = Property([Detector], doc="Detectors to yield from")
+
+    @BufferedGenerator.generator_method
+    def detections_gen(self):
+        detector_iters = (iter(detector) for detector in self.detectors)
+        iter_detections = {
+            detector_iter: next(detector_iter)
+            for detector_iter in detector_iters}
+
+        min_time = None
+        while iter_detections:  # Whilst still iterators left
+            for detector_iter, (time, detections) in iter_detections.items():
+                if min_time is None or time < min_time:
+                    min_time = time
+                    min_detector_iter = detector_iter
+                    min_detections = detections
+
+            yield min_time, min_detections
+            min_time = None
+
+            try:
+                # Grab next set for this iter
+                iter_detections[min_detector_iter] = next(min_detector_iter)
+            except StopIteration:
+                # Empty iterator, remove from dictionary
+                del iter_detections[min_detector_iter]

--- a/stonesoup/feeder/tests/test_multi.py
+++ b/stonesoup/feeder/tests/test_multi.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+import pytest
+
+from ..multi import MultiDetectorFeeder
+
+
+@pytest.mark.parametrize('n', [1, 2, 3])
+def test_multi(n, detector):
+    single_time_list = list()
+    multi_time_list = list()
+    multi_detector = MultiDetectorFeeder([detector]*n)
+    for single_iterations, (time, _) in enumerate(detector, 1):
+        single_time_list.append(time)
+    for multi_iterations, (time, _) in enumerate(multi_detector, 1):
+        multi_time_list.append(time)
+    assert multi_iterations == single_iterations * n
+    # Compare every other element but skip last ones due to out of sequence
+    # measurements coming from detector.
+    assert multi_time_list[:-n:n] == single_time_list[:-1]
+    assert multi_time_list[-1] == single_time_list[-1]


### PR DESCRIPTION
This enables multiple detectors to feed into single tracker, e.g. for a multi-sensor tracking scenario.