### PR TITLE
Modify SinglePointInitiator to work with non-linear models

### DIFF
--- a/stonesoup/initiator/simple.py
+++ b/stonesoup/initiator/simple.py
@@ -11,14 +11,18 @@ from ..types.particle import Particle
 from ..types.state import GaussianState
 from ..types.track import Track
 from ..types.update import GaussianStateUpdate, ParticleStateUpdate
-from ..updater.kalman import KalmanUpdater
+from ..updater.kalman import ExtendedKalmanUpdater
 from ..dataassociator import DataAssociator
 from ..deleter import Deleter
 from ..updater import Updater
 
 
 class SinglePointInitiator(GaussianInitiator):
-    """ SinglePointInitiator class"""
+    """SinglePointInitiator class
+
+    This uses an :class:`~.ExtendedKalmanUpdater` to carry out an update using
+    provided :attr:`prior_state` for each unassociated detection.
+    """
 
     prior_state = Property(GaussianState, doc="Prior state information")
     measurement_model = Property(MeasurementModel, doc="Measurement model")
@@ -38,7 +42,7 @@ class SinglePointInitiator(GaussianInitiator):
             A list of new tracks with an initial :class:`~.GaussianState`
         """
 
-        updater = KalmanUpdater(self.measurement_model)
+        updater = ExtendedKalmanUpdater(self.measurement_model)
 
         tracks = set()
         for detection in unassociated_detections:

--- a/stonesoup/initiator/tests/test_simple.py
+++ b/stonesoup/initiator/tests/test_simple.py
@@ -3,11 +3,12 @@ import datetime
 import numpy as np
 import pytest
 
+from ...models.base import LinearModel
 from ...models.measurement.linear import LinearGaussian
 from ...models.measurement.nonlinear import CartesianToBearingRange
 from ...models.transition.linear import \
     CombinedLinearGaussianTransitionModel, ConstantVelocity
-from ...updater.kalman import KalmanUpdater
+from ...updater.kalman import KalmanUpdater, ExtendedKalmanUpdater
 from ...predictor.kalman import KalmanPredictor
 from ...deleter.time import UpdateTimeDeleter
 from ...hypothesiser.distance import DistanceHypothesiser
@@ -22,7 +23,12 @@ from ..simple import (
 )
 
 
-def test_spi():
+@pytest.mark.parametrize(
+    'measurement_model',
+    [LinearGaussian(2, [0, 1], np.diag([1, 1])),
+     CartesianToBearingRange(2, [1, 0], np.diag([0.1, 1]))],
+    ids=['linear', 'non-linear'])
+def test_spi(measurement_model):
     """Test SinglePointInitiator"""
 
     # Prior state information
@@ -30,11 +36,11 @@ def test_spi():
         np.array([[0], [0]]),
         np.array([[100, 0], [0, 1]]))
 
-    # Define a measurement model
-    measurement_model = LinearGaussian(2, [0], np.array([[1]]))
-
     # Create the Kalman updater
-    kup = KalmanUpdater(measurement_model)
+    if isinstance(measurement_model, LinearModel):
+        kup = KalmanUpdater(measurement_model)
+    else:
+        kup = ExtendedKalmanUpdater(measurement_model)
 
     # Define the Initiator
     initiator = SinglePointInitiator(
@@ -43,8 +49,8 @@ def test_spi():
 
     # Define 2 detections from which tracks are to be initiated
     timestamp = datetime.datetime.now()
-    detections = [Detection(np.array([[4.5]]), timestamp),
-                  Detection(np.array([[-4.5]]), timestamp)]
+    detections = [Detection(np.array([[4.5], [2.0]]), timestamp),
+                  Detection(np.array([[-4.5], [2.0]]), timestamp)]
 
     # Run the initiator based on the available detections
     tracks = initiator.initiate(detections)


### PR DESCRIPTION
This changes the `SinglePointInitiator` to use a Extended Kalman Updater, rather than the non-linear Kalman Filter. As the KF/EKF updater only differs on how the measurement matrix is fetch, this results in no change to the linear usage, but adds support to non-linear case.