### PR TITLE
Fix orientation setter in sensors with internal platforms.

### DIFF
--- a/stonesoup/sensor/base.py
+++ b/stonesoup/sensor/base.py
@@ -95,7 +95,7 @@ class BaseSensor(Base, ABC):
     @orientation.setter
     def orientation(self, value: StateVector):
         if self._has_internal_platform:
-            self.platform.position = value
+            self.platform.orientation = value
         else:
             raise AttributeError('Cannot set sensor position unless the sensor has its own '
                                  'default platform')

--- a/stonesoup/sensor/tests/test_sensor.py
+++ b/stonesoup/sensor/tests/test_sensor.py
@@ -28,7 +28,7 @@ def test_sensor_position_orientation_setting():
     sensor.position = StateVector([0, 1, 0])
     assert np.array_equal(sensor.position, StateVector([0, 1, 0]))
     sensor.orientation = StateVector([0, 1, 0])
-    assert np.array_equal(sensor.orientation, StateVector([0, 0, 0]))
+    assert np.array_equal(sensor.orientation, StateVector([0, 1, 0]))
 
     position = StateVector([0, 0, 1])
     sensor = DummySensor()


### PR DESCRIPTION
A little, and obscure, mistake in setting the orientation of a platform with an internal sensor. Embarrassingly, there was a matching typo in the test...

A very small fix, but important.