### PR TITLE
Added StatesLengthLimiter

### DIFF
--- a/docs/source/stonesoup.initiator.rst
+++ b/docs/source/stonesoup.initiator.rst
@@ -10,4 +10,8 @@ Initiators
 .. automodule:: stonesoup.initiator.simple
     :show-inheritance:
 
+Wrappers
+--------
+.. automodule:: stonesoup.initiator.wrapper
+    :show-inheritance:
 

--- a/stonesoup/initiator/tests/test_wrapper.py
+++ b/stonesoup/initiator/tests/test_wrapper.py
@@ -1,0 +1,62 @@
+from datetime import datetime
+from datetime import timedelta
+
+import numpy as np
+import pytest
+
+from ...models.measurement.linear import LinearGaussian
+from ...models.transition.linear import ConstantVelocity
+from ...updater.kalman import KalmanUpdater
+from ...types.detection import Detection
+from ...types.hypothesis import SingleHypothesis
+from ...types.state import GaussianState
+from ...predictor.kalman import KalmanPredictor
+from ..simple import SinglePointInitiator
+from ..wrapper import StatesLengthLimiter
+
+
+@pytest.mark.parametrize("max_len", (1, 5, 9))
+def test_states_length_limiter(max_len):
+    """Test StatesLengthLimiter"""
+
+    # Measurements
+    start_time = datetime.now()
+    measurements = []
+    for i in range(10):
+        measurements.append(Detection(np.array([[i*2.0]]),
+                                      timestamp=start_time+timedelta(seconds=i*100)))
+
+    # Tracking components
+    # ===================
+    # transition & measurement models
+    transition_model = ConstantVelocity(0.05)
+    transition_model.matrix(time_interval=timedelta(seconds=1))
+    measurement_model = LinearGaussian(2, [0], np.array([[1]]))
+
+    # Predictor and Updater
+    predictor = KalmanPredictor(transition_model)
+    updater = KalmanUpdater(measurement_model)
+
+    # Track initiator
+    prior = GaussianState(
+        np.array([[0], [0]]),
+        np.array([[100, 0], [0, 1]]), timestamp=start_time)
+    initiator = StatesLengthLimiter(SinglePointInitiator(
+        prior,
+        measurement_model), max_len)
+
+    track = None
+    # Do tracking ...
+    for measurement in measurements:
+        prediction = predictor.predict(prior, timestamp=measurement.timestamp)
+        hypothesis = SingleHypothesis(prediction, measurement)
+        posterior = updater.update(hypothesis)
+        if track is None:
+            track = initiator.initiate([measurement]).pop()
+        else:
+            track.append(posterior)
+        prior = track[-1]
+
+        assert len(track) <= max_len
+
+    assert len(track) == max_len

--- a/stonesoup/initiator/wrapper.py
+++ b/stonesoup/initiator/wrapper.py
@@ -1,0 +1,30 @@
+import collections
+from .base import Initiator
+from ..base import Property
+
+
+class StatesLengthLimiter(Initiator):
+    """Wrapper that defines the length of track history stored in memory
+
+    By default Stone Soup stores the track history for all tracks in memory.  If
+    running Stone Soup on very large data your application may run out of memory and
+    the process terminated - often by the operating system.
+
+    This wrapper converts the states space list to a collections.deque data type
+    with the maximum length specified.
+
+    .. code-block:: python
+
+        from stonesoup.initiator.wrapper import StatesLengthLimiter
+
+        initiator = StatesLengthLimiter(<initiator model>, max_length)
+
+    """
+    initiator = Property(Initiator, doc="Stone Soup Initiator")
+    max_length = Property(int, doc="Length of track history to be stored in memory")
+
+    def initiate(self, *args, **kwargs):
+        tracks = self.initiator.initiate(*args, **kwargs)
+        for track in tracks:
+            track.states = collections.deque(track.states, self.max_length)
+        return tracks

--- a/stonesoup/serialise.py
+++ b/stonesoup/serialise.py
@@ -9,7 +9,7 @@ components and data types.
 import datetime
 import warnings
 from io import StringIO
-from collections import OrderedDict
+from collections import OrderedDict, deque
 from functools import lru_cache
 from pathlib import Path
 from importlib import import_module
@@ -46,6 +46,12 @@ class YAML:
             Path, self.path_to_yaml)
         self._yaml.constructor.add_constructor(
             "!pathlib.Path", self.path_from_yaml)
+
+        # deque
+        self._yaml.representer.add_representer(
+            deque, self.deque_to_yaml)
+        self._yaml.constructor.add_constructor(
+            "!collections.deque", self.deque_from_yaml)
 
         # Declarative classes
         self._yaml.representer.add_multi_representer(
@@ -174,3 +180,16 @@ class YAML:
 
         Value should be total number of seconds."""
         return Path(constructor.construct_scalar(node))
+
+    @staticmethod
+    def deque_to_yaml(representer, node):
+        """Convert collections.deque to YAML"""
+        return representer.represent_sequence(
+            "!collections.deque",
+            (list(node), node.maxlen))
+
+    @staticmethod
+    def deque_from_yaml(constructor, node):
+        """Convert YAML to collections.deque"""
+        iterable, maxlen = constructor.construct_sequence(node, deep=True)
+        return deque(iterable, maxlen)

--- a/stonesoup/tests/test_serialise.py
+++ b/stonesoup/tests/test_serialise.py
@@ -95,6 +95,18 @@ def test_datetime(base, serialised_file):
     assert instance.property_d == new_instance.property_d
 
 
+def test_deque(base, serialised_file):
+    from collections import deque
+
+    max_len = 5
+    instance = deque([3, 4, 5, 6, 7, 8, 9], max_len)
+
+    serialised_str = serialised_file.dumps(instance)
+
+    new_instance = serialised_file.load(serialised_str)
+    assert new_instance == instance
+
+
 def test_path(serialised_file):
     import pathlib
     import tempfile

--- a/stonesoup/types/track.py
+++ b/stonesoup/types/track.py
@@ -43,6 +43,11 @@ class Track(StateMutableSequence):
         self._update_metadata_from_state(value)
         return super().insert(index, value)
 
+    def append(self, value):
+        # Update metadata
+        self._update_metadata_from_state(value)
+        return self.states.append(value)
+
     @property
     def metadata(self):
         """Returns metadata associated with a track.


### PR DESCRIPTION
By default Stone Soup stores the track history for all tracks in memory.  If
running Stone Soup on very large data your application may run out of memory
and the process terminated - often by the operating system.

This wrapper converts the states space list to a collections.deque data
type with the maximum length specified.