### PR TITLE
Speed up GNNWith2DAssignment

### DIFF
--- a/stonesoup/dataassociator/_assignment.py
+++ b/stonesoup/dataassociator/_assignment.py
@@ -128,8 +128,9 @@ def assign2D(C, maximize=False):
     # end.
     if not maximize:
         CDelta = numpy.inf
+        idxs = numpy.unravel_index([i for i in range(totalNumElsInC)], C.shape)
         for i in range(0, totalNumElsInC):
-            idx = numpy.unravel_index(i, C.shape)
+            idx = (idxs[0][i], idxs[1][i])
             if C[idx] < CDelta:
                 CDelta = C[idx]
 
@@ -138,13 +139,14 @@ def assign2D(C, maximize=False):
             CDelta = 0
 
         for i in range(0, totalNumElsInC):
-            idx = numpy.unravel_index(i, C.shape)
+            idx = (idxs[0][i], idxs[1][i])
             C[idx] = C[idx] - CDelta
 
     else:
         CDelta = -numpy.inf
+        idxs = numpy.unravel_index([i for i in range(totalNumElsInC)], C.shape)
         for i in range(0, totalNumElsInC):
-            idx = numpy.unravel_index(i, C.shape)
+            idx = (idxs[0][i], idxs[1][i])
             if C[idx] > CDelta:
                 CDelta = C[idx]
 
@@ -153,7 +155,7 @@ def assign2D(C, maximize=False):
             CDelta = 0
 
         for i in range(0, totalNumElsInC):
-            idx = numpy.unravel_index(i, C.shape)
+            idx = (idxs[0][i], idxs[1][i])
             C[idx] = -C[idx] + CDelta
 
     CDelta = CDelta * numCol


### PR DESCRIPTION
This PR introduces a speed up to GNNWith2DAssignment. This is achieved by reducing the number of calls to ``numpy.unravel_index()``, which seemed to be adding a significant overhead.

To test the achieved performance, a simulation is run that involves 5000 targets over 1 hour, with 250 detections per second.

This is a view of the profiler output prior to the change:
![image](https://user-images.githubusercontent.com/11223208/76250601-89a46180-623d-11ea-9f56-588ef3d4ce8e.png)

And this is a view of the profiler output using the change in this PR:
![image](https://user-images.githubusercontent.com/11223208/76250034-60370600-623c-11ea-8939-9b09960b7d7c.png)



The overall simulation runtime was reduced from ```2:42:21``` to ```1:51:37``` (```h:mm:ss```).


 