### PR TITLE
Update AESARadar to avoid mutating measurement model

### DIFF
--- a/stonesoup/sensor/radar/radar.py
+++ b/stonesoup/sensor/radar/radar.py
@@ -492,8 +492,8 @@ class AESARadar(Sensor):
         # Is the state detected?
         if np.random.rand() <= det_prob:
             measurement_model = copy.deepcopy(self.measurement_model)
-            measurement_model.translation_offset = self.translation_offset
-            measurement_model.rotation_offset = self.rotation_offset
+            measurement_model.translation_offset = self.translation_offset.copy()
+            measurement_model.rotation_offset = self.rotation_offset.copy()
             measured_pos = self.measurement_model.function(sky_state, noise=noise)
 
             return Detection(measured_pos, timestamp=sky_state.timestamp,

--- a/stonesoup/sensor/radar/radar.py
+++ b/stonesoup/sensor/radar/radar.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+import copy
+
 import numpy as np
 
 from math import erfc
@@ -489,9 +491,10 @@ class AESARadar(Sensor):
         det_prob = self.gen_probability(sky_state)[0]
         # Is the state detected?
         if np.random.rand() <= det_prob:
-            self.measurement_model.translation_offset = self.translation_offset
-            self.measurement_model.rotation_offset = self.rotation_offset
+            measurement_model = copy.deepcopy(self.measurement_model)
+            measurement_model.translation_offset = self.translation_offset
+            measurement_model.rotation_offset = self.rotation_offset
             measured_pos = self.measurement_model.function(sky_state, noise=noise)
 
             return Detection(measured_pos, timestamp=sky_state.timestamp,
-                             measurement_model=self.measurement_model)
+                             measurement_model=measurement_model)


### PR DESCRIPTION
The AESA radar `measure` function was previously written so that saved a reference to a measurement model with each detection that is later mutated. This code change it to use a deepcopy instead.