### PR TITLE
Add support for array/number types and parser type in YAML

### DIFF
--- a/stonesoup/reader/yaml.py
+++ b/stonesoup/reader/yaml.py
@@ -15,7 +15,7 @@ class YAMLReader(FileReader, BufferedGenerator):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self._yaml = YAML()
+        self._yaml = YAML(typ='safe')
 
     @BufferedGenerator.generator_method
     def data_gen(self):

--- a/stonesoup/serialise.py
+++ b/stonesoup/serialise.py
@@ -8,6 +8,7 @@ components and data types.
 .. _YAML: http://yaml.org/"""
 import datetime
 import warnings
+import sys
 from io import StringIO
 from collections import OrderedDict
 from functools import lru_cache
@@ -23,13 +24,33 @@ from .types.angle import Angle
 from .types.array import Matrix
 from .types.numeric import Probability
 
+__all__ = ['YAML']
+
+typ = 'stonesoup'
+
+
+def init_typ(yaml):
+
+    class _StoneSoupConstructor(yaml.Constructor):
+        if sys.version_info < (3, 6):  # pragma: no cover
+            from collections import OrderedDict
+            yaml_multi_constructors = OrderedDict(yaml.Constructor.yaml_multi_constructors)
+
+    class _StoneSoupRepresenter(yaml.Representer):
+        if sys.version_info < (3, 6):  # pragma: no cover
+            from collections import OrderedDict
+            yaml_multi_representers = OrderedDict(yaml.Representer.yaml_multi_representers)
+
+    yaml.Constructor = _StoneSoupConstructor
+    yaml.Representer = _StoneSoupRepresenter
+
 
 class YAML:
     """Class for YAML serialisation."""
     tag_prefix = '!{}.'.format(__name__.split('.', 1)[0])
 
     def __init__(self, typ='rt'):
-        self._yaml = ruamel.yaml.YAML(typ=typ)
+        self._yaml = ruamel.yaml.YAML(typ=[typ, 'stonesoup'], plug_ins=['stonesoup.serialise'])
         self._yaml.default_flow_style = False
 
         # NumPy

--- a/stonesoup/serialise.py
+++ b/stonesoup/serialise.py
@@ -28,8 +28,8 @@ class YAML:
     """Class for YAML serialisation."""
     tag_prefix = '!{}.'.format(__name__.split('.', 1)[0])
 
-    def __init__(self):
-        self._yaml = ruamel.yaml.YAML()
+    def __init__(self, typ='rt'):
+        self._yaml = ruamel.yaml.YAML(typ=typ)
         self._yaml.default_flow_style = False
 
         # NumPy
@@ -179,7 +179,9 @@ class YAML:
 
     def ndarray_to_yaml(self, representer, node):
         """Convert numpy.ndarray to YAML."""
-        if node.ndim > 1:
+
+        # If using "round trip" type, change flow style to make more readable
+        if node.ndim > 1 and 'rt' in self._yaml.typ:
             array = [self._yaml.seq(row) for row in node.tolist()]
             [seq.fa.set_flow_style() for seq in array]
         else:

--- a/stonesoup/tests/test_serialise.py
+++ b/stonesoup/tests/test_serialise.py
@@ -9,9 +9,9 @@ from ..types.array import Matrix, StateVector, CovarianceMatrix
 from ..types.angle import Angle, Bearing, Elevation, Longitude, Latitude
 
 
-@pytest.fixture()
-def serialised_file():
-    return YAML()
+@pytest.fixture(params=['rt', 'safe'])
+def serialised_file(request):
+    return YAML(typ=request.param)
 
 
 def test_declarative(base, serialised_file):
@@ -45,6 +45,9 @@ def test_nested_declarative(base, serialised_file):
 
 
 def test_duplicate_tag_warning(base, serialised_file):
+    if 'safe' in serialised_file._yaml.typ:
+        pytest.xfail("With 'safe' constructor, warning isn't raised")
+
     class _TestDuplicateBase(base):
         pass
 

--- a/stonesoup/writer/tests/test_yaml.py
+++ b/stonesoup/writer/tests/test_yaml.py
@@ -31,7 +31,7 @@ def test_detections_yaml(detection_reader, tmpdir):
          time: &id001 2018-01-01 14:01:00
          detections: !!set
            ? !stonesoup.types.detection.Detection
-           - state_vector: !numpy.ndarray
+           - state_vector: !stonesoup.types.array.StateVector
              - [1]
            - timestamp: *id001
            - metadata: {}
@@ -41,13 +41,13 @@ def test_detections_yaml(detection_reader, tmpdir):
          time: &id001 2018-01-01 14:02:00
          detections: !!set
            ? !stonesoup.types.detection.Detection
-           - state_vector: !numpy.ndarray
+           - state_vector: !stonesoup.types.array.StateVector
              - [2]
            - timestamp: *id001
            - metadata: {}
            :
            ? !stonesoup.types.detection.Detection
-           - state_vector: !numpy.ndarray
+           - state_vector: !stonesoup.types.array.StateVector
              - [2]
            - timestamp: *id001
            - metadata: {}
@@ -80,7 +80,7 @@ def test_groundtruth_paths_yaml(groundtruth_reader, tmpdir):
           ? !stonesoup.types.groundtruth.GroundTruthPath
           - states:
             - !stonesoup.types.groundtruth.GroundTruthState
-              - state_vector: !numpy.ndarray
+              - state_vector: !stonesoup.types.array.StateVector
                 - [1]
               - timestamp: *id001
               - metadata: {}
@@ -113,7 +113,7 @@ def test_tracks_yaml(tracker, tmpdir):
           ? !stonesoup.types.track.Track
           - states:
             - !stonesoup.types.state.State
-              - state_vector: !numpy.ndarray
+              - state_vector: !stonesoup.types.array.StateVector
                 - [1]
               - timestamp: *id001
           - id: '0'


### PR DESCRIPTION
- Add support for Array, Angle and Numeric types in YAML serialiser
- Allow setting of YAML parser type, so faster C library can be used for parsing