### PR TITLE
Property extensions

### DIFF
--- a/stonesoup/base.py
+++ b/stonesoup/base.py
@@ -121,7 +121,8 @@ class Property:
                     setattr(instance, self._property_name, value)
                 else:
                     # if the value has been set, raise an AttributeError
-                    raise AttributeError(f'{self._property_name} is readonly')
+                    raise AttributeError(
+                        '{} is readonly'.format(self._property_name))
 
             self._setter = _setter
 

--- a/stonesoup/base.py
+++ b/stonesoup/base.py
@@ -104,22 +104,46 @@ class Property:
         self.cls = cls
         self.default = default
         self.doc = doc
+        self._setter = None
+        self._getter = None
+        self._deleter = None
 
     def __get__(self, instance, owner):
         if instance is None:
             return self
-        return getattr(instance, self._property_name)
+        if self._getter is None:
+            return getattr(instance, self._property_name)
+        else:
+            return self._getter(instance)
 
     def __set__(self, instance, value):
-        setattr(instance, self._property_name, value)
+        if self._setter is None:
+            setattr(instance, self._property_name, value)
+        else:
+            self._setter(instance, value)
 
     def __delete__(self, instance):
-        delattr(instance, self._property_name)
+        if self._deleter is None:
+            delattr(instance, self._property_name)
+        else:
+            self._deleter(instance, self._property_name)
 
     def __set_name__(self, owner, name):
         if not isinstance(owner, BaseMeta):
             raise AttributeError("Cannot use Property on this class type")
         self._property_name = "_property_{}".format(name)
+
+    def deleter(self, method):  # real signature unknown
+        """ Descriptor to change the deleter on a property. """
+        self._deleter = method
+
+    def getter(self, method):  # real signature unknown
+        """ Descriptor to change the getter on a property. """
+        self._getter = method
+
+    def setter(self, method):  # real signature unknown
+        """ Descriptor to change the setter on a property. """
+        self._setter = method
 
 
 class BaseMeta(ABCMeta):

--- a/stonesoup/tests/test_declarative.py
+++ b/stonesoup/tests/test_declarative.py
@@ -180,3 +180,29 @@ def test_basic_getter():
     # now test when the default is used
     test_object_default = TestGetter()
     assert test_object_default.times_two == 10
+
+
+def test_readonly():
+
+    class TestReadonly(Base):
+        readonly_property_default = Property(float, default=0, readonly=True)
+        readonly_property_no_default = Property(float, readonly=True)
+
+    test_object = TestReadonly(readonly_property_default=10,
+                               readonly_property_no_default=20)
+
+    # first test read
+    assert test_object.readonly_property_default == 10
+    assert test_object.readonly_property_no_default == 20
+
+    # then test that write raises an exception
+    with pytest.raises(AttributeError):
+        test_object.readonly_property_default = 20
+    with pytest.raises(AttributeError):
+        test_object.readonly_property_no_default = 10
+
+    # now test when the default is used
+    test_object_default = TestReadonly(readonly_property_no_default=20)
+    assert test_object_default.readonly_property_default == 0
+    with pytest.raises(AttributeError):
+        test_object_default.readonly_property_default = 20

--- a/stonesoup/tests/test_declarative.py
+++ b/stonesoup/tests/test_declarative.py
@@ -3,7 +3,7 @@ import sys
 
 import pytest
 
-from ..base import Property
+from ..base import Property, Base
 
 
 def test_properties(base):
@@ -85,3 +85,98 @@ def test_non_base_property():
     with pytest.raises(RuntimeError):
         class _TestNonBase:
             property_a = Property(int)
+
+
+def test_readonly_with_setter():
+
+    class TestReadonly(Base):
+        readonly_property_default = Property(float, default=0)
+        readonly_property_no_default = Property(float)
+
+        @readonly_property_default.setter
+        def set_readonly_default(self, value):
+            # assign on first write only
+            if not hasattr(self, '_property_readonly_property_default'):
+                self._property_readonly_property_default = value
+            else:
+                # if the value has already been created, the raise an error as
+                # it should be read only.
+                raise AttributeError
+
+        @readonly_property_no_default.setter
+        def set_readonly_no_default(self, value):
+            # assign on first write only
+            if not hasattr(self, '_property_readonly_property_no_default'):
+                self._property_readonly_property_no_default = value
+            else:
+                # if the value has already been created, the raise an error as
+                # it should be read only.
+                raise AttributeError
+
+    test_object = TestReadonly(readonly_property_default=10,
+                               readonly_property_no_default=20)
+
+    # first test read
+    assert test_object.readonly_property_default == 10
+    assert test_object.readonly_property_no_default == 20
+
+    # then test that write raises an exception
+    with pytest.raises(AttributeError):
+        test_object.readonly_property_default = 20
+    with pytest.raises(AttributeError):
+        test_object.readonly_property_no_default = 10
+
+    # now test when the default is used
+    test_object_default = TestReadonly(readonly_property_no_default=20)
+    assert test_object_default.readonly_property_default == 0
+    with pytest.raises(AttributeError):
+        test_object_default.readonly_property_default = 20
+
+
+def test_basic_setter():
+
+    class TestSetter(Base):
+        times_two = Property(float, default=5)
+
+        @times_two.setter
+        def set_times_two(self, value):
+            self._property_times_two = value * 2
+
+    test_object = TestSetter(times_two=10)
+    assert test_object.times_two == 20
+    test_object.times_two = 100
+    assert test_object.times_two == 200
+
+    # now test when the default is used
+    test_object_default = TestSetter()
+    assert test_object_default.times_two == 10
+
+
+def test_basic_getter():
+    # I cannot see a use case where a Stone Soup `Property` with a getter would
+    # be appropriate. This would be best done with a Python `property` in all
+    # use cases I can see, but is tested here for completeness
+    class TestGetter(Base):
+        times_two = Property(float, default=None)
+        base_value = Property(float, default=5)
+
+        @times_two.getter
+        def get_times_two(self):
+            return self.base_value * 2
+
+        # Force the saved value to always be None. Again, don't do this: use a
+        # python property
+        @times_two.setter
+        def set_times_two(self, value):
+            if value is not None:
+                raise ValueError
+            self._property_times_two = value
+
+    test_object = TestGetter(base_value=10)
+    assert test_object.times_two == 20
+    test_object.base_value = 100
+    assert test_object.times_two == 200
+
+    # now test when the default is used
+    test_object_default = TestGetter()
+    assert test_object_default.times_two == 10


### PR DESCRIPTION
This branch adds getter and setter options to Stone Soup `Property`s, analogous to those for Python `property`s. 

It also added the ability to make a `Property` read only, such that it is written once (in the parent object's constructor) and thereafter cannot be changed. 

Tests are also added to `test_declarative.py`