### PR TITLE
Pass States not StateVectors

### DIFF
--- a/stonesoup/dataassociator/tracktotrack.py
+++ b/stonesoup/dataassociator/tracktotrack.py
@@ -104,9 +104,9 @@ class EuclideanTrackToTrack(TrackToTrackAssociator):
 
                     distance = np.linalg.norm(
                         self.measurement_model_track1.function(
-                            state1.state_vector, noise=0)
+                            state1, noise=0)
                         - self.measurement_model_track2.function(
-                            state2.state_vector, noise=0))
+                            state2, noise=0))
 
                     if distance <= self.association_threshold:
                         n_succesful += 1
@@ -235,9 +235,9 @@ class EuclideanTrackToTruth(TrackToTrackAssociator):
 
                     distance = np.linalg.norm(
                         self.measurement_model_track.function(
-                            track_state.state_vector, noise=0)
+                            track_state, noise=0)
                         - self.measurement_model_truth.function(
-                            truth_state.state_vector, noise=0))
+                            truth_state, noise=0))
                     if min_dist and distance < min_dist:
                         min_dist = distance
                         min_truth = truth

--- a/stonesoup/functions.py
+++ b/stonesoup/functions.py
@@ -237,8 +237,6 @@ def unscented_transform(sigma_points_states, mean_weights, covar_weights,
     for sigma_points_state in sigma_points_states:
         sigma_points = np.c_[sigma_points, sigma_points_state.state_vector]
 
-    ac = fun(sigma_points_states[0])  # eh?
-
     # Transform points through f
     sigma_points_t = np.zeros((ndim_state, n_points))
     if points_noise is None:

--- a/stonesoup/functions.py
+++ b/stonesoup/functions.py
@@ -6,7 +6,6 @@ from copy import copy
 
 from .types.numeric import Probability
 from .types.array import Matrix
-from .types.state import State
 
 
 def tria(matrix):
@@ -81,16 +80,18 @@ def jacobian(fun, x):
     return jac.astype(np.float_)
 
 
-def gauss2sigma(mean, covar, alpha=1.0, beta=2.0, kappa=None):
-    """Approximate a given distribution to a Gaussian, using a
+def gauss2sigma(state, alpha=1.0, beta=2.0, kappa=None):
+    """
+    Approximate a given distribution to a Gaussian, using a
     deterministically selected set of sigma points.
 
     Parameters
     ----------
-    mean : :class:`numpy.ndarray` of shape `(Ns, 1)`
-        Mean of the Gaussian
-    covar : :class:`~.CovarianceMatrix` of shape `(Ns, Ns)`
-        Covariance of the Gaussian
+    state : :class:`~State`
+        A state object capable of returning a :attr:`state_vector` of
+        shape `(Ns, 1)` representing the Gaussian mean and a
+        :class:`~.CovarianceMatrix` of shape `(Ns, Ns)` which is the
+        covariance of the distribution
     alpha : float, optional
         Spread of the sigma points. Typically `1e-3`.
         (default is 1)
@@ -104,21 +105,25 @@ def gauss2sigma(mean, covar, alpha=1.0, beta=2.0, kappa=None):
 
     Returns
     -------
-    : :class:`numpy.ndarray` of shape `(Ns, 2*Ns+1)`
-        An array containing the locations of the sigma points
+    : :class:`list` of length `2*Ns+1`
+        An list of States containing the locations of the sigma points.
+        Note that only the :attr:`state_vector` attribute in these
+        States will be meaningful. Other quantities, like :attr:`covar`
+        will be inherited from the input and don't really make sense
+        for a sigma point.
     : :class:`numpy.ndarray` of shape `(2*Ns+1,)`
         An array containing the sigma point mean weights
     : :class:`numpy.ndarray` of shape `(2*Ns+1,)`
         An array containing the sigma point covariance weights
     """
 
-    ndim_state = np.shape(mean)[0]
+    ndim_state = np.shape(state.state_vector)[0]
 
     if kappa is None:
         kappa = 3.0 - ndim_state
 
     # Compute Square Root matrix via Colesky decomp.
-    sqrt_sigma = np.linalg.cholesky(covar)
+    sqrt_sigma = np.linalg.cholesky(state.covar)
 
     # Calculate scaling factor for all off-center points
     alpha2 = np.power(alpha, 2)
@@ -126,9 +131,16 @@ def gauss2sigma(mean, covar, alpha=1.0, beta=2.0, kappa=None):
     c = ndim_state + lamda
 
     # Calculate sigma point locations
-    sigma_points = np.tile(mean, (1, 2 * ndim_state + 1))
+    sigma_points = np.tile(state.state_vector, (1, 2 * ndim_state + 1))
     sigma_points[:, 1:(ndim_state + 1)] += sqrt_sigma * np.sqrt(c)
     sigma_points[:, (ndim_state + 1):] -= sqrt_sigma * np.sqrt(c)
+
+    # Put these sigma points into s State object list
+    sigma_points_states = []
+    for sigma_point in sigma_points.T:
+        state_copy = copy(state)
+        state_copy.state_vector = np.atleast_2d(sigma_point).T
+        sigma_points_states.append(state_copy)
 
     # Calculate weights
     mean_weights = np.ones(2 * ndim_state + 1)
@@ -137,7 +149,7 @@ def gauss2sigma(mean, covar, alpha=1.0, beta=2.0, kappa=None):
     covar_weights = np.copy(mean_weights)
     covar_weights[0] = lamda / c + (1 - alpha2 + beta)
 
-    return sigma_points, mean_weights, covar_weights
+    return sigma_points_states, mean_weights, covar_weights
 
 
 def sigma2gauss(sigma_points, mean_weights, covar_weights, covar_noise=None):
@@ -173,9 +185,10 @@ def sigma2gauss(sigma_points, mean_weights, covar_weights, covar_noise=None):
     return mean, covar
 
 
-def unscented_transform(sigma_points, mean_weights, covar_weights,
+def unscented_transform(sigma_points_states, mean_weights, covar_weights,
                         fun, points_noise=None, covar_noise=None):
-    """ Apply the Unscented Transform to a set of sigma points
+    """
+    Apply the Unscented Transform to a set of sigma points
 
     Apply f to points (with secondary argument points_noise, if available),
     then approximate the resulting mean and covariance. If sigma_noise is
@@ -216,17 +229,25 @@ def unscented_transform(sigma_points, mean_weights, covar_weights,
         An array containing the transformed sigma point covariance weights
     """
 
-    ndim_state, n_points = sigma_points.shape
+    n_points = len(sigma_points_states)
+    ndim_state = len(sigma_points_states[0].state_vector)
+
+    # Reconstruct the sigma_points matrix
+    sigma_points = np.empty((ndim_state, 0))
+    for sigma_points_state in sigma_points_states:
+        sigma_points = np.c_[sigma_points, sigma_points_state.state_vector]
+
+    ac = fun(sigma_points_states[0])  # eh?
 
     # Transform points through f
     sigma_points_t = np.zeros((ndim_state, n_points))
     if points_noise is None:
         sigma_points_t = np.asarray(
-            [fun(State(sigma_points[:, i:i+1]))
+            [fun(sigma_points_states[i])
              for i in range(n_points)]).squeeze(2).T
     else:
         sigma_points_t = np.asarray(
-            [fun(State(sigma_points[:, i:i+1]), points_noise[:, i:i+1])
+            [fun(sigma_points_states[i], points_noise[:, i:i+1])
              for i in range(n_points)]).squeeze(2).T
     sigma_points_t = sigma_points_t.view(Matrix)
 

--- a/stonesoup/functions.py
+++ b/stonesoup/functions.py
@@ -219,11 +219,11 @@ def unscented_transform(sigma_points, mean_weights, covar_weights,
     sigma_points_t = np.zeros((ndim_state, n_points))
     if points_noise is None:
         sigma_points_t = np.asarray(
-            [fun(sigma_points[:, i:i+1])
+            [fun(State(sigma_points[:, i:i+1]))
              for i in range(n_points)]).squeeze(2).T
     else:
         sigma_points_t = np.asarray(
-            [fun(sigma_points[:, i:i+1], points_noise[:, i:i+1])
+            [fun(State(sigma_points[:, i:i+1]), points_noise[:, i:i+1])
              for i in range(n_points)]).squeeze(2).T
     sigma_points_t = sigma_points_t.view(Matrix)
 

--- a/stonesoup/functions.py
+++ b/stonesoup/functions.py
@@ -5,6 +5,7 @@ import numpy as np
 
 from .types.numeric import Probability
 from .types.array import Matrix
+from .types.state import State
 
 
 def tria(matrix):
@@ -44,8 +45,8 @@ def jacobian(fun, x):
         A (non-linear) transition function
         Must be of the form "y = fun(x)", where y can be a scalar or \
         :class:`numpy.ndarray` of shape `(Nd, 1)` or `(Nd,)`
-    x : :class:`numpy.ndarray` of shape `(Ns, 1)`
-        A state vector
+    x : :class:`State`
+        A state with state vector of shape `(Ns, 1)`
 
     Returns
     -------
@@ -53,10 +54,10 @@ def jacobian(fun, x):
         The computed Jacobian
     """
 
-    if isinstance(x, (int, float)):
+    if isinstance(x.state_vector, (int, float)):
         ndim = 1
     else:
-        ndim = np.shape(x)[0]
+        ndim = np.shape(x.state_vector)[0]
 
     # For numerical reasons the step size needs to large enough
     delta = 1.e-8  # 100*ndim*np.finfo(float).eps
@@ -68,10 +69,10 @@ def jacobian(fun, x):
         nrows = f1.size
 
     F2 = np.empty((nrows, ndim))
-    X1 = np.tile(x, ndim)+np.eye(ndim)*delta
+    X1 = np.tile(x.state_vector, ndim)+np.eye(ndim)*delta
 
     for col in range(0, X1.shape[1]):
-        F2[:, [col]] = fun(X1[:, [col]])
+        F2[:, [col]] = fun(State(X1[:, [col]]))
 
     jac = np.divide(F2-f1, delta)
     return jac.astype(np.float_)

--- a/stonesoup/functions.py
+++ b/stonesoup/functions.py
@@ -2,6 +2,7 @@
 """Mathematical functions used within Stone Soup"""
 
 import numpy as np
+from copy import copy
 
 from .types.numeric import Probability
 from .types.array import Matrix
@@ -68,11 +69,13 @@ def jacobian(fun, x):
     else:
         nrows = f1.size
 
+    x2 = copy(x)  # Create a clone of the input
     F2 = np.empty((nrows, ndim))
     X1 = np.tile(x.state_vector, ndim)+np.eye(ndim)*delta
 
     for col in range(0, X1.shape[1]):
-        F2[:, [col]] = fun(State(X1[:, [col]]))
+        x2.state_vector = X1[:, [col]]
+        F2[:, [col]] = fun(x2)
 
     jac = np.divide(F2-f1, delta)
     return jac.astype(np.float_)

--- a/stonesoup/initiator/simple.py
+++ b/stonesoup/initiator/simple.py
@@ -8,7 +8,7 @@ from ..models.base import NonLinearModel, ReversibleModel
 from ..types.hypothesis import SingleHypothesis
 from ..types.numeric import Probability
 from ..types.particle import Particle
-from ..types.state import GaussianState
+from ..types.state import State, GaussianState
 from ..types.track import Track
 from ..types.update import GaussianStateUpdate, ParticleStateUpdate
 from ..updater.kalman import KalmanUpdater
@@ -81,9 +81,10 @@ class SimpleMeasurementInitiator(GaussianInitiator):
 
             if isinstance(measurement_model, NonLinearModel):
                 if isinstance(measurement_model, ReversibleModel):
-                    state = measurement_model.inverse_function(
+                    state_vector = measurement_model.inverse_function(
                         detection)
-                    model_matrix = measurement_model.jacobian(state)
+                    model_matrix = measurement_model.jacobian(State(
+                        state_vector))
                     inv_model_matrix = np.linalg.pinv(model_matrix)
                 else:
                     raise Exception("Invalid measurement model used.\

--- a/stonesoup/initiator/simple.py
+++ b/stonesoup/initiator/simple.py
@@ -81,9 +81,9 @@ class SimpleMeasurementInitiator(GaussianInitiator):
 
             if isinstance(measurement_model, NonLinearModel):
                 if isinstance(measurement_model, ReversibleModel):
-                    state_vector = measurement_model.inverse_function(
-                        detection.state_vector)
-                    model_matrix = measurement_model.jacobian(state_vector)
+                    state = measurement_model.inverse_function(
+                        detection)
+                    model_matrix = measurement_model.jacobian(state)
                     inv_model_matrix = np.linalg.pinv(model_matrix)
                 else:
                     raise Exception("Invalid measurement model used.\

--- a/stonesoup/metricgenerator/ospametric.py
+++ b/stonesoup/metricgenerator/ospametric.py
@@ -289,9 +289,9 @@ class GOSPAMetric(MetricGenerator):
 
                 euc_distance = np.linalg.norm(
                     self.measurement_model_track.function(
-                        track_state.state_vector, noise=0)
+                        track_state, noise=0)
                     - self.measurement_model_truth.function(
-                        truth_state.state_vector, noise=0))
+                        truth_state, noise=0))
 
                 if euc_distance < self.c:
                     cost_matrix[i_track, i_truth] = euc_distance

--- a/stonesoup/models/base.py
+++ b/stonesoup/models/base.py
@@ -21,7 +21,7 @@ class Model(Base):
         pass
 
     @abstractmethod
-    def function(self, state_vector, noise=None):
+    def function(self, state, noise=None):
         """ Model function"""
         pass
 
@@ -31,7 +31,7 @@ class Model(Base):
         pass
 
     @abstractmethod
-    def pdf(self, state_vector1, state_vector2):
+    def pdf(self, state1, state2):
         """Model pdf/likelihood evaluator method"""
         pass
 
@@ -46,13 +46,13 @@ class LinearModel(Model):
         """ Model matrix"""
         pass
 
-    def function(self, state_vector, noise=None, **kwargs):
+    def function(self, state, noise=None, **kwargs):
         """Model linear function :math:`f_k(x(k),w(k)) = F_k(x_k) + w_k`
 
         Parameters
         ----------
-        state_vector: :class:`~.StateVector`
-            An input state vector
+        state: :class:`~.State`
+            An input state
         noise: :class:`numpy.ndarray`
             An externally generated random process noise sample (the default is
             `None`, in which case process noise will be generated via
@@ -60,15 +60,19 @@ class LinearModel(Model):
 
         Returns
         -------
-        : :class:`numpy.ndarray`
-            The model function evaluated.
-        """
+        : :class:`State`
+            The updated State with the model function evaluated.
 
+        Warning
+        -------
+        The original state vector is modified - discuss
+
+        """
         if noise is None:
             # TODO: doesn't make sense for noise=None to generate noise
             noise = self.rvs(**kwargs)
 
-        return self.matrix(**kwargs) @ state_vector + noise
+        return self.matrix(**kwargs) @ state.state_vector + noise
 
 
 class NonLinearModel(Model):
@@ -76,7 +80,7 @@ class NonLinearModel(Model):
 
     Base/Abstract class for all non-linear models"""
 
-    def jacobian(self, state_vector, **kwargs):
+    def jacobian(self, state, **kwargs):
         """Model jacobian matrix :math:`H_{jac}`
 
         Parameters
@@ -94,10 +98,10 @@ class NonLinearModel(Model):
         def fun(x):
             return self.function(x, noise=0)
 
-        return compute_jac(fun, state_vector)
+        return compute_jac(fun, state)
 
     @abstractmethod
-    def function(self, state_vector, noise=None, **kwargs):
+    def function(self, state, noise=None, **kwargs):
         """Model function :math:`f(t,x(t),w(t))`
 
         Parameters
@@ -125,7 +129,7 @@ class ReversibleModel(NonLinearModel):
     of the relevant linear-to-non-linear function"""
 
     @abstractmethod
-    def inverse_function(self, state_vector, **kwargs):
+    def inverse_function(self, state, **kwargs):
         """Takes in the result of the function and
         computes the inverse function, returning the initial
         input of the function.
@@ -190,11 +194,11 @@ class GaussianModel(Model):
 
         return np.atleast_2d(noise).T
 
-    def pdf(self, state_vector1, state_vector2, **kwargs):
+    def pdf(self, state1, state2, **kwargs):
         r"""Model pdf/likelihood evaluation function
 
         Evaluates the pdf/likelihood of ``state_vector1``, given the state
-        ``state_vector2`` which is passed to :meth:`~.function`.
+        ``state_vector2`` which is passed to :math:`~.function()`.
 
         In mathematical terms, this can be written as:
 
@@ -207,18 +211,18 @@ class GaussianModel(Model):
 
         Parameters
         ----------
-        state_vector1 : :class:`~.StateVector`
-        state_vector2 : :class:`~.StateVector`
+        state1 : :class:`~.State`
+        state2 : :class:`~.State`
 
         Returns
         -------
         : :class:`~.Probability`
-            The likelihood of ``state_vector1``, given ``state_vector2``
+            The likelihood of ``state1``, given ``state2`` # (given "prior" state2 I think)
         """
 
         likelihood = multivariate_normal.logpdf(
-            state_vector1.T,
-            mean=self.function(state_vector2, noise=0, **kwargs).ravel(),
+            state1.state_vector.T,
+            mean=self.function(state2, noise=0, **kwargs).ravel(),
             cov=self.covar(**kwargs)
         )
         return Probability(likelihood, log_value=True)

--- a/stonesoup/models/base.py
+++ b/stonesoup/models/base.py
@@ -217,7 +217,8 @@ class GaussianModel(Model):
         Returns
         -------
         : :class:`~.Probability`
-            The likelihood of ``state1``, given ``state2`` # (given "prior" state2 I think)
+            The likelihood of ``state1``, given ``state2`` # (given "prior"
+            state2 in fact)
         """
 
         likelihood = multivariate_normal.logpdf(

--- a/stonesoup/models/measurement/linear.py
+++ b/stonesoup/models/measurement/linear.py
@@ -55,13 +55,13 @@ class LinearGaussian(MeasurementModel, LinearModel, GaussianModel):
 
         return model_matrix
 
-    def function(self, state_vector, noise=None, **kwargs):
+    def function(self, state, noise=None, **kwargs):
         """Model function :math:`h(t,x(t),w(t))`
 
         Parameters
         ----------
-        state_vector: :class:`~.StateVector`
-            An input state vector
+        state: :class:`~.State`
+            An input state
         noise: :class:`numpy.ndarray`
             An externally generated random process noise sample (the default in
             `None`, in which case process noise will be added via :meth:`rvs`)
@@ -75,7 +75,7 @@ class LinearGaussian(MeasurementModel, LinearModel, GaussianModel):
         if noise is None:
             noise = self.rvs()  # TODO: change noise=None generates noise!
 
-        return self.matrix(**kwargs)@state_vector + noise
+        return self.matrix(**kwargs)@state.state_vector + noise
 
     def covar(self, **kwargs):
         """Returns the measurement model noise covariance matrix.

--- a/stonesoup/models/measurement/nonlinear.py
+++ b/stonesoup/models/measurement/nonlinear.py
@@ -139,13 +139,13 @@ class CartesianToElevationBearingRange(
 
         return 3
 
-    def function(self, state_vector, noise=None, **kwargs):
+    def function(self, state, noise=None, **kwargs):
         r"""Model function :math:`h(\vec{x}_t,\vec{v}_t)`
 
         Parameters
         ----------
-        state_vector: :class:`~.StateVector`
-            An input state vector
+        state: :class:`~.State`
+            An input state
         noise: :class:`numpy.ndarray`
             An externally generated random process noise sample (the default in
             `None`, in which case process noise will be generated internally)
@@ -160,7 +160,7 @@ class CartesianToElevationBearingRange(
             noise = self.rvs()
 
         # Account for origin offset
-        xyz = state_vector[self.mapping] - self.translation_offset
+        xyz = state.state_vector[self.mapping] - self.translation_offset
 
         # Rotate coordinates
         xyz_rot = self._rotation_matrix @ xyz
@@ -172,9 +172,9 @@ class CartesianToElevationBearingRange(
                          [Bearing(phi)],
                          [rho]]) + noise
 
-    def inverse_function(self, state_vector, **kwargs):
+    def inverse_function(self, state, **kwargs):
 
-        theta, phi, rho = state_vector[:, 0]
+        theta, phi, rho = state.state_vector[:, 0]
         x, y, z = sphere2cart(rho, phi, theta)
 
         xyz = [[x], [y], [z]]
@@ -267,14 +267,14 @@ class CartesianToBearingRange(
 
         return 2
 
-    def inverse_function(self, state_vector, **kwargs):
+    def inverse_function(self, state, **kwargs):
         if not ((self.rotation_offset[0][0] == 0)
                 and (self.rotation_offset[1][0] == 0)):
             raise RuntimeError(
                 "Measurement model assumes 2D space. \
                 Rotation in 3D space is unsupported at this time.")
 
-        phi, rho = state_vector[:, 0]
+        phi, rho = state.state_vector[:, 0]
         x, y = pol2cart(rho, phi)
 
         xyz = [[x], [y], [0]]
@@ -288,7 +288,7 @@ class CartesianToBearingRange(
 
         return res
 
-    def function(self, state_vector, noise=None, **kwargs):
+    def function(self, state, noise=None, **kwargs):
         r"""Model function :math:`h(\vec{x}_t,\vec{v}_t)`
 
         Parameters
@@ -309,9 +309,9 @@ class CartesianToBearingRange(
             noise = self.rvs()
 
         # Account for origin offset
-        xyz = [[state_vector[self.mapping[0], 0]
+        xyz = [[state.state_vector[self.mapping[0], 0]
                 - self.translation_offset[0, 0]],
-               [state_vector[self.mapping[1], 0]
+               [state.state_vector[self.mapping[1], 0]
                 - self.translation_offset[1, 0]],
                [0]]
 
@@ -403,7 +403,7 @@ class CartesianToElevationBearing(NonLinearGaussianMeasurement):
 
         return 2
 
-    def function(self, state_vector, noise=None, **kwargs):
+    def function(self, state, noise=None, **kwargs):
         r"""Model function :math:`h(\vec{x}_t,\vec{v}_t)`
 
         Parameters
@@ -424,7 +424,7 @@ class CartesianToElevationBearing(NonLinearGaussianMeasurement):
             noise = self.rvs()
 
         # Account for origin offset
-        xyz = state_vector[self.mapping] - self.translation_offset
+        xyz = state.state_vector[self.mapping] - self.translation_offset
 
         # Rotate coordinates
         xyz_rot = self._rotation_matrix @ xyz

--- a/stonesoup/models/measurement/tests/test_lg.py
+++ b/stonesoup/models/measurement/tests/test_lg.py
@@ -5,6 +5,7 @@ import numpy as np
 from scipy.stats import multivariate_normal
 
 from ..linear import LinearGaussian
+from ....types.state import State
 
 
 @pytest.mark.parametrize(
@@ -36,6 +37,7 @@ def test_lgmodel(H, R, ndim_state, mapping):
 
     # State related variables
     state_vec = np.array([[n] for n in range(ndim_state)])
+    state = State(state_vec)
 
     # Create and a Constant Velocity model object
     lg = LinearGaussian(ndim_state=ndim_state,
@@ -48,14 +50,14 @@ def test_lgmodel(H, R, ndim_state, mapping):
     # Ensure ```lg.covar()``` returns R
     assert np.array_equal(R, lg.covar())
 
-    # Project a state throught the model
+    # Project a state through the model
     # (without noise)
-    meas_pred_wo_noise = lg.function(state_vec, noise=0)
+    meas_pred_wo_noise = lg.function(state, noise=0)
     assert np.array_equal(meas_pred_wo_noise, H@state_vec)
 
     # Evaluate the likelihood of the predicted measurement, given the state
     # (without noise)
-    prob = lg.pdf(meas_pred_wo_noise, state_vec)
+    prob = lg.pdf(State(meas_pred_wo_noise), state)
     assert approx(prob), multivariate_normal.pdf(
         meas_pred_wo_noise.T,
         mean=np.array(H@state_vec).ravel(),
@@ -63,12 +65,12 @@ def test_lgmodel(H, R, ndim_state, mapping):
 
     # Propagate a state vector through the model
     # (with internal noise)
-    meas_pred_w_inoise = lg.function(state_vec, noise=lg.rvs())
+    meas_pred_w_inoise = lg.function(state, noise=lg.rvs())
     assert not np.array_equal(meas_pred_w_inoise, H@state_vec)
 
     # Evaluate the likelihood of the predicted state, given the prior
     # (with noise)
-    prob = lg.pdf(meas_pred_w_inoise, state_vec)
+    prob = lg.pdf(State(meas_pred_w_inoise), state)
     assert approx(prob) == multivariate_normal.pdf(
         meas_pred_w_inoise.T,
         mean=np.array(H@state_vec).ravel(),
@@ -77,13 +79,13 @@ def test_lgmodel(H, R, ndim_state, mapping):
     # Propagate a state vector through the model
     # (with external noise)
     noise = lg.rvs()
-    meas_pred_w_enoise = lg.function(state_vec,
+    meas_pred_w_enoise = lg.function(state,
                                      noise=noise)
     assert np.array_equal(meas_pred_w_enoise, H@state_vec+noise)
 
     # Evaluate the likelihood of the predicted state, given the prior
     # (with noise)
-    prob = lg.pdf(meas_pred_w_enoise, state_vec)
+    prob = lg.pdf(State(meas_pred_w_enoise), state)
     assert approx(prob) == multivariate_normal.pdf(
         meas_pred_w_enoise.T,
         mean=np.array(H@state_vec).ravel(),

--- a/stonesoup/models/measurement/tests/test_models.py
+++ b/stonesoup/models/measurement/tests/test_models.py
@@ -8,6 +8,7 @@ from ..nonlinear import (
     CartesianToElevationBearingRange, CartesianToBearingRange,
     CartesianToElevationBearing)
 from ...base import ReversibleModel
+from ....types.state import State
 from ....functions import jacobian as compute_jac
 from ....types.angle import Bearing, Elevation
 
@@ -171,6 +172,7 @@ def test_models(h, ModelClass, state_vec, R,
     """ CartesianToBearingRange Measurement Model test """
 
     ndim_state = state_vec.size
+    state = State(state_vec)
 
     # Create and a measurement model object
     model = ModelClass(ndim_state=ndim_state,
@@ -179,38 +181,38 @@ def test_models(h, ModelClass, state_vec, R,
                        translation_offset=translation_offset,
                        rotation_offset=rotation_offset)
 
-    # Project a state throught the model
+    # Project a state through the model
     # (without noise)
-    meas_pred_wo_noise = model.function(state_vec, noise=0)
+    meas_pred_wo_noise = model.function(state, noise=0)
     eval_m = h(state_vec, model.translation_offset, model.rotation_offset)
     assert np.array_equal(meas_pred_wo_noise, eval_m)
 
     # Ensure ```lg.transfer_function()``` returns H
     def fun(x):
         return model.function(x, noise=0)
-    H = compute_jac(fun, state_vec)
-    assert np.array_equal(H, model.jacobian(state_vec))
+    H = compute_jac(fun, state)
+    assert np.array_equal(H, model.jacobian(state))
 
     # Check Jacobian has proper dimensions
     assert H.shape == (model.ndim_meas, ndim_state)
 
     # Ensure inverse function returns original
     if isinstance(model, ReversibleModel):
-        J = model.inverse_function(meas_pred_wo_noise)
+        J = model.inverse_function(State(meas_pred_wo_noise))
         assert np.allclose(J, state_vec)
 
     # Ensure ```lg.covar()``` returns R
     assert np.array_equal(R, model.covar())
 
-    # Project a state throught the model
+    # Project a state through the model
     # (without noise)
-    meas_pred_wo_noise = model.function(state_vec, noise=0)
+    meas_pred_wo_noise = model.function(state, noise=0)
     assert np.array_equal(meas_pred_wo_noise,  h(
         state_vec, model.translation_offset, model.rotation_offset))
 
     # Evaluate the likelihood of the predicted measurement, given the state
     # (without noise)
-    prob = model.pdf(meas_pred_wo_noise, state_vec)
+    prob = model.pdf(State(meas_pred_wo_noise), state)
     assert approx(prob) == multivariate_normal.pdf(
         meas_pred_wo_noise.T,
         mean=np.array(h(state_vec,
@@ -220,14 +222,14 @@ def test_models(h, ModelClass, state_vec, R,
 
     # Propagate a state vector through the model
     # (with internal noise)
-    meas_pred_w_inoise = model.function(state_vec)
+    meas_pred_w_inoise = model.function(state)
     assert not np.array_equal(
         meas_pred_w_inoise,  h(state_vec, model.translation_offset,
                                model.rotation_offset))
 
     # Evaluate the likelihood of the predicted state, given the prior
     # (with noise)
-    prob = model.pdf(meas_pred_w_inoise, state_vec)
+    prob = model.pdf(State(meas_pred_w_inoise), state)
     assert approx(prob) == multivariate_normal.pdf(
         meas_pred_w_inoise.T,
         mean=np.array(h(state_vec,
@@ -238,14 +240,14 @@ def test_models(h, ModelClass, state_vec, R,
     # Propagate a state vector throught the model
     # (with external noise)
     noise = model.rvs()
-    meas_pred_w_enoise = model.function(state_vec,
+    meas_pred_w_enoise = model.function(state,
                                         noise=noise)
     assert np.array_equal(meas_pred_w_enoise,  h(
         state_vec, model.translation_offset, model.rotation_offset)+noise)
 
     # Evaluate the likelihood of the predicted state, given the prior
     # (with noise)
-    prob = model.pdf(meas_pred_w_enoise, state_vec)
+    prob = model.pdf(State(meas_pred_w_enoise), state)
     assert approx(prob) == multivariate_normal.pdf(
         meas_pred_w_enoise.T,
         mean=np.array(h(state_vec,

--- a/stonesoup/models/transition/tests/test_ca.py
+++ b/stonesoup/models/transition/tests/test_ca.py
@@ -5,6 +5,7 @@ import datetime
 from pytest import approx
 import scipy as sp
 from scipy.stats import multivariate_normal
+from ....types.state import State
 
 from ..linear import (
     ConstantAcceleration, CombinedLinearGaussianTransitionModel)
@@ -86,7 +87,7 @@ def base(state_vec, noise_diff_coeffs):
     # Propagate a state vector through the model
     # (without noise)
     new_state_vec_wo_noise = model_obj.function(
-        state_vec,
+        State(state_vec),
         timestamp=new_timestamp,
         time_interval=time_interval,
         noise=0)
@@ -94,8 +95,8 @@ def base(state_vec, noise_diff_coeffs):
 
     # Evaluate the likelihood of the predicted state, given the prior
     # (without noise)
-    prob = model_obj.pdf(new_state_vec_wo_noise,
-                         state_vec,
+    prob = model_obj.pdf(State(new_state_vec_wo_noise),
+                         State(state_vec),
                          timestamp=new_timestamp,
                          time_interval=time_interval)
     assert approx(prob) == multivariate_normal.pdf(
@@ -106,15 +107,15 @@ def base(state_vec, noise_diff_coeffs):
     # Propagate a state vector throughout the model
     # (with internal noise)
     new_state_vec_w_inoise = model_obj.function(
-        state_vec,
+        State(state_vec),
         timestamp=new_timestamp,
         time_interval=time_interval)
     assert not sp.array_equal(new_state_vec_w_inoise, F@state_vec)
 
     # Evaluate the likelihood of the predicted state, given the prior
     # (with noise)
-    prob = model_obj.pdf(new_state_vec_w_inoise,
-                         state_vec,
+    prob = model_obj.pdf(State(new_state_vec_w_inoise),
+                         State(state_vec),
                          timestamp=new_timestamp,
                          time_interval=time_interval)
     assert approx(prob) == multivariate_normal.pdf(
@@ -126,7 +127,7 @@ def base(state_vec, noise_diff_coeffs):
     # (with external noise)
     noise = model_obj.rvs(timestamp=new_timestamp, time_interval=time_interval)
     new_state_vec_w_enoise = model_obj.function(
-        state_vec,
+        State(state_vec),
         timestamp=new_timestamp,
         time_interval=time_interval,
         noise=noise)
@@ -134,7 +135,7 @@ def base(state_vec, noise_diff_coeffs):
 
     # Evaluate the likelihood of the predicted state, given the prior
     # (with noise)
-    prob = model_obj.pdf(new_state_vec_w_enoise, state_vec,
+    prob = model_obj.pdf(State(new_state_vec_w_enoise), State(state_vec),
                          timestamp=new_timestamp, time_interval=time_interval)
     assert approx(prob) == multivariate_normal.pdf(
         new_state_vec_w_enoise.T,

--- a/stonesoup/models/transition/tests/test_combined.py
+++ b/stonesoup/models/transition/tests/test_combined.py
@@ -32,7 +32,9 @@ def test_combined():
     assert (DIM, DIM) == combined_model.matrix(time_interval=t_delta).shape
     assert (DIM, DIM) == combined_model.covar(time_interval=t_delta).shape
     assert (DIM, 1) == combined_model.function(
-        State(x_prior), noise=np.random.randn(DIM, 1), time_interval=t_delta).shape
+        State(x_prior), noise=np.random.randn(DIM, 1),
+        time_interval=t_delta).shape
     assert (DIM, 1) == combined_model.rvs(time_interval=t_delta).shape
     assert isinstance(
-        combined_model.pdf(State(x_post), State(x_prior), time_interval=t_delta), Real)
+        combined_model.pdf(State(x_post), State(x_prior),
+                           time_interval=t_delta), Real)

--- a/stonesoup/models/transition/tests/test_combined.py
+++ b/stonesoup/models/transition/tests/test_combined.py
@@ -7,6 +7,7 @@ import numpy as np
 from ..linear import (
     LinearGaussianTimeInvariantTransitionModel, ConstantVelocity,
     CombinedLinearGaussianTransitionModel)
+from ....types.state import State
 
 
 def test_combined():
@@ -31,7 +32,7 @@ def test_combined():
     assert (DIM, DIM) == combined_model.matrix(time_interval=t_delta).shape
     assert (DIM, DIM) == combined_model.covar(time_interval=t_delta).shape
     assert (DIM, 1) == combined_model.function(
-        x_prior, noise=np.random.randn(DIM, 1), time_interval=t_delta).shape
+        State(x_prior), noise=np.random.randn(DIM, 1), time_interval=t_delta).shape
     assert (DIM, 1) == combined_model.rvs(time_interval=t_delta).shape
     assert isinstance(
-        combined_model.pdf(x_post, x_prior, time_interval=t_delta), Real)
+        combined_model.pdf(State(x_post), State(x_prior), time_interval=t_delta), Real)

--- a/stonesoup/models/transition/tests/test_ct.py
+++ b/stonesoup/models/transition/tests/test_ct.py
@@ -6,17 +6,17 @@ import scipy as sp
 from scipy.stats import multivariate_normal
 
 from ..linear import ConstantTurn
-
+from ....types.state import State
 
 def test_ctmodel():
     """ ConstantTurn Transition Model test """
-    state_vec = sp.array([[3.0], [1.0], [2.0], [1.0]])
+    state = State(sp.array([[3.0], [1.0], [2.0], [1.0]]))
     noise_diff_coeffs = sp.array([0.01, 0.01])
     turn_rate = 0.1
-    base(ConstantTurn, state_vec, noise_diff_coeffs, turn_rate)
+    base(ConstantTurn, state, noise_diff_coeffs, turn_rate)
 
 
-def base(model, state_vec, noise_diff_coeffs, turn_rate):
+def base(model, state, noise_diff_coeffs, turn_rate):
     """ Base test for n-dimensional ConstantAcceleration Transition Models """
 
     # Create an ConstantTurn model object
@@ -24,7 +24,7 @@ def base(model, state_vec, noise_diff_coeffs, turn_rate):
     model_obj = model(noise_diff_coeffs=noise_diff_coeffs, turn_rate=turn_rate)
 
     # State related variables
-    state_vec = state_vec
+    state_vec = state.state_vector
     old_timestamp = datetime.datetime.now()
     timediff = 1  # 1sec
     new_timestamp = old_timestamp + datetime.timedelta(seconds=timediff)
@@ -74,7 +74,7 @@ def base(model, state_vec, noise_diff_coeffs, turn_rate):
     # Propagate a state vector through the model
     # (without noise)
     new_state_vec_wo_noise = model_obj.function(
-        state_vec, noise=0,
+        state, noise=0,
         timestamp=new_timestamp,
         time_interval=time_interval)
 
@@ -82,8 +82,8 @@ def base(model, state_vec, noise_diff_coeffs, turn_rate):
 
     # Evaluate the likelihood of the predicted state, given the prior
     # (without noise)
-    prob = model_obj.pdf(new_state_vec_wo_noise,
-                         state_vec,
+    prob = model_obj.pdf(State(new_state_vec_wo_noise),
+                         state,
                          timestamp=new_timestamp,
                          time_interval=time_interval)
     assert approx(prob) == multivariate_normal.pdf(
@@ -94,15 +94,15 @@ def base(model, state_vec, noise_diff_coeffs, turn_rate):
     # Propagate a state vector throughout the model
     # (with internal noise)
     new_state_vec_w_inoise = model_obj.function(
-        state_vec,
+        state,
         timestamp=new_timestamp,
         time_interval=time_interval)
     assert not sp.array_equal(new_state_vec_w_inoise, F@state_vec)
 
     # Evaluate the likelihood of the predicted state, given the prior
     # (with noise)
-    prob = model_obj.pdf(new_state_vec_w_inoise,
-                         state_vec,
+    prob = model_obj.pdf(State(new_state_vec_w_inoise),
+                         state,
                          timestamp=new_timestamp,
                          time_interval=time_interval)
     assert approx(prob) == multivariate_normal.pdf(
@@ -114,7 +114,7 @@ def base(model, state_vec, noise_diff_coeffs, turn_rate):
     # (with external noise)
     noise = model_obj.rvs(timestamp=new_timestamp, time_interval=time_interval)
     new_state_vec_w_enoise = model_obj.function(
-        state_vec,
+        state,
         timestamp=new_timestamp,
         time_interval=time_interval,
         noise=noise)
@@ -122,7 +122,7 @@ def base(model, state_vec, noise_diff_coeffs, turn_rate):
 
     # Evaluate the likelihood of the predicted state, given the prior
     # (with noise)
-    prob = model_obj.pdf(new_state_vec_w_enoise, state_vec,
+    prob = model_obj.pdf(State(new_state_vec_w_enoise), state,
                          timestamp=new_timestamp, time_interval=time_interval)
     assert approx(prob) == multivariate_normal.pdf(
         new_state_vec_w_enoise.T,

--- a/stonesoup/models/transition/tests/test_ct.py
+++ b/stonesoup/models/transition/tests/test_ct.py
@@ -8,6 +8,7 @@ from scipy.stats import multivariate_normal
 from ..linear import ConstantTurn
 from ....types.state import State
 
+
 def test_ctmodel():
     """ ConstantTurn Transition Model test """
     state = State(sp.array([[3.0], [1.0], [2.0], [1.0]]))

--- a/stonesoup/models/transition/tests/test_cv.py
+++ b/stonesoup/models/transition/tests/test_cv.py
@@ -6,13 +6,14 @@ import scipy as sp
 from scipy.stats import multivariate_normal
 
 from ..linear import ConstantVelocity
+from ....types.state import State
 
 
 def test_cvmodel():
     """ ConstanVelocity Transition Model test """
 
     # State related variables
-    state_vec = sp.array([[3.0], [1.0]])
+    state = State(sp.array([[3.0], [1.0]]))
     old_timestamp = datetime.datetime.now()
     timediff = 1  # 1sec
     new_timestamp = old_timestamp + datetime.timedelta(seconds=timediff)
@@ -40,57 +41,57 @@ def test_cvmodel():
     # Propagate a state vector through the model
     # (without noise)
     new_state_vec_wo_noise = cv.function(
-        state_vec,
+        state,
         timestamp=new_timestamp,
         time_interval=time_interval,
         noise=0)
-    assert sp.array_equal(new_state_vec_wo_noise, F@state_vec)
+    assert sp.array_equal(new_state_vec_wo_noise, F@state.state_vector)
 
     # Evaluate the likelihood of the predicted state, given the prior
     # (without noise)
-    prob = cv.pdf(new_state_vec_wo_noise,
-                  state_vec,
+    prob = cv.pdf(State(new_state_vec_wo_noise),
+                  state,
                   timestamp=new_timestamp,
                   time_interval=time_interval)
     assert approx(prob) == multivariate_normal.pdf(
         new_state_vec_wo_noise.T,
-        mean=sp.array(F@state_vec).ravel(),
+        mean=sp.array(F@state.state_vector).ravel(),
         cov=Q)
 
     # Propagate a state vector throught the model
     # (with internal noise)
     new_state_vec_w_inoise = cv.function(
-        state_vec,
+        state,
         timestamp=new_timestamp,
         time_interval=time_interval)
-    assert not sp.array_equal(new_state_vec_w_inoise, F@state_vec)
+    assert not sp.array_equal(new_state_vec_w_inoise, F@state.state_vector)
 
     # Evaluate the likelihood of the predicted state, given the prior
     # (with noise)
-    prob = cv.pdf(new_state_vec_w_inoise,
-                  state_vec,
+    prob = cv.pdf(State(new_state_vec_w_inoise),
+                  state,
                   timestamp=new_timestamp,
                   time_interval=time_interval)
     assert approx(prob) == multivariate_normal.pdf(
         new_state_vec_w_inoise.T,
-        mean=sp.array(F@state_vec).ravel(),
+        mean=sp.array(F@state.state_vector).ravel(),
         cov=Q)
 
     # Propagate a state vector throught the model
     # (with external noise)
     noise = cv.rvs(timestamp=new_timestamp, time_interval=time_interval)
     new_state_vec_w_enoise = cv.function(
-        state_vec,
+        state,
         timestamp=new_timestamp,
         time_interval=time_interval,
         noise=noise)
-    assert sp.array_equal(new_state_vec_w_enoise, F@state_vec+noise)
+    assert sp.array_equal(new_state_vec_w_enoise, F@state.state_vector+noise)
 
     # Evaluate the likelihood of the predicted state, given the prior
     # (with noise)
-    prob = cv.pdf(new_state_vec_w_enoise, state_vec,
+    prob = cv.pdf(State(new_state_vec_w_enoise), state,
                   timestamp=new_timestamp, time_interval=time_interval)
     assert approx(prob) == multivariate_normal.pdf(
         new_state_vec_w_enoise.T,
-        mean=sp.array(F@state_vec).ravel(),
+        mean=sp.array(F@state.state_vector).ravel(),
         cov=Q)

--- a/stonesoup/models/transition/tests/test_ou.py
+++ b/stonesoup/models/transition/tests/test_ou.py
@@ -7,13 +7,14 @@ import scipy as sp
 from scipy.stats import multivariate_normal
 
 from stonesoup.models.transition.linear import OrnsteinUhlenbeck
+from ....types.state import State
 
 
 def test_oumodel():
     """ OrnsteinUhlenbeck Transition Model test """
 
     # State related variables
-    state_vec = sp.array([[3.0], [1.0]])
+    state = State(sp.array([[3.0], [1.0]]))
     old_timestamp = datetime.datetime.now()
     timediff = 1  # 1sec
     new_timestamp = old_timestamp + datetime.timedelta(seconds=timediff)
@@ -52,58 +53,58 @@ def test_oumodel():
     # Propagate a state vector throught the model
     # (without noise)
     new_state_vec_wo_noise = ou.function(
-        state_vec,
+        state,
         timestamp=new_timestamp,
         time_interval=time_interval,
         noise=0)
-    assert sp.allclose(new_state_vec_wo_noise, F @ state_vec, rtol=1e-10)
+    assert sp.allclose(new_state_vec_wo_noise, F @ state.state_vector, rtol=1e-10)
 
     # Evaluate the likelihood of the predicted state, given the prior
     # (without noise)
-    prob = ou.pdf(new_state_vec_wo_noise,
-                  state_vec,
+    prob = ou.pdf(State(new_state_vec_wo_noise),
+                  state,
                   timestamp=new_timestamp,
                   time_interval=time_interval)
     assert approx(prob) == multivariate_normal.pdf(
         new_state_vec_wo_noise.T,
-        mean=sp.array(F @ state_vec).ravel(),
+        mean=sp.array(F @ state.state_vector).ravel(),
         cov=Q)
 
-    # Propagate a state vector throught the model
+    # Propagate a state vector through the model
     # (with internal noise)
     new_state_vec_w_inoise = ou.function(
-        state_vec,
+        state,
         timestamp=new_timestamp,
         time_interval=time_interval)
-    assert not sp.allclose(new_state_vec_w_inoise, F @ state_vec, rtol=1e-10)
+    assert not sp.allclose(new_state_vec_w_inoise, F @ state.state_vector, rtol=1e-10)
 
     # Evaluate the likelihood of the predicted state, given the prior
     # (with noise)
-    prob = ou.pdf(new_state_vec_w_inoise,
-                  state_vec,
+    prob = ou.pdf(State(new_state_vec_w_inoise),
+                  state,
                   timestamp=new_timestamp,
                   time_interval=time_interval)
     assert approx(prob) == multivariate_normal.pdf(
         new_state_vec_w_inoise.T,
-        mean=sp.array(F @ state_vec).ravel(),
+        mean=sp.array(F @ state.state_vector).ravel(),
         cov=Q)
 
-    # Propagate a state vector throught the model
+    # Propagate a state vector through the model
     # (with external noise)
     noise = ou.rvs(timestamp=new_timestamp, time_interval=time_interval)
     new_state_vec_w_enoise = ou.function(
-        state_vec,
+        state,
         timestamp=new_timestamp,
         time_interval=time_interval,
         noise=noise)
-    assert sp.allclose(new_state_vec_w_enoise, F @ state_vec + noise,
+    assert sp.allclose(new_state_vec_w_enoise, F @ state.state_vector + noise,
                        rtol=1e-10)
 
     # Evaluate the likelihood of the predicted state, given the prior
     # (with noise)
-    prob = ou.pdf(new_state_vec_w_enoise, state_vec,
+    prob = ou.pdf(State(new_state_vec_w_enoise), state,
                   timestamp=new_timestamp, time_interval=time_interval)
     assert approx(prob) == multivariate_normal.pdf(
         new_state_vec_w_enoise.T,
-        mean=sp.array(F @ state_vec).ravel(),
+        mean=sp.array(F @ state.state_vector).ravel(),
         cov=Q)

--- a/stonesoup/models/transition/tests/test_ou.py
+++ b/stonesoup/models/transition/tests/test_ou.py
@@ -57,7 +57,8 @@ def test_oumodel():
         timestamp=new_timestamp,
         time_interval=time_interval,
         noise=0)
-    assert sp.allclose(new_state_vec_wo_noise, F @ state.state_vector, rtol=1e-10)
+    assert sp.allclose(new_state_vec_wo_noise, F @ state.state_vector,
+                       rtol=1e-10)
 
     # Evaluate the likelihood of the predicted state, given the prior
     # (without noise)
@@ -76,7 +77,8 @@ def test_oumodel():
         state,
         timestamp=new_timestamp,
         time_interval=time_interval)
-    assert not sp.allclose(new_state_vec_w_inoise, F @ state.state_vector, rtol=1e-10)
+    assert not sp.allclose(new_state_vec_w_inoise, F @ state.state_vector,
+                           rtol=1e-10)
 
     # Evaluate the likelihood of the predicted state, given the prior
     # (with noise)

--- a/stonesoup/models/transition/tests/test_rw.py
+++ b/stonesoup/models/transition/tests/test_rw.py
@@ -6,13 +6,14 @@ import scipy as sp
 from scipy.stats import multivariate_normal
 
 from ..linear import RandomWalk
+from ....types.state import State
 
 
 def test_rwodel():
     """ RandomWalk Transition Model test """
 
     # State related variables
-    state_vec = sp.array([[3.0]])
+    state = State(sp.array([[3.0]]))
     old_timestamp = datetime.datetime.now()
     timediff = 1  # 1sec
     new_timestamp = old_timestamp + datetime.timedelta(seconds=timediff)
@@ -37,57 +38,57 @@ def test_rwodel():
     # Propagate a state vector through the model
     # (without noise)
     new_state_vec_wo_noise = rw.function(
-        state_vec,
+        state,
         timestamp=new_timestamp,
         time_interval=time_interval,
         noise=0)
-    assert sp.array_equal(new_state_vec_wo_noise, F@state_vec)
+    assert sp.array_equal(new_state_vec_wo_noise, F@state.state_vector)
 
     # Evaluate the likelihood of the predicted state, given the prior
     # (without noise)
-    prob = rw.pdf(new_state_vec_wo_noise,
-                  state_vec,
+    prob = rw.pdf(State(new_state_vec_wo_noise),
+                  state,
                   timestamp=new_timestamp,
                   time_interval=time_interval)
     assert approx(prob) == multivariate_normal.pdf(
         new_state_vec_wo_noise.T,
-        mean=sp.array(F@state_vec).ravel(),
+        mean=sp.array(F@state.state_vector).ravel(),
         cov=Q)
 
     # Propagate a state vector throught the model
     # (with internal noise)
     new_state_vec_w_inoise = rw.function(
-        state_vec,
+        state,
         timestamp=new_timestamp,
         time_interval=time_interval)
-    assert not sp.array_equal(new_state_vec_w_inoise, F@state_vec)
+    assert not sp.array_equal(new_state_vec_w_inoise, F@state.state_vector)
 
     # Evaluate the likelihood of the predicted state, given the prior
     # (with noise)
-    prob = rw.pdf(new_state_vec_w_inoise,
-                  state_vec,
+    prob = rw.pdf(State(new_state_vec_w_inoise),
+                  state,
                   timestamp=new_timestamp,
                   time_interval=time_interval)
     assert approx(prob) == multivariate_normal.pdf(
         new_state_vec_w_inoise.T,
-        mean=sp.array(F@state_vec).ravel(),
+        mean=sp.array(F@state.state_vector).ravel(),
         cov=Q)
 
-    # Propagate a state vector throught the model
+    # Propagate a state vector through the model
     # (with external noise)
     noise = rw.rvs(timestamp=new_timestamp, time_interval=time_interval)
     new_state_vec_w_enoise = rw.function(
-        state_vec,
+        state,
         timestamp=new_timestamp,
         time_interval=time_interval,
         noise=noise)
-    assert sp.array_equal(new_state_vec_w_enoise, F@state_vec+noise)
+    assert sp.array_equal(new_state_vec_w_enoise, F@state.state_vector + noise)
 
     # Evaluate the likelihood of the predicted state, given the prior
     # (with noise)
-    prob = rw.pdf(new_state_vec_w_enoise, state_vec,
+    prob = rw.pdf(State(new_state_vec_w_enoise), state,
                   timestamp=new_timestamp, time_interval=time_interval)
     assert approx(prob) == multivariate_normal.pdf(
         new_state_vec_w_enoise.T,
-        mean=sp.array(F@state_vec).ravel(),
+        mean=sp.array(F@state.state_vector).ravel(),
         cov=Q)

--- a/stonesoup/models/transition/tests/test_singer.py
+++ b/stonesoup/models/transition/tests/test_singer.py
@@ -6,38 +6,40 @@ import scipy as sp
 from scipy.stats import multivariate_normal
 
 from ..linear import Singer, CombinedLinearGaussianTransitionModel
-
+from ....types.state import State
 
 def test_singer1dmodel():
     """ Singer 1D Transition Model test """
-    state_vec = sp.array([[3.0], [1.0], [0.1]])
+    state = State(sp.array([[3.0], [1.0], [0.1]]))
     noise_diff_coeffs = sp.array([0.01])
     damping_coeffs = sp.array([0.1])
-    base(state_vec, noise_diff_coeffs, damping_coeffs)
+    base(state, noise_diff_coeffs, damping_coeffs)
 
 
 def test_singer2dmodel():
     """ Singer 2D Transition Model test """
-    state_vec = sp.array([[3.0], [1.0], [0.1],
-                          [2.0], [2.0], [0.2]])
+    state = State(sp.array([[3.0], [1.0], [0.1],
+                          [2.0], [2.0], [0.2]]))
     noise_diff_coeffs = sp.array([0.01, 0.02])
     damping_coeffs = sp.array([0.1, 0.1])
 
-    base(state_vec, noise_diff_coeffs, damping_coeffs)
+    base(state, noise_diff_coeffs, damping_coeffs)
 
 
 def test_singer3dmodel():
     """ Singer 3D Transition Model test """
-    state_vec = sp.array([[3.0], [1.0], [0.1],
+    state = State(sp.array([[3.0], [1.0], [0.1],
                           [2.0], [2.0], [0.2],
-                          [4.0], [0.5], [0.05]])
+                          [4.0], [0.5], [0.05]]))
     noise_diff_coeffs = sp.array([0.01, 0.02, 0.005])
     damping_coeffs = sp.array([0.1, 0.1, 0.1])
-    base(state_vec, noise_diff_coeffs, damping_coeffs)
+    base(state, noise_diff_coeffs, damping_coeffs)
 
 
-def base(state_vec, noise_diff_coeffs, damping_coeffs, timediff=1.0):
+def base(state, noise_diff_coeffs, damping_coeffs, timediff=1.0):
     """ Base test for n-dimensional ConstantAcceleration Transition Models """
+
+    state_vec = state.state_vector
 
     # Create a 1D Singer or an n-dimensional
     # CombinedLinearGaussianTransitionModel object
@@ -120,7 +122,7 @@ def base(state_vec, noise_diff_coeffs, damping_coeffs, timediff=1.0):
     # Propagate a state vector through the model
     # (without noise)
     new_state_vec_wo_noise = model_obj.function(
-        state_vec,
+        state,
         timestamp=new_timestamp,
         time_interval=time_interval,
         noise=0)
@@ -128,8 +130,8 @@ def base(state_vec, noise_diff_coeffs, damping_coeffs, timediff=1.0):
 
     # Evaluate the likelihood of the predicted state, given the prior
     # (without noise)
-    prob = model_obj.pdf(new_state_vec_wo_noise,
-                         state_vec,
+    prob = model_obj.pdf(State(new_state_vec_wo_noise),
+                         state,
                          timestamp=new_timestamp,
                          time_interval=time_interval)
     assert approx(prob) == multivariate_normal.pdf(
@@ -140,7 +142,7 @@ def base(state_vec, noise_diff_coeffs, damping_coeffs, timediff=1.0):
     # Propagate a state vector throughout the model
     # (with internal noise)
     new_state_vec_w_inoise = model_obj.function(
-        state_vec,
+        state,
         timestamp=new_timestamp,
         time_interval=time_interval)
     assert not sp.allclose(new_state_vec_w_inoise, F@state_vec, rtol=1e-6)
@@ -148,8 +150,8 @@ def base(state_vec, noise_diff_coeffs, damping_coeffs, timediff=1.0):
     # Evaluate the likelihood of the predicted state, given the prior
     # (with noise)
     # (with noise)
-    prob = model_obj.pdf(new_state_vec_w_inoise,
-                         state_vec,
+    prob = model_obj.pdf(State(new_state_vec_w_inoise),
+                         state,
                          timestamp=new_timestamp,
                          time_interval=time_interval)
     assert approx(prob) == multivariate_normal.pdf(
@@ -161,7 +163,7 @@ def base(state_vec, noise_diff_coeffs, damping_coeffs, timediff=1.0):
     # (with external noise)
     noise = model_obj.rvs(timestamp=new_timestamp, time_interval=time_interval)
     new_state_vec_w_enoise = model_obj.function(
-        state_vec,
+        state,
         timestamp=new_timestamp,
         time_interval=time_interval,
         noise=noise)
@@ -169,7 +171,7 @@ def base(state_vec, noise_diff_coeffs, damping_coeffs, timediff=1.0):
 
     # Evaluate the likelihood of the predicted state, given the prior
     # (with noise)
-    prob = model_obj.pdf(new_state_vec_w_enoise, state_vec,
+    prob = model_obj.pdf(State(new_state_vec_w_enoise), state,
                          timestamp=new_timestamp, time_interval=time_interval)
     assert approx(prob) == multivariate_normal.pdf(
         new_state_vec_w_enoise.T,

--- a/stonesoup/models/transition/tests/test_singer.py
+++ b/stonesoup/models/transition/tests/test_singer.py
@@ -8,6 +8,7 @@ from scipy.stats import multivariate_normal
 from ..linear import Singer, CombinedLinearGaussianTransitionModel
 from ....types.state import State
 
+
 def test_singer1dmodel():
     """ Singer 1D Transition Model test """
     state = State(sp.array([[3.0], [1.0], [0.1]]))
@@ -18,8 +19,7 @@ def test_singer1dmodel():
 
 def test_singer2dmodel():
     """ Singer 2D Transition Model test """
-    state = State(sp.array([[3.0], [1.0], [0.1],
-                          [2.0], [2.0], [0.2]]))
+    state = State(sp.array([[3.0], [1.0], [0.1], [2.0], [2.0], [0.2]]))
     noise_diff_coeffs = sp.array([0.01, 0.02])
     damping_coeffs = sp.array([0.1, 0.1])
 
@@ -28,9 +28,8 @@ def test_singer2dmodel():
 
 def test_singer3dmodel():
     """ Singer 3D Transition Model test """
-    state = State(sp.array([[3.0], [1.0], [0.1],
-                          [2.0], [2.0], [0.2],
-                          [4.0], [0.5], [0.05]]))
+    state = State(sp.array([[3.0], [1.0], [0.1], [2.0], [2.0], [0.2], [4.0],
+                            [0.5], [0.05]]))
     noise_diff_coeffs = sp.array([0.01, 0.02, 0.005])
     damping_coeffs = sp.array([0.1, 0.1, 0.1])
     base(state, noise_diff_coeffs, damping_coeffs)

--- a/stonesoup/models/transition/tests/test_singer_approximate.py
+++ b/stonesoup/models/transition/tests/test_singer_approximate.py
@@ -8,6 +8,7 @@ from scipy.stats import multivariate_normal
 from ..linear import SingerApproximate, CombinedLinearGaussianTransitionModel
 from ....types.state import State
 
+
 def test_singer1dmodel_approximate():
     """ SingerApproximate 1D Transition Model test for small timediff """
     state = State(sp.array([[3.0], [1.0], [0.1]]))
@@ -18,8 +19,7 @@ def test_singer1dmodel_approximate():
 
 def test_singer2dmodel_approximate():
     """ SingerApproximate 2D Transition Model test for small timediff """
-    state = State(sp.array([[3.0], [1.0], [0.1],
-                          [2.0], [2.0], [0.2]]))
+    state = State(sp.array([[3.0], [1.0], [0.1], [2.0], [2.0], [0.2]]))
     noise_diff_coeffs = sp.array([0.01, 0.02])
     damping_coeffs = sp.array([0.1, 0.1])
 
@@ -28,9 +28,8 @@ def test_singer2dmodel_approximate():
 
 def test_singer3dmodel_approximate():
     """ SingerApproximate 3D Transition Model test for small timediff """
-    state = State(sp.array([[3.0], [1.0], [0.1],
-                          [2.0], [2.0], [0.2],
-                          [4.0], [0.5], [0.05]]))
+    state = State(sp.array([[3.0], [1.0], [0.1], [2.0], [2.0], [0.2], [4.0],
+                            [0.5], [0.05]]))
     noise_diff_coeffs = sp.array([0.01, 0.02, 0.005])
     damping_coeffs = sp.array([0.1, 0.1, 0.1])
     base(state, noise_diff_coeffs, damping_coeffs, timediff=0.4)

--- a/stonesoup/models/transition/tests/test_singer_approximate.py
+++ b/stonesoup/models/transition/tests/test_singer_approximate.py
@@ -6,38 +6,40 @@ import scipy as sp
 from scipy.stats import multivariate_normal
 
 from ..linear import SingerApproximate, CombinedLinearGaussianTransitionModel
-
+from ....types.state import State
 
 def test_singer1dmodel_approximate():
     """ SingerApproximate 1D Transition Model test for small timediff """
-    state_vec = sp.array([[3.0], [1.0], [0.1]])
+    state = State(sp.array([[3.0], [1.0], [0.1]]))
     noise_diff_coeffs = sp.array([0.01])
     damping_coeffs = sp.array([0.1])
-    base(state_vec, noise_diff_coeffs, damping_coeffs, timediff=0.4)
+    base(state, noise_diff_coeffs, damping_coeffs, timediff=0.4)
 
 
 def test_singer2dmodel_approximate():
     """ SingerApproximate 2D Transition Model test for small timediff """
-    state_vec = sp.array([[3.0], [1.0], [0.1],
-                          [2.0], [2.0], [0.2]])
+    state = State(sp.array([[3.0], [1.0], [0.1],
+                          [2.0], [2.0], [0.2]]))
     noise_diff_coeffs = sp.array([0.01, 0.02])
     damping_coeffs = sp.array([0.1, 0.1])
 
-    base(state_vec, noise_diff_coeffs, damping_coeffs, timediff=0.4)
+    base(state, noise_diff_coeffs, damping_coeffs, timediff=0.4)
 
 
 def test_singer3dmodel_approximate():
     """ SingerApproximate 3D Transition Model test for small timediff """
-    state_vec = sp.array([[3.0], [1.0], [0.1],
+    state = State(sp.array([[3.0], [1.0], [0.1],
                           [2.0], [2.0], [0.2],
-                          [4.0], [0.5], [0.05]])
+                          [4.0], [0.5], [0.05]]))
     noise_diff_coeffs = sp.array([0.01, 0.02, 0.005])
     damping_coeffs = sp.array([0.1, 0.1, 0.1])
-    base(state_vec, noise_diff_coeffs, damping_coeffs, timediff=0.4)
+    base(state, noise_diff_coeffs, damping_coeffs, timediff=0.4)
 
 
-def base(state_vec, noise_diff_coeffs, damping_coeffs, timediff=1.0):
+def base(state, noise_diff_coeffs, damping_coeffs, timediff=1.0):
     """ Base test for n-dimensional ConstantAcceleration Transition Models """
+
+    state_vec = state.state_vector
 
     # Create a 1D Singer or an n-dimensional
     # CombinedLinearGaussianTransitionModel object
@@ -107,7 +109,7 @@ def base(state_vec, noise_diff_coeffs, damping_coeffs, timediff=1.0):
     # Propagate a state vector through the model
     # (without noise)
     new_state_vec_wo_noise = model_obj.function(
-        state_vec,
+        state,
         timestamp=new_timestamp,
         time_interval=time_interval,
         noise=0)
@@ -115,8 +117,8 @@ def base(state_vec, noise_diff_coeffs, damping_coeffs, timediff=1.0):
 
     # Evaluate the likelihood of the predicted state, given the prior
     # (without noise)
-    prob = model_obj.pdf(new_state_vec_wo_noise,
-                         state_vec,
+    prob = model_obj.pdf(State(new_state_vec_wo_noise),
+                         state,
                          timestamp=new_timestamp,
                          time_interval=time_interval)
     assert approx(prob) == multivariate_normal.pdf(
@@ -127,15 +129,15 @@ def base(state_vec, noise_diff_coeffs, damping_coeffs, timediff=1.0):
     # Propagate a state vector throughout the model
     # (with internal noise)
     new_state_vec_w_inoise = model_obj.function(
-        state_vec,
+        state,
         timestamp=new_timestamp,
         time_interval=time_interval)
     assert not sp.allclose(new_state_vec_w_inoise, F@state_vec, rtol=1e-10)
 
     # Evaluate the likelihood of the predicted state, given the prior
     # (with noise)
-    prob = model_obj.pdf(new_state_vec_w_inoise,
-                         state_vec,
+    prob = model_obj.pdf(State(new_state_vec_w_inoise),
+                         state,
                          timestamp=new_timestamp,
                          time_interval=time_interval)
     assert approx(prob) == multivariate_normal.pdf(
@@ -147,7 +149,7 @@ def base(state_vec, noise_diff_coeffs, damping_coeffs, timediff=1.0):
     # (with external noise)
     noise = model_obj.rvs(timestamp=new_timestamp, time_interval=time_interval)
     new_state_vec_w_enoise = model_obj.function(
-        state_vec,
+        state,
         timestamp=new_timestamp,
         time_interval=time_interval,
         noise=noise)
@@ -155,7 +157,7 @@ def base(state_vec, noise_diff_coeffs, damping_coeffs, timediff=1.0):
 
     # Evaluate the likelihood of the predicted state, given the prior
     # (with noise)
-    prob = model_obj.pdf(new_state_vec_w_enoise, state_vec,
+    prob = model_obj.pdf(State(new_state_vec_w_enoise), state,
                          timestamp=new_timestamp, time_interval=time_interval)
     assert approx(prob) == multivariate_normal.pdf(
         new_state_vec_w_enoise.T,

--- a/stonesoup/models/transition/tests/test_time_invariant.py
+++ b/stonesoup/models/transition/tests/test_time_invariant.py
@@ -4,6 +4,7 @@ from numbers import Real
 import numpy as np
 
 from ..linear import LinearGaussianTimeInvariantTransitionModel
+from ....types.state import State
 
 
 def test_linear_gaussian():
@@ -18,6 +19,6 @@ def test_linear_gaussian():
     assert F.shape[0] == model.ndim_state
     assert np.array_equal(F, model.matrix())
     assert np.array_equal(Q, model.covar())
-    assert np.array_equal(x_2, model.function(x_1, noise=np.zeros([3, 1])))
+    assert np.array_equal(x_2, model.function(State(x_1), noise=np.zeros([3, 1])))
     assert isinstance(model.rvs(), np.ndarray)
-    assert isinstance(model.pdf(x_2, x_1), Real)
+    assert isinstance(model.pdf(State(x_2), State(x_1)), Real)

--- a/stonesoup/models/transition/tests/test_time_invariant.py
+++ b/stonesoup/models/transition/tests/test_time_invariant.py
@@ -19,6 +19,7 @@ def test_linear_gaussian():
     assert F.shape[0] == model.ndim_state
     assert np.array_equal(F, model.matrix())
     assert np.array_equal(Q, model.covar())
-    assert np.array_equal(x_2, model.function(State(x_1), noise=np.zeros([3, 1])))
+    assert np.array_equal(x_2, model.function(State(x_1),
+                                              noise=np.zeros([3, 1])))
     assert isinstance(model.rvs(), np.ndarray)
     assert isinstance(model.pdf(State(x_2), State(x_1)), Real)

--- a/stonesoup/platform/base.py
+++ b/stonesoup/platform/base.py
@@ -49,7 +49,7 @@ class Platform(Base):
 
         self.state = State(
             state_vector=self.transition_model.function(
-                state_vector=self.state.state_vector,
+                state=self.state,
                 timestamp=timestamp,
                 time_interval=time_interval,
                 **kwargs),

--- a/stonesoup/predictor/kalman.py
+++ b/stonesoup/predictor/kalman.py
@@ -226,7 +226,7 @@ class ExtendedKalmanPredictor(KalmanPredictor):
         if isinstance(self.transition_model, LinearModel):
             return self.transition_model.matrix(**kwargs)
         else:
-            return self.transition_model.jacobian(prior.state_vector, **kwargs)
+            return self.transition_model.jacobian(prior, **kwargs)
 
     def _transition_function(self, prior, **kwargs):
         r"""This is the application of :math:`f_k(\mathbf{x}_{k-1})`, the

--- a/stonesoup/predictor/kalman.py
+++ b/stonesoup/predictor/kalman.py
@@ -246,8 +246,7 @@ class ExtendedKalmanPredictor(KalmanPredictor):
             The predicted state
 
         """
-        return self.transition_model.function(prior.state_vector, noise=0,
-                                              **kwargs)
+        return self.transition_model.function(prior, noise=0, **kwargs)
 
     @property
     def _control_matrix(self):
@@ -304,7 +303,7 @@ class UnscentedKalmanPredictor(KalmanPredictor):
 
         self._time_interval = None
 
-    def _transition_and_control_function(self, prior_state_vector, **kwargs):
+    def _transition_and_control_function(self, prior_state, **kwargs):
         r"""Returns the result of applying the transition and control functions
         for the unscented transform
 
@@ -323,9 +322,8 @@ class UnscentedKalmanPredictor(KalmanPredictor):
         """
 
         return \
-            self.transition_model.function(
-                prior_state_vector, noise=0, **kwargs) \
-            + self.control_model.control_input()
+            self.transition_model.function(prior_state, noise=0, **kwargs) + \
+            self.control_model.control_input()
 
     @lru_cache()
     def predict(self, prior, timestamp=None, **kwargs):

--- a/stonesoup/predictor/kalman.py
+++ b/stonesoup/predictor/kalman.py
@@ -312,7 +312,7 @@ class UnscentedKalmanPredictor(KalmanPredictor):
         prior_state_vector : :class:`~.State`
             Prior state vector
         **kwargs : various, optional
-            These are passed to :meth:`~.TransitionModel.function`
+            These are passed to :class:`~.TransitionModel.function`
 
         Returns
         -------
@@ -359,8 +359,8 @@ class UnscentedKalmanPredictor(KalmanPredictor):
             + self.control_model.control_noise
 
         # Get the sigma points from the prior mean and covariance.
-        sigma_points, mean_weights, covar_weights = gauss2sigma(
-            prior.state_vector, prior.covar, self.alpha, self.beta, self.kappa)
+        sigma_point_states, mean_weights, covar_weights = gauss2sigma(
+            prior, self.alpha, self.beta, self.kappa)
 
         # This ensures that function passed to unscented transform has the
         # correct time interval
@@ -371,7 +371,7 @@ class UnscentedKalmanPredictor(KalmanPredictor):
         # Put these through the unscented transform, together with the total
         # covariance to get the parameters of the Gaussian
         x_pred, p_pred, _, _, _, _ = unscented_transform(
-            sigma_points, mean_weights, covar_weights,
+            sigma_point_states, mean_weights, covar_weights,
             transition_and_control_function, covar_noise=total_noise_covar
         )
 

--- a/stonesoup/predictor/particle.py
+++ b/stonesoup/predictor/particle.py
@@ -42,7 +42,7 @@ class ParticlePredictor(Predictor):
         new_particles = []
         for particle in prior.particles:
             new_state_vector = self.transition_model.function(
-                particle.state_vector,
+                particle,
                 time_interval=time_interval,
                 **kwargs)
             new_particles.append(

--- a/stonesoup/sensor/radar.py
+++ b/stonesoup/sensor/radar.py
@@ -83,7 +83,7 @@ class RadarRangeBearing(Sensor):
         """
 
         measurement_vector = self.measurement_model.function(
-            ground_truth.state_vector, noise=noise, **kwargs)
+            ground_truth, noise=noise, **kwargs)
 
         model_copy = copy.copy(self.measurement_model)
 
@@ -163,7 +163,7 @@ class RadarRotatingRangeBearing(RadarRangeBearing):
         # Transform state to measurement space and generate
         # random noise
         measurement_vector = self.measurement_model.function(
-            ground_truth.state_vector, noise=0, **kwargs)
+            ground_truth, noise=0, **kwargs)
         if(noise is None):
             measurement_noise = self.measurement_model.rvs()
         else:

--- a/stonesoup/simulator/simple.py
+++ b/stonesoup/simulator/simple.py
@@ -46,8 +46,7 @@ class SingleTargetGroundTruthSimulator(GroundTruthSimulator):
             time += self.timestep
             # Move track forward
             trans_state_vector = self.transition_model.function(
-                gttrack[-1].state_vector,
-                time_interval=self.timestep)
+                gttrack[-1], time_interval=self.timestep)
             gttrack.append(GroundTruthState(
                 trans_state_vector, timestamp=time,
                 metadata={"index": self.index}))
@@ -111,8 +110,7 @@ class MultiTargetGroundTruthSimulator(SingleTargetGroundTruthSimulator):
             for gttrack in groundtruth_paths:
                 self.index = gttrack[-1].metadata.get("index")
                 trans_state_vector = self.transition_model.function(
-                    gttrack[-1].state_vector,
-                    time_interval=self.timestep)
+                    gttrack[-1], time_interval=self.timestep)
                 gttrack.append(GroundTruthState(
                     trans_state_vector, timestamp=time,
                     metadata={"index": self.index}))
@@ -194,8 +192,7 @@ class SimpleDetectionSimulator(DetectionSimulator):
                 if np.random.rand() < self.detection_probability:
                     detection = TrueDetection(
                         self.measurement_model.function(
-                            track[-1].state_vector),
-                        timestamp=track[-1].timestamp,
+                            track[-1]), timestamp=track[-1].timestamp,
                         groundtruth_path=track)
                     detection.clutter = False
                     self.real_detections.add(detection)

--- a/stonesoup/simulator/tests/conftest.py
+++ b/stonesoup/simulator/tests/conftest.py
@@ -6,16 +6,16 @@ import numpy as np
 @pytest.fixture()
 def transition_model1():
     class TestTransitionModel:
-        def function(self, state_vector, time_interval):
-            return state_vector + time_interval.total_seconds()
+        def function(self, state, time_interval):
+            return state.state_vector + time_interval.total_seconds()
     return TestTransitionModel()
 
 
 @pytest.fixture()
 def transition_model2():
     class TestTransitionModel:
-        def function(self, state_vector, time_interval):
-            return state_vector + 2*time_interval.total_seconds()
+        def function(self, state, time_interval):
+            return state.state_vector + 2*time_interval.total_seconds()
     return TestTransitionModel()
 
 
@@ -26,7 +26,7 @@ def measurement_model():
         ndim_meas = 2
 
         @staticmethod
-        def function(state_vector):
+        def function(state):
             matrix = np.array([[1, 0, 0, 0], [0, 0, 1, 0]])
-            return matrix @ state_vector
+            return matrix @ state.state_vector
     return TestMeasurementModel()

--- a/stonesoup/tests/test_functions.py
+++ b/stonesoup/tests/test_functions.py
@@ -4,6 +4,7 @@ from pytest import approx
 
 from ..functions import (
     jacobian, gm_reduce_single, mod_bearing, mod_elevation)
+from ..types.state import State
 
 
 def test_jacobian():
@@ -13,9 +14,9 @@ def test_jacobian():
     state_mean = np.array([[3.0], [1.0]])
 
     def f(x):
-        return np.array([[1, 1], [0, 1]])@x
+        return np.array([[1, 1], [0, 1]])@x.state_vector
 
-    jac = jacobian(f, state_mean)
+    jac = jacobian(f, State(state_mean))
     jac = jac  # Stop flake8 unused warning
 
 
@@ -25,35 +26,35 @@ def test_jacobian2():
     # Sample functions to compute Jacobian on
     def fun(x):
         """ function for testing scalars i.e. scalar input, scalar output"""
-        return 2*x**2
+        return 2*x.state_vector**2
 
-    def fun1d(vec):
+    def fun1d(ins):
         """ test function with vector input, scalar output"""
-        out = 2*vec[0]+3*vec[1]
+        out = 2*ins.state_vector[0]+3*ins.state_vector[1]
         return out
 
     def fun2d(vec):
         """ test function with 2d input and 2d output"""
         out = np.empty((2, 1))
-        out[0] = 2*vec[0]**2 + 3*vec[1]**2
-        out[1] = 2*vec[0]+3*vec[1]
+        out[0] = 2*vec.state_vector[0]**2 + 3*vec.state_vector[1]**2
+        out[1] = 2*vec.state_vector[0]+3*vec.state_vector[1]
         return out
         x = 3
-        jac = jacobian(fun, x)
+        jac = jacobian(fun, State(np.array([[x]])))
         assert jac == 4*x
 
     x = np.array([[1], [2]])
     # Tolerance value to use to test if arrays are equal
     tol = 1.0e-5
 
-    jac = jacobian(fun1d, x)
+    jac = jacobian(fun1d, State(x))
     T = np.array([2.0, 3.0])
 
     FOM = np.where(np.abs(jac-T) > tol)
     # Check # of array elements bigger than tol
     assert len(FOM[0]) == 0
 
-    jac = jacobian(fun2d, x)
+    jac = jacobian(fun2d, State(x))
     T = np.array([[4.0*x[0], 6*x[1]],
                   [2, 3]])
     FOM = np.where(np.abs(jac - T) > tol)

--- a/stonesoup/updater/kalman.py
+++ b/stonesoup/updater/kalman.py
@@ -352,7 +352,7 @@ class UnscentedKalmanUpdater(KalmanUpdater):
         measurement_model = self._check_measurement_model(measurement_model)
 
         sigma_points, mean_weights, covar_weights = \
-            gauss2sigma(predicted_state.state_vector, predicted_state.covar,
+            gauss2sigma(predicted_state,
                         self.alpha, self.beta, self.kappa)
 
         meas_pred_mean, meas_pred_covar, cross_covar, _, _, _ = \

--- a/stonesoup/updater/kalman.py
+++ b/stonesoup/updater/kalman.py
@@ -137,7 +137,7 @@ class KalmanUpdater(Updater):
         # native to the updater
         measurement_model = self._check_measurement_model(measurement_model)
 
-        pred_meas = measurement_model.function(predicted_state.state_vector,
+        pred_meas = measurement_model.function(predicted_state,
                                                noise=0, **kwargs)
 
         hh = self._measurement_matrix(predicted_state=predicted_state,
@@ -264,7 +264,7 @@ class ExtendedKalmanUpdater(KalmanUpdater):
         if isinstance(measurement_model, LinearModel):
             return measurement_model.matrix(**kwargs)
         else:
-            return measurement_model.jacobian(predicted_state.state_vector,
+            return measurement_model.jacobian(predicted_state,
                                               **kwargs)
 
 

--- a/stonesoup/updater/particle.py
+++ b/stonesoup/updater/particle.py
@@ -40,7 +40,7 @@ class ParticleUpdater(Updater):
 
         for particle in hypothesis.prediction.particles:
             particle.weight *= measurement_model.pdf(
-                hypothesis.measurement.state_vector, particle.state_vector,
+                hypothesis.measurement, particle,
                 **kwargs)
 
         # Normalise the weights
@@ -67,7 +67,7 @@ class ParticleUpdater(Updater):
         new_particles = []
         for particle in state_prediction.particles:
             new_state_vector = measurement_model.function(
-                particle.state_vector, noise=0, **kwargs)
+                particle, noise=0, **kwargs)
             new_particles.append(
                 Particle(new_state_vector,
                          weight=particle.weight,


### PR DESCRIPTION
Designed to modify the `function()` and `pdf()` methods in `Model` so that they take `State` rather than `StateVector` objects. This so that functions can access parameters not in the state vector.