### PR TITLE
Avoid calculating measurement prediction for missed detections

### DIFF
--- a/stonesoup/hypothesiser/distance.py
+++ b/stonesoup/hypothesiser/distance.py
@@ -67,16 +67,13 @@ class DistanceHypothesiser(Hypothesiser):
 
         # Common state & measurement prediction
         prediction = self.predictor.predict(track.state, timestamp=timestamp)
-        measurement_prediction = self.updater.predict_measurement(
-            prediction)
 
         # Missed detection hypothesis with distance as 'missed_distance'
         hypotheses.append(
             SingleDistanceHypothesis(
                 prediction,
                 MissedDetection(timestamp=timestamp),
-                self.missed_distance,
-                measurement_prediction))
+                self.missed_distance))
 
         # True detection hypotheses
         for detection in detections:

--- a/stonesoup/hypothesiser/probability.py
+++ b/stonesoup/hypothesiser/probability.py
@@ -117,8 +117,6 @@ class PDAHypothesiser(Hypothesiser):
 
         # Common state & measurement prediction
         prediction = self.predictor.predict(track.state, timestamp=timestamp)
-        measurement_prediction = self.updater.predict_measurement(
-            prediction)
 
         # Missed detection hypothesis
         probability = Probability(1 - self.prob_detect*self.prob_gate)
@@ -126,8 +124,7 @@ class PDAHypothesiser(Hypothesiser):
             SingleProbabilityHypothesis(
                 prediction,
                 MissedDetection(timestamp=timestamp),
-                probability,
-                measurement_prediction))
+                probability))
 
         # True detection hypotheses
         for detection in detections:


### PR DESCRIPTION
These aren't really required, as no comparison to measurement space is done. This also causes issues where no measurement model is provided for an updater, as reasonable use case when adding measurement models to detections.