### PR TITLE
Change Property to use type hints and drop Python 3.5 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,6 @@ workflows:
   version: 2
   test:
     jobs:
-      - test-35
       - test-36
       - test-37
       - test-38
@@ -11,9 +10,9 @@ workflows:
     jobs:
       - docs
 jobs:
-  test-35: &test-template
+  test-36: &test-template
     docker:
-      - image: circleci/python:3.5
+      - image: circleci/python:3.6
     steps:
       - checkout
       - restore_cache:
@@ -45,10 +44,6 @@ jobs:
               -f test-reports/coverage.xml \
               -F unittests \
               -n ${CIRCLE_BUILD_NUM}
-  test-36:
-    <<: *test-template
-    docker:
-      - image: circleci/python:3.6
   test-37:
     <<: *test-template
     docker:

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Stone Soup uses the following dependencies:
 
 | Name | License |
 | ---- | ------- |
-| [Python](https://www.python.org/) (v3.5+) | PSFL |
+| [Python](https://www.python.org/) (v3.6+) | PSFL |
 | [SciPy](https://www.scipy.org/) | BSD |
 | [matplotlib](https://matplotlib.org/) | [PSF/BSD-compatible](https://matplotlib.org/users/license.html) |
 | [ruamel.yaml](https://yaml.readthedocs.io/) | MIT |

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup(name='stonesoup',
           'Topic :: Scientific/Engineering',
       ],
       packages=find_packages(exclude=('docs', '*.tests')),
+      python_requires='>=3.6',
       install_requires=[
           'ruamel.yaml>=0.15.45', 'numpy>=1.17', 'scipy', 'matplotlib', 'utm', 'pymap3d'],
       extras_require={

--- a/stonesoup/base.py
+++ b/stonesoup/base.py
@@ -222,7 +222,7 @@ class BaseMeta(ABCMeta):
                 cls._properties.move_to_end(name)
         for name, prop in cls._properties.items():
             if not (isinstance(prop.cls, type) or
-                    str(prop.cls).startswith('typing.')):
+                    (hasattr(prop.cls, '__module__') and prop.cls.__module__ == 'typing')):
                 raise ValueError(f'Invalid type specification ({str(prop.cls)}) '
                                  f'for property {name} of class {cls.__name__}')
 

--- a/stonesoup/base.py
+++ b/stonesoup/base.py
@@ -55,7 +55,6 @@ This is equivalent to the following:
 
 """
 import inspect
-import sys
 import weakref
 from abc import ABCMeta
 from collections import OrderedDict
@@ -221,10 +220,6 @@ class BaseMeta(ABCMeta):
             # Optional arguments must follow mandatory
             if cls._properties[name].default is not Property.empty:
                 cls._properties.move_to_end(name)
-
-        if sys.version_info <= (3, 6):  # pragma: no cover
-            for name, property_ in cls._properties.items():
-                property_.__set_name__(cls, name)
 
         cls._validate_init()
         cls._generate_signature()

--- a/stonesoup/base.py
+++ b/stonesoup/base.py
@@ -220,6 +220,11 @@ class BaseMeta(ABCMeta):
             # Optional arguments must follow mandatory
             if cls._properties[name].default is not Property.empty:
                 cls._properties.move_to_end(name)
+        for name, prop in cls._properties.items():
+            if not (isinstance(prop.cls, type) or
+                    str(prop.cls).startswith('typing.')):
+                raise ValueError(f'Invalid type specification ({str(prop.cls)}) '
+                                 f'for property {name} of class {cls.__name__}')
 
         cls._validate_init()
         cls._generate_signature()

--- a/stonesoup/base.py
+++ b/stonesoup/base.py
@@ -12,8 +12,8 @@ An example would be:
 
     class Foo(Base):
         '''Example Foo class'''
-        foo = Property(str, doc="foo string parameter")
-        bar = Property(int, default=10, doc="bar int parameter, default is 10")
+        foo: str = Property(doc="foo string parameter")
+        bar: int = Property(default=10, doc="bar int parameter, default is 10")
 
 
 This is equivalent to the following:
@@ -44,8 +44,8 @@ This is equivalent to the following:
 
         class Foo(Base):
         '''Example Foo class'''
-        foo = Property(str, doc="foo string parameter")
-        bar = Property(int, default=10, doc="bar int parameter, default is 10")
+        foo: str = Property(doc="foo string parameter")
+        bar: int = Property(default=10, doc="bar int parameter, default is 10")
 
         def __init__(self, foo, bar=bar.default, *args, **kwargs):
             if bar < 0:
@@ -107,7 +107,7 @@ class Property:
     empty = inspect.Parameter.empty
     _property_name = None
 
-    def __init__(self, cls, *, default=inspect.Parameter.empty, doc=None,
+    def __init__(self, cls=None, *, default=inspect.Parameter.empty, doc=None,
                  readonly=False):
         self.cls = cls
         self.default = default
@@ -203,6 +203,13 @@ class BaseMeta(ABCMeta):
             if type(bcls) is mcls:
                 bcls._subclasses.add(cls)
                 cls._properties.update(bcls._properties)
+        for key, value in namespace.items():
+            if isinstance(value, Property):
+                cls._properties[key] = value
+                if value.cls is None and '__annotations__' in namespace:
+                    value.cls = namespace['__annotations__'][key]
+                    if isinstance(value.cls, str) and value.cls == name:
+                        value.cls = cls
         cls._properties.update(
             (key, value) for key, value in namespace.items()
             if isinstance(value, Property))

--- a/stonesoup/dataassociator/base.py
+++ b/stonesoup/dataassociator/base.py
@@ -16,8 +16,7 @@ class DataAssociator(Base):
     from hypotheses generate from a :class:`~.Hypothesiser`.
     """
 
-    hypothesiser = Property(
-        Hypothesiser,
+    hypothesiser: Hypothesiser = Property(
         doc="Generate a set of hypotheses for each track-detection pair")
 
     @abstractmethod

--- a/stonesoup/dataassociator/neighbour.py
+++ b/stonesoup/dataassociator/neighbour.py
@@ -15,8 +15,7 @@ class NearestNeighbour(DataAssociator):
     Neighbour method.
     """
 
-    hypothesiser = Property(
-        Hypothesiser,
+    hypothesiser: Hypothesiser = Property(
         doc="Generate a set of hypotheses for each prediction-detection pair")
 
     def associate(self, tracks, detections, time):
@@ -77,8 +76,7 @@ class GlobalNearestNeighbour(DataAssociator):
     Nearest Neighbour method, assuming a distance-based hypothesis score.
     """
 
-    hypothesiser = Property(
-        Hypothesiser,
+    hypothesiser: Hypothesiser = Property(
         doc="Generate a set of hypotheses for each prediction-detection pair")
 
     def associate(self, tracks, detections, time):
@@ -119,8 +117,7 @@ class GNNWith2DAssignment(DataAssociator):
     distances and a "shortest path" assignment algorithm.
     """
 
-    hypothesiser = Property(
-        Hypothesiser,
+    hypothesiser: Hypothesiser = Property(
         doc="Generate a set of hypotheses for each prediction-detection pair")
 
     def associate(self, tracks, detections, time):

--- a/stonesoup/dataassociator/probability.py
+++ b/stonesoup/dataassociator/probability.py
@@ -19,8 +19,7 @@ class PDA(DataAssociator):
     probability that it is associated to each specific detection.
     """
 
-    hypothesiser = Property(
-        Hypothesiser,
+    hypothesiser: Hypothesiser = Property(
         doc="Generate a set of hypotheses for each prediction-detection pair")
 
     def associate(self, tracks, detections, time):
@@ -73,8 +72,7 @@ class JPDA(DataAssociator):
     takes place in the function :meth:`enumerate_JPDA_hypotheses`.
     """
 
-    hypothesiser = Property(
-        PDAHypothesiser,
+    hypothesiser: PDAHypothesiser = Property(
         doc="Generate a set of hypotheses for each prediction-detection pair")
 
     def associate(self, tracks, detections, time):

--- a/stonesoup/dataassociator/tracktotrack.py
+++ b/stonesoup/dataassociator/tracktotrack.py
@@ -30,22 +30,22 @@ class TrackToTrack(TrackToTrackAssociator):
     combinations
     """
 
-    association_threshold = Property(
-        float, default=10,
+    association_threshold: float = Property(
+        default=10,
         doc="Threshold distance measure which states must be within for an "
             "association to be recorded.Default is 10")
-    consec_pairs_confirm = Property(
-        int, default=3,
+    consec_pairs_confirm: int = Property(
+        default=3,
         doc="Number of consecutive time instances which track pairs are "
             "required to be within a specified threshold in order for an "
             "association to be formed. Default is 3")
-    consec_misses_end = Property(
-        int, default=2,
+    consec_misses_end: int = Property(
+        default=2,
         doc="Number of consecutive time instances which track pairs are "
             "required to exceed a specified threshold in order for an "
             "association to be ended. Default is 2")
-    measure = Property(
-        Measure, default=Euclidean(),
+    measure: Measure = Property(
+        default=Euclidean(),
         doc="Distance measure to use. Default :class:`~.measures.Euclidean()`")
 
     def associate_tracks(self, tracks_set_1, tracks_set_2):
@@ -153,25 +153,22 @@ class TrackToTruth(TrackToTrackAssociator):
     Tracks (one-2-many relationship).
     """
 
-    association_threshold = Property(
-        float,
+    association_threshold: float = Property(
         default=10,
         doc="Threshold distance measure which states must be within for an "
             "association to be recorded.Default is 10")
-    consec_pairs_confirm = Property(
-        int,
+    consec_pairs_confirm: int = Property(
         default=3,
         doc="Number of consecutive time instances which track-truth pairs are "
             "required to be within a specified threshold in order for an "
             "association to be formed. Default is 3")
-    consec_misses_end = Property(
-        int,
+    consec_misses_end: int = Property(
         default=2,
         doc="Number of consecutive time instances which track-truth pairs are "
             "required to exceed a specified threshold in order for an "
             "association to be ended. Default is 2")
-    measure = Property(
-        Measure, default=Euclidean(),
+    measure: Measure = Property(
+        default=Euclidean(),
         doc="Distance measure to use. Default :class:`~.measures.Euclidean()`")
 
     def associate_tracks(self, tracks_set, truth_set):

--- a/stonesoup/deleter/error.py
+++ b/stonesoup/deleter/error.py
@@ -13,8 +13,7 @@ class CovarianceBasedDeleter(Deleter):
     exceeds a given threshold.
     """
 
-    covar_trace_thresh = Property(
-        float, doc="Covariance matrix trace threshold")
+    covar_trace_thresh: float = Property(doc="Covariance matrix trace threshold")
 
     def check_for_deletion(self, track, **kwargs):
         """Check if a given track should be deleted

--- a/stonesoup/deleter/multi.py
+++ b/stonesoup/deleter/multi.py
@@ -2,6 +2,8 @@
 """Contains deleters which use a composite of deleters to decide whether a track is to be deleted
 """
 
+from typing import Collection
+
 from ..base import Property
 from .base import Deleter
 
@@ -14,9 +16,9 @@ class CompositeDeleter(Deleter):
     at least one deleter listed.
     """
 
-    deleters = Property([Deleter], doc="List of deleters to be applied to the track")
-    intersect = Property(
-        bool, default=True,
+    deleters: Collection[Deleter] = Property(doc="List of deleters to be applied to the track")
+    intersect: bool = Property(
+        default=True,
         doc="Boolean that determines whether the composite deleter will intersect or unify "
             "deletion results. Default is `True`, applying an intersection.")
 

--- a/stonesoup/deleter/time.py
+++ b/stonesoup/deleter/time.py
@@ -14,8 +14,7 @@ class UpdateTimeStepsDeleter(Deleter):
     last :attr:`time_steps_since_update`.
     """
 
-    time_steps_since_update = Property(
-        int, doc="Maximum time steps since last update")
+    time_steps_since_update: int = Property(doc="Maximum time steps since last update")
 
     def check_for_deletion(self, track, **kwargs):
         """Delete track without update with measurements within time steps
@@ -42,8 +41,7 @@ class UpdateTimeDeleter(Deleter):
     measurements is greater than :attr:`time_since_update`.
     """
 
-    time_since_update = Property(
-        timedelta, doc="Maximum time since last update")
+    time_since_update: timedelta = Property(doc="Maximum time since last update")
 
     def check_for_deletion(self, track, timestamp=None, **kwargs):
         """Delete track based on time of last update with measurements

--- a/stonesoup/detector/base.py
+++ b/stonesoup/detector/base.py
@@ -10,4 +10,4 @@ class Detector(DetectionReader):
     data.
     """
 
-    sensor = Property(SensorDataReader, doc="Source of sensor data")
+    sensor: SensorDataReader = Property(doc="Source of sensor data")

--- a/stonesoup/detector/tensorflow.py
+++ b/stonesoup/detector/tensorflow.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from typing import Optional
 
 try:
     import tensorflow as tf
@@ -71,7 +72,7 @@ class TensorFlowBoxObjectDetector(Detector):
         default=False)
 
     session_config = Property(
-        tf.compat.v1.ConfigProto,
+        Optional[tf.compat.v1.ConfigProto],
         doc="A `ConfigProto <https://www.tensorflow.org/code/tensorflow/core/protobuf/config"
             ".proto>`_ protocol buffer with configuration options for the TensorFlow session. "
             "Defaults to ``None``",

--- a/stonesoup/feeder/base.py
+++ b/stonesoup/feeder/base.py
@@ -14,7 +14,7 @@ class Feeder(Reader):
     modify the sequence, duplicate or drop data.
     """
 
-    reader = Property(Reader, doc="Source of detections")
+    reader: Reader = Property(doc="Source of detections")
 
     @abstractmethod
     @BufferedGenerator.generator_method

--- a/stonesoup/feeder/filter.py
+++ b/stonesoup/feeder/filter.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
 from operator import attrgetter
 from types import FunctionType
-
-import numpy as np
+from typing import Sequence, Tuple
 
 from .base import DetectionFeeder, GroundTruthFeeder
 from ..base import Property
@@ -24,9 +23,7 @@ class MetadataReducer(DetectionFeeder):
 
     """
 
-    metadata_field = Property(
-        str,
-        doc="Field used to reduce set of detections")
+    metadata_field: str = Property(doc="Field used to reduce set of detections")
 
     @BufferedGenerator.generator_method
     def data_gen(self):
@@ -68,8 +65,7 @@ class MetadataValueFilter(MetadataReducer):
 
     """
 
-    operator = Property(
-        FunctionType,
+    operator: FunctionType = Property(
         doc="A unary operator/function of the form :code:`b = f(val)`, "
             "where :code:`val` is the value of the selected "
             ":py:attr:`~metadata_field`. The function MUST return a "
@@ -80,8 +76,7 @@ class MetadataValueFilter(MetadataReducer):
             "Any custom function that conforms to the above specifications can"
             " be used as an operator, e.g. :code:`operator=lambda x: x < 0.1`")
 
-    keep_unmatched = Property(
-        bool,
+    keep_unmatched: bool = Property(
         doc="If set to :code:`True`, any detections that do not have a "
             "metadata field matching the name :py:attr:`~metadata_field` "
             "(meaning they also cannot be processed by the "
@@ -136,8 +131,7 @@ class BoundingBoxReducer(DetectionFeeder, GroundTruthFeeder):
 
     """
 
-    limits = Property(
-        np.ndarray,
+    limits: Sequence[Tuple[float, float]] = Property(
         doc="Array of points that define the bounds of the desired bounding "
             "box. Expressed as a 2D array of min/max coordinate pairs (e.g. "
             ":code:`limits = [[x_min, x_max], [y_min, y_max], ...]`), where "
@@ -145,8 +139,7 @@ class BoundingBoxReducer(DetectionFeeder, GroundTruthFeeder):
             "limits. Points that fall ON or WITHIN the box's bounds are "
             "considered as valid and are thus forwarded through the feeder, "
             "whereas points that fall OUTSIDE the box will be filtered out.")
-    mapping = Property(
-        np.ndarray,
+    mapping: Sequence[int] = Property(
         default=None,
         doc="Mapping between the state and bounding box coordinates. "
             "Should be specified as a vector of length equal to the number of "

--- a/stonesoup/feeder/geo.py
+++ b/stonesoup/feeder/geo.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import warnings
 from abc import abstractmethod
+from typing import Tuple
 
 import utm
 from pymap3d import geodetic2enu, geodetic2ned
@@ -11,10 +12,10 @@ from ..buffered_generator import BufferedGenerator
 
 
 class _LLARefConverter(DetectionFeeder, GroundTruthFeeder):
-    reference_point = Property(
-        (float, float, float), doc="(Long, Lat, Altitude)")
-    mapping = Property(
-        (float, float, float), default=(0, 1, 2),
+    reference_point: Tuple[float, float, float] = Property(
+        doc="(Long, Lat, Altitude)")
+    mapping: Tuple[int, int, int] = Property(
+        default=(0, 1, 2),
         doc="Indexes of long, lat, altitude. Default (0, 1, 2)")
 
     @property
@@ -76,15 +77,15 @@ class LongLatToUTMConverter(DetectionFeeder, GroundTruthFeeder):
 
     """
 
-    mapping = Property(
-        (float, float), default=(0, 1),
+    mapping: Tuple[int, int] = Property(
+        default=(0, 1),
         doc="Indexes of long, lat. Default (0, 1)")
-    zone_number = Property(
-        int, default=None,
+    zone_number: int = Property(
+        default=None,
         doc="UTM zone number to carry out conversion. Default `None`, where it will select the "
             "zone based on the first yielded data.")
-    northern = Property(
-        bool, default=None,
+    northern: bool = Property(
+        default=None,
         doc="UTM northern for northern or southern grid. Default `None`, where it will be based "
             "on the first yielded data.")
 

--- a/stonesoup/feeder/multi.py
+++ b/stonesoup/feeder/multi.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import heapq
+from typing import Collection
 
 from .base import DetectionFeeder, GroundTruthFeeder
 from ..base import Property
@@ -13,10 +14,8 @@ class MultiDataFeeder(DetectionFeeder, GroundTruthFeeder):
     This returns states from multiple data readers as a single stream,
     yielding from the reader yielding the lowest timestamp first.
     """
-
     reader = None
-
-    readers = Property([Reader], doc='Readers to yield from')
+    readers: Collection[Reader] = Property(doc='Readers to yield from')
 
     @BufferedGenerator.generator_method
     def data_gen(self):

--- a/stonesoup/feeder/time.py
+++ b/stonesoup/feeder/time.py
@@ -14,7 +14,7 @@ class TimeBufferedFeeder(DetectionFeeder, GroundTruthFeeder):
     Any "old" data (where the time is earlier than the head of the
     buffer) shall be dropped, producing a :class:`UserWarning`.
     """
-    buffer_size = Property(int, default=1000, doc="Max size of buffer")
+    buffer_size: int = Property(default=1000, doc="Max size of buffer")
 
     @BufferedGenerator.generator_method
     def data_gen(self):
@@ -47,8 +47,7 @@ class TimeSyncFeeder(DetectionFeeder, GroundTruthFeeder):
     the case.
     """
 
-    time_window = Property(
-        datetime.timedelta,
+    time_window: datetime.timedelta = Property(
         default=datetime.timedelta(seconds=1),
         doc="Time window to group detections")
 

--- a/stonesoup/gater/base.py
+++ b/stonesoup/gater/base.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from typing import Union
+
 from ..base import Property
 from ..hypothesiser import Hypothesiser
 
@@ -10,5 +12,5 @@ class Gater(Hypothesiser):
     returned hypotheses.
     """
 
-    hypothesiser = Property(
-        Hypothesiser, doc="Hypothesiser that is being wrapped.")
+    hypothesiser: Union[Hypothesiser, 'Gater'] = Property(
+        doc="Hypothesiser or Gater that is being wrapped.")

--- a/stonesoup/gater/distance.py
+++ b/stonesoup/gater/distance.py
@@ -12,12 +12,12 @@ class DistanceGater(Gater):
     hypothised measurement, then removes any hypotheses whose calculated distance exceeds the
     specified gate threshold.
     """
-    measure = Property(Measure,
-                       doc="Measure class used to calculate the distance between the measurement "
-                           "prediction and the hypothesised measurement.")
-    gate_threshold = Property(float,
-                              doc="The gate threshold. Hypotheses whose calculated distance "
-                                  "exceeds this threshold will be filtered out.")
+    measure: Measure = Property(
+        doc="Measure class used to calculate the distance between the measurement "
+            "prediction and the hypothesised measurement.")
+    gate_threshold: float = Property(
+        doc="The gate threshold. Hypotheses whose calculated distance "
+            "exceeds this threshold will be filtered out.")
 
     def hypothesise(self, track, detections, *args, **kwargs):
 

--- a/stonesoup/gater/filtered.py
+++ b/stonesoup/gater/filtered.py
@@ -10,11 +10,9 @@ class FilteredDetectionsGater(Gater):
     they are fed into the hypothesiser.
     """
 
-    metadata_filter = Property(
-        str, doc="Metadata attribute used to filter which detections "
-                 "tracks are valid for association.")
-    match_missing = Property(
-        bool,
+    metadata_filter: str = Property(
+        doc="Metadata attribute used to filter which detections tracks are valid for association.")
+    match_missing: bool = Property(
         default=True,
         doc="Match detections with missing metadata. Default 'True'.")
 

--- a/stonesoup/hypothesiser/distance.py
+++ b/stonesoup/hypothesiser/distance.py
@@ -17,24 +17,16 @@ class DistanceHypothesiser(Hypothesiser):
     :class:`Measure` class.
     """
 
-    predictor = Property(
-        Predictor,
-        doc="Predict tracks to detection times")
-    updater = Property(
-        Updater,
-        doc="Updater used to get measurement prediction")
-    measure = Property(
-        Measure,
+    predictor: Predictor = Property(doc="Predict tracks to detection times")
+    updater: Updater = Property(doc="Updater used to get measurement prediction")
+    measure: Measure = Property(
         doc="Measure class used to calculate the distance between two states.")
-    missed_distance = Property(
-        float,
+    missed_distance: float = Property(
         default=float('inf'),
         doc="Distance for a missed detection. Default is set to infinity")
-    include_all = Property(
-        bool,
+    include_all: bool = Property(
         default=False,
-        doc="If `True`, hypotheses beyond missed distance will be returned. "
-            "Default `False`")
+        doc="If `True`, hypotheses beyond missed distance will be returned. Default `False`")
 
     def hypothesise(self, track, detections, timestamp):
         """ Evaluate and return all track association hypotheses.

--- a/stonesoup/hypothesiser/gaussianmixture.py
+++ b/stonesoup/hypothesiser/gaussianmixture.py
@@ -15,11 +15,9 @@ class GaussianMixtureHypothesiser(Hypothesiser):
     pertaining to an individual component-detection hypothesis
     """
 
-    hypothesiser = Property(
-        Hypothesiser,
+    hypothesiser: Hypothesiser = Property(
         doc="Underlying hypothesiser used to generate detection-target pairs")
-    order_by_detection = Property(
-        bool,
+    order_by_detection: bool = Property(
         default=False,
         doc="Flag to order the :class:`~.MultipleHypothesis` "
             "list by detection or component")

--- a/stonesoup/hypothesiser/probability.py
+++ b/stonesoup/hypothesiser/probability.py
@@ -18,22 +18,14 @@ class PDAHypothesiser(Hypothesiser):
     detections.
     """
 
-    predictor = Property(
-        Predictor,
-        doc="Predict tracks to detection times")
-    updater = Property(
-        Updater,
-        doc="Updater used to get measurement prediction")
-    clutter_spatial_density = Property(
-        float,
-        doc="Spatial density of clutter - tied to probability of false "
-            "detection")
-    prob_detect = Property(
-        Probability,
+    predictor: Predictor = Property(doc="Predict tracks to detection times")
+    updater: Updater = Property(doc="Updater used to get measurement prediction")
+    clutter_spatial_density: float = Property(
+        doc="Spatial density of clutter - tied to probability of false detection")
+    prob_detect: Probability = Property(
         default=Probability(0.85),
         doc="Target Detection Probability")
-    prob_gate = Property(
-        Probability,
+    prob_gate: Probability = Property(
         default=Probability(0.95),
         doc="Gate Probability - prob. gate contains true measurement "
             "if detected")

--- a/stonesoup/initiator/simple.py
+++ b/stonesoup/initiator/simple.py
@@ -24,8 +24,8 @@ class SinglePointInitiator(GaussianInitiator):
     provided :attr:`prior_state` for each unassociated detection.
     """
 
-    prior_state = Property(GaussianState, doc="Prior state information")
-    measurement_model = Property(MeasurementModel, doc="Measurement model")
+    prior_state: GaussianState = Property(doc="Prior state information")
+    measurement_model: MeasurementModel = Property(doc="Measurement model")
 
     def initiate(self, unassociated_detections, **kwargs):
         """Initiates tracks given unassociated measurements
@@ -75,12 +75,10 @@ class SimpleMeasurementInitiator(GaussianInitiator):
     covariance matrix is positive definite, especially for subsequent Cholesky
     decompositions.
     """
-    prior_state = Property(GaussianState, doc="Prior state information")
-    measurement_model = Property(MeasurementModel, doc="Measurement model")
-    skip_non_reversible = Property(bool, default=False)
-    diag_load = Property(float,
-                         default=0.0,
-                         doc="Positive float value for diagonal loading")
+    prior_state: GaussianState = Property(doc="Prior state information")
+    measurement_model: MeasurementModel = Property(doc="Measurement model")
+    skip_non_reversible: bool = Property(default=False)
+    diag_load: float = Property(default=0.0, doc="Positive float value for diagonal loading")
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -156,18 +154,15 @@ class MultiMeasurementInitiator(GaussianInitiator):
     initiated only to then be removed shortly after.
     Does cause slight delay in initiation to tracker."""
 
-    prior_state = Property(GaussianState, doc="Prior state information")
-    measurement_model = Property(MeasurementModel, doc="Measurement model")
-    deleter = Property(Deleter, doc="Deleter used to delete the track.")
-    data_associator = Property(
-        DataAssociator,
+    prior_state: GaussianState = Property(doc="Prior state information")
+    measurement_model: MeasurementModel = Property(doc="Measurement model")
+    deleter: Deleter = Property(doc="Deleter used to delete the track.")
+    data_associator: DataAssociator = Property(
         doc="Association algorithm to pair predictions to detections.")
-    updater = Property(
-        Updater,
+    updater: Updater = Property(
         doc="Updater used to update the track object to the new state.")
-    min_points = Property(
-        int, default=2,
-        doc="Minimum number of track points required to confirm a track.")
+    min_points: int = Property(
+        default=2, doc="Minimum number of track points required to confirm a track.")
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -216,11 +211,10 @@ class GaussianParticleInitiator(ParticleInitiator):
     :class:`~.ParticleState`.
     """
 
-    initiator = Property(
-        GaussianInitiator,
+    initiator: GaussianInitiator = Property(
         doc="Gaussian Initiator which will be used to generate tracks.")
-    number_particles = Property(
-        float, default=200, doc="Number of particles for initial track state")
+    number_particles: int = Property(
+        default=200, doc="Number of particles for initial track state")
 
     def initiate(self, unassociated_detections, **kwargs):
         """Initiates tracks given unassociated measurements

--- a/stonesoup/initiator/wrapper.py
+++ b/stonesoup/initiator/wrapper.py
@@ -20,8 +20,8 @@ class StatesLengthLimiter(Initiator):
         initiator = StatesLengthLimiter(<initiator model>, max_length)
 
     """
-    initiator = Property(Initiator, doc="Stone Soup Initiator")
-    max_length = Property(int, doc="Length of track history to be stored in memory")
+    initiator: Initiator = Property(doc="Stone Soup Initiator")
+    max_length: int = Property(doc="Length of track history to be stored in memory")
 
     def initiate(self, *args, **kwargs):
         tracks = self.initiator.initiate(*args, **kwargs)

--- a/stonesoup/measures.py
+++ b/stonesoup/measures.py
@@ -13,8 +13,7 @@ class Measure(Base):
     A measure provides a means to assess the seperation between two
     :class:`~.State` objects state1 and state2.
     """
-    mapping = Property(
-        np.array,
+    mapping: np.ndarray = Property(
         default=None,
         doc="Mapping array which specifies which elements within the"
             " state vectors are to be assessed as part of the measure"
@@ -94,9 +93,7 @@ class EuclideanWeighted(Measure):
     :class:`Measure` objects must be created with the specific weighting
 
     """
-    weighting = Property(
-        [np.array],
-        doc="Weighting vector for the Euclidean calculation")
+    weighting: np.ndarray = Property(doc="Weighting vector for the Euclidean calculation")
 
     def __call__(self, state1, state2):
         r"""Calculate the weighted Euclidean distance between a pair of state

--- a/stonesoup/metricgenerator/manager.py
+++ b/stonesoup/metricgenerator/manager.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
-from .base import MetricManager
+from typing import Sequence
+
+from .base import MetricManager, MetricGenerator
 from ..base import Property
 from ..dataassociator import Associator
 from ..types.detection import Detection
@@ -14,10 +16,8 @@ class SimpleManager(MetricManager):
     :class:`~.Track`, :class:`~.Detection` and :class:`~.GroundTruthPath`
     objects.
     """
-    generators = Property(list, doc='List of generators to use', default=None)
-    associator = Property(Associator,
-                          doc="Associator to combine tracks and truth",
-                          default=None)
+    generators: Sequence[MetricGenerator] = Property(doc='List of generators to use', default=None)
+    associator: Associator = Property(doc="Associator to combine tracks and truth", default=None)
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/stonesoup/metricgenerator/metrictables.py
+++ b/stonesoup/metricgenerator/metrictables.py
@@ -1,10 +1,11 @@
 from operator import attrgetter
+from typing import Collection
 
 import numpy as np
 import matplotlib
 from matplotlib import pyplot as plt
 
-from .base import MetricTableGenerator
+from .base import MetricTableGenerator, MetricGenerator
 from ..base import Property
 
 
@@ -16,7 +17,7 @@ class RedGreenTableGenerator(MetricTableGenerator):
     well the tracker performed in relation to each metric, where
     red is worse and green is better"""
 
-    metrics = Property(set, doc="Set of metrics to put in the table")
+    metrics: Collection[MetricGenerator] = Property(doc="Set of metrics to put in the table")
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/stonesoup/metricgenerator/ospametric.py
+++ b/stonesoup/metricgenerator/ospametric.py
@@ -25,10 +25,10 @@ class GOSPAMetric(MetricGenerator):
         Generalized optimal sub-pattern assignment metric, 2016,
         [online] Available: http://arxiv.org/abs/1601.05585.
     """
-    p = Property(float, doc="1<=p<infty, exponent.")
-    c = Property(float, doc="c>0, cutoff distance.")
-    measure = Property(
-        Measure, default=Euclidean(),
+    p: float = Property(doc="1<=p<infty, exponent.")
+    c: float = Property(doc="c>0, cutoff distance.")
+    measure: Measure = Property(
+        default=Euclidean(),
         doc="Distance measure to use. Default :class:`~.measures.Euclidean()`")
 
     def __init__(self, *args, **kwargs):
@@ -374,8 +374,8 @@ class OSPAMetric(GOSPAMetric):
         2008
     """
 
-    c = Property(float, doc='Maximum distance for possible association')
-    p = Property(float, doc='norm associated to distance')
+    c: float = Property(doc='Maximum distance for possible association')
+    p: float = Property(doc='norm associated to distance')
 
     def compute_over_time(self, measured_states, truth_states):
         """Compute the OSPA metric at every timestep from a list of measured

--- a/stonesoup/metricgenerator/plotter.py
+++ b/stonesoup/metricgenerator/plotter.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from typing import Tuple
+
 import numpy as np
 import matplotlib.pyplot as plt
 import matplotlib.lines
@@ -17,14 +19,11 @@ class TwoDPlotter(PlotGenerator):
     Plots of :class:`~.Track`, :class:`~.Detection` and
     :class:`~.GroundTruthPath` objects in two dimensions.
     """
-    track_indices = Property(
-        list,
+    track_indices: Tuple[int, int] = Property(
         doc="Elements of track state vector to plot as x and y")
-    gtruth_indices = Property(
-        list,
+    gtruth_indices: Tuple[int, int] = Property(
         doc="Elements of ground truth path state vector to plot as x and y")
-    detection_indices = Property(
-        list,
+    detection_indices: Tuple[int, int] = Property(
         doc="Elements of detection state vector to plot as x and y")
 
     def compute_metric(self, manager, *args, **kwargs):

--- a/stonesoup/mixturereducer/gaussianmixture.py
+++ b/stonesoup/mixturereducer/gaussianmixture.py
@@ -27,14 +27,10 @@ class GaussianMixtureReducer(MixtureReducer):
     pp. 4091–4104, 2006..
     """
 
-    prune_threshold = Property(float, default=1e-9,
-                               doc="Threshold for pruning.")
-    merge_threshold = Property(float, default=16,
-                               doc='Threshold for merging')
-    merging = Property(bool, default=True,
-                       doc='Flag for merging')
-    pruning = Property(bool, default=True,
-                       doc='Flag for pruning')
+    prune_threshold: float = Property(default=1e-9, doc="Threshold for pruning.")
+    merge_threshold: float = Property(default=16, doc='Threshold for merging')
+    merging: bool = Property(default=True, doc='Flag for merging')
+    pruning: bool = Property(default=True, doc='Flag for pruning')
 
     def reduce(self, components_list):
         """

--- a/stonesoup/models/control/base.py
+++ b/stonesoup/models/control/base.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 from abc import abstractmethod
-
-import scipy as sp
+from typing import Sequence
 
 from ..base import Model
 from ...base import Property
@@ -10,9 +9,8 @@ from ...base import Property
 class ControlModel(Model):
     """Control Model base class"""
 
-    ndim_state = Property(int, doc="Number of state dimensions")
-    mapping = Property(
-        sp.ndarray, doc="Mapping between control and state dims")
+    ndim_state: int = Property(doc="Number of state dimensions")
+    mapping: Sequence[int] = Property(doc="Mapping between control and state dims")
 
     @property
     @abstractmethod

--- a/stonesoup/models/control/linear.py
+++ b/stonesoup/models/control/linear.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from scipy import ndarray
+import numpy as np
 from scipy.stats import multivariate_normal
 
 from .base import ControlModel
@@ -22,13 +22,10 @@ class LinearControlModel(ControlModel, LinearModel):
 
     """
 
-    control_vector = Property(
-        ndarray, doc="Control vector at time :math:`k`")
-    control_matrix = Property(
-        ndarray,
+    control_vector: np.ndarray = Property(doc="Control vector at time :math:`k`")
+    control_matrix: np.ndarray = Property(
         doc="Control input model matrix at time :math:`k`, :math:`B_k`")
-    control_noise = Property(
-        ndarray,
+    control_noise: np.ndarray = Property(
         default=None,
         doc="Control input noise covariance at time :math:`k`")
 

--- a/stonesoup/models/measurement/base.py
+++ b/stonesoup/models/measurement/base.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 from abc import abstractmethod, ABC
-
-import numpy as np
+from typing import Sequence
 
 from ..base import Model
 from ...base import Property
@@ -10,8 +9,8 @@ from ...base import Property
 class MeasurementModel(Model, ABC):
     """Measurement Model base class"""
 
-    ndim_state = Property(int, doc="Number of state dimensions")
-    mapping = Property(np.ndarray, doc="Mapping between measurement and state dims")
+    ndim_state: int = Property(doc="Number of state dimensions")
+    mapping: Sequence[int] = Property(doc="Mapping between measurement and state dims")
 
     @property
     def ndim(self):

--- a/stonesoup/models/measurement/linear.py
+++ b/stonesoup/models/measurement/linear.py
@@ -24,7 +24,7 @@ class LinearGaussian(MeasurementModel, LinearModel, GaussianModel):
 
     """
 
-    noise_covar = Property(CovarianceMatrix, doc="Noise covariance")
+    noise_covar: CovarianceMatrix = Property(doc="Noise covariance")
 
     @property
     def ndim_meas(self):

--- a/stonesoup/models/measurement/nonlinear.py
+++ b/stonesoup/models/measurement/nonlinear.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from abc import ABC
-from typing import List, Union
 import copy
+from typing import Sequence, Tuple, Union
 
 import numpy as np
 from scipy.linalg import inv, pinv, block_diag
@@ -30,7 +30,7 @@ class CombinedReversibleGaussianMeasurementModel(ReversibleModel, GaussianModel,
     :class:`~.LinearModel` or :class:`~.ReversibleModel`.
     """
     mapping = None
-    model_list = Property(List[MeasurementModel], doc="List of Measurement Models.")
+    model_list: Sequence[GaussianModel] = Property(doc="List of Measurement Models.")
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -95,14 +95,14 @@ class NonLinearGaussianMeasurement(MeasurementModel, NonLinearModel, GaussianMod
     GaussianModel classes. It is not meant to be instantiated directly \
     but subclasses should be derived from this class.
     """
-    noise_covar = Property(CovarianceMatrix, doc="Noise covariance")
-    rotation_offset = Property(
-        StateVector, default=None,
-        doc="A 3x1 array of angles (rad), specifying the clockwise rotation\
-            around each Cartesian axis in the order :math:`x,y,z`.\
-            The rotation angles are positive if the rotation is in the \
-            counter-clockwise direction when viewed by an observer looking\
-            along the respective rotation axis, towards the origin.")
+    noise_covar: CovarianceMatrix = Property(doc="Noise covariance")
+    rotation_offset: StateVector = Property(
+        default=None,
+        doc="A 3x1 array of angles (rad), specifying the clockwise rotation "
+            "around each Cartesian axis in the order :math:`x,y,z`. "
+            "The rotation angles are positive if the rotation is in the "
+            "counter-clockwise direction when viewed by an observer looking "
+            "along the respective rotation axis, towards the origin.")
 
     def __init__(self, *args, **kwargs):
         """
@@ -204,10 +204,10 @@ class CartesianToElevationBearingRange(NonLinearGaussianMeasurement, ReversibleM
 
     """  # noqa:E501
 
-    translation_offset = Property(
-        StateVector, default=None,
-        doc="A 3x1 array specifying the Cartesian origin offset in terms of :math:`x,y,z`\
-            coordinates.")
+    translation_offset: StateVector = Property(
+        default=None,
+        doc="A 3x1 array specifying the Cartesian origin offset in terms of :math:`x,y,z` "
+            "coordinates.")
 
     def __init__(self, *args, **kwargs):
         """
@@ -339,10 +339,9 @@ class CartesianToBearingRange(NonLinearGaussianMeasurement, ReversibleModel):
 
     """  # noqa:E501
 
-    translation_offset = Property(
-        StateVector, default=None,
-        doc="A 2x1 array specifying the origin offset in terms of :math:`x,y`\
-            coordinates.")
+    translation_offset: StateVector = Property(
+        default=None,
+        doc="A 2x1 array specifying the origin offset in terms of :math:`x,y` coordinates.")
 
     def __init__(self, *args, **kwargs):
         """
@@ -487,10 +486,9 @@ class CartesianToElevationBearing(NonLinearGaussianMeasurement):
 
     """  # noqa:E501
 
-    translation_offset = Property(
-        StateVector, default=None,
-        doc="A 3x1 array specifying the origin offset in terms of :math:`x,y,z`\
-            coordinates.")
+    translation_offset: StateVector = Property(
+        default=None,
+        doc="A 3x1 array specifying the origin offset in terms of :math:`x,y,z` coordinates.")
 
     def __init__(self, *args, **kwargs):
         """
@@ -582,9 +580,9 @@ class Cartesian2DToBearing(NonLinearGaussianMeasurement):
 
     """  # noqa:E501
 
-    translation_offset = Property(StateVector, default=None,
-                                  doc="A 2x1 array specifying the origin offset in terms of \
-                                  :math:`x,y` coordinates.")
+    translation_offset: StateVector = Property(
+        default=None,
+        doc="A 2x1 array specifying the origin offset in terms of :math:`x,y` coordinates.")
 
     def __init__(self, *args, **kwargs):
         """
@@ -712,16 +710,15 @@ class CartesianToBearingRangeRate(NonLinearGaussianMeasurement):
     expects a 6D state space.
     """
 
-    translation_offset = Property(
-        StateVector, default=None,
+    translation_offset: StateVector = Property(
+        default=None,
         doc="A 3x1 array specifying the origin offset in terms of :math:`x,y` coordinates.")
-    velocity_mapping = Property(
-        np.array, default=(1, 3, 5),
+    velocity_mapping: Tuple[int, int, int] = Property(
+        default=(1, 3, 5),
         doc="Mapping to the targets velocity within its state space")
-    velocity = Property(
-        StateVector, default=None,
-        doc="A 3x1 array specifying the sensor velocity in terms of :math:`x,y,z` \
-        coordinates.")
+    velocity: StateVector = Property(
+        default=None,
+        doc="A 3x1 array specifying the sensor velocity in terms of :math:`x,y,z` coordinates.")
 
     def __init__(self, *args, **kwargs):
         """
@@ -858,14 +855,14 @@ class CartesianToElevationBearingRangeRate(NonLinearGaussianMeasurement, Reversi
     expects a 6D state space.
     """
 
-    translation_offset = Property(
-        StateVector, default=None,
+    translation_offset: StateVector = Property(
+        default=None,
         doc="A 3x1 array specifying the origin offset in terms of :math:`x,y,z` coordinates.")
-    velocity_mapping = Property(
-        np.array, default=(1, 3, 5),
+    velocity_mapping: Tuple[int, int, int] = Property(
+        default=(1, 3, 5),
         doc="Mapping to the targets velocity within its state space")
-    velocity = Property(
-        StateVector, default=None,
+    velocity: StateVector = Property(
+        default=None,
         doc="A 3x1 array specifying the sensor velocity in terms of :math:`x,y,z` coordinates.")
 
     def __init__(self, *args, **kwargs):

--- a/stonesoup/models/transition/base.py
+++ b/stonesoup/models/transition/base.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from abc import abstractmethod
+from typing import Sequence
 
 from scipy.linalg import block_diag
 
@@ -22,7 +23,7 @@ class TransitionModel(Model):
 
 
 class _CombinedGaussianTransitionModel(TransitionModel, GaussianModel):
-    model_list = Property([GaussianModel], doc="List of Transition Models.")
+    model_list: Sequence[GaussianModel] = Property(doc="List of Transition Models.")
 
     @property
     def ndim_state(self):

--- a/stonesoup/models/transition/linear.py
+++ b/stonesoup/models/transition/linear.py
@@ -1,10 +1,9 @@
 # -*- coding: utf-8 -*-
-
+import math
+from typing import Sequence
 from functools import lru_cache
 
-import math
 import numpy as np
-import scipy as sp
 from scipy.integrate import quad
 from scipy.linalg import block_diag
 
@@ -58,12 +57,10 @@ class LinearGaussianTimeInvariantTransitionModel(LinearGaussianTransitionModel,
                                                  TimeInvariantModel):
     r"""Generic Linear Gaussian Time Invariant Transition Model."""
 
-    transition_matrix = Property(
-        sp.ndarray, doc="Transition matrix :math:`\\mathbf{F}`.")
-    control_matrix = Property(
-        sp.ndarray, default=None, doc="Control matrix :math:`\\mathbf{B}`.")
-    covariance_matrix = Property(
-        sp.ndarray,
+    transition_matrix: np.ndarray = Property(doc="Transition matrix :math:`\\mathbf{F}`.")
+    control_matrix: np.ndarray = Property(
+        default=None, doc="Control matrix :math:`\\mathbf{B}`.")
+    covariance_matrix: CovarianceMatrix = Property(
         doc="Transition noise covariance matrix :math:`\\mathbf{Q}`.")
 
     def matrix(self, **kwargs):
@@ -115,12 +112,11 @@ class ConstantNthDerivative(LinearGaussianTransitionModel, TimeVariantModel):
     calculated as the terms of the taylor expansion of each state variable.
     """
 
-    constant_derivative = Property(
-        int, doc="The order of the derivative with respect to time to be kept\
-                    constant, eg if 2 identical to constant acceleration")
-    noise_diff_coeff = Property(
-        float, doc="The Nth derivative noise diffusion \
-                   coefficient (Variance) :math:`q`")
+    constant_derivative: int = Property(
+        doc="The order of the derivative with respect to time to be kept constant, eg if 2 "
+            "identical to constant acceleration")
+    noise_diff_coeff: float = Property(
+        doc="The Nth derivative noise diffusion coefficient (Variance) :math:`q`")
 
     @property
     def ndim_state(self):
@@ -164,8 +160,7 @@ class RandomWalk(ConstantNthDerivative):
         The target is assumed to be (almost) stationary, where
         target velocity is modelled as white noise.
         """
-    noise_diff_coeff = Property(
-        float, doc="The position noise diffusion coefficient :math:`q`")
+    noise_diff_coeff: float = Property(doc="The position noise diffusion coefficient :math:`q`")
 
     @property
     def constant_derivative(self):
@@ -217,8 +212,7 @@ class ConstantVelocity(ConstantNthDerivative):
                         \frac{dt^2}{2} & dt
                 \end{bmatrix} q
     """
-    noise_diff_coeff = Property(
-        float, doc="The velocity noise diffusion coefficient :math:`q`")
+    noise_diff_coeff: float = Property(doc="The velocity noise diffusion coefficient :math:`q`")
 
     @property
     def constant_derivative(self):
@@ -276,8 +270,8 @@ class ConstantAcceleration(ConstantNthDerivative):
                         \frac{dt^3}{6} & \frac{dt^2}{2} & dt
                       \end{bmatrix} q
     """
-    noise_diff_coeff = Property(
-        float, doc="The acceleration noise diffusion coefficient :math:`q`")
+    noise_diff_coeff: float = Property(
+        doc="The acceleration noise diffusion coefficient :math:`q`")
 
     @property
     def constant_derivative(self):
@@ -306,13 +300,11 @@ class NthDerivativeDecay(LinearGaussianTransitionModel, TimeVariantModel):
     simply, but examples for N=1 and N=2 are given in
     :class:`~.OrnsteinUhlenbeck` and :class:`~.Singer` respectively.
         """
-    decay_derivative = Property(
-        int, doc="The derivative with respect to time to decay exponentially, "
-                 "eg if 2 identical to singer")
-    noise_diff_coeff = Property(
-        float, doc="The noise diffusion coefficient :math:`q`")
-    damping_coeff = Property(
-        float, doc="The Nth derivative damping coefficient :math:`K`")
+    decay_derivative: int = Property(
+        doc="The derivative with respect to time to decay exponentially, eg if 2 identical to "
+            "singer")
+    noise_diff_coeff: float = Property(doc="The noise diffusion coefficient :math:`q`")
+    damping_coeff: float = Property(doc="The Nth derivative damping coefficient :math:`K`")
 
     @property
     def ndim_state(self):
@@ -415,10 +407,8 @@ class OrnsteinUhlenbeck(NthDerivativeDecay):
                 \end{bmatrix} q
     """
 
-    noise_diff_coeff = Property(
-        float, doc="The velocity noise diffusion coefficient :math:`q`")
-    damping_coeff = Property(
-        float, doc="The velocity damping coefficient :math:`K`")
+    noise_diff_coeff: float = Property(doc="The velocity noise diffusion coefficient :math:`q`")
+    damping_coeff: float = Property(doc="The velocity damping coefficient :math:`K`")
 
     @property
     def decay_derivative(self):
@@ -487,10 +477,9 @@ class Singer(NthDerivativeDecay):
                     \end{bmatrix}
     """
 
-    noise_diff_coeff = Property(
-        float, doc="The acceleration noise diffusion coefficient :math:`q`")
-    damping_coeff = Property(
-        float, doc=r"The reciprocal of the decorrelation time :math:`\alpha`")
+    noise_diff_coeff: float = Property(
+        doc="The acceleration noise diffusion coefficient :math:`q`")
+    damping_coeff: float = Property(doc=r"The reciprocal of the decorrelation time :math:`\alpha`")
 
     @property
     def decay_derivative(self):
@@ -602,13 +591,12 @@ class ConstantTurnSandwich(LinearGaussianTransitionModel, TimeVariantModel):
     known (nearly) constant turn rate.
     """
 
-    turn_noise_diff_coeffs = Property(
-        np.ndarray,
+    turn_noise_diff_coeffs: np.ndarray = Property(
         doc="The acceleration noise diffusion coefficients :math:`q`")
-    turn_rate = Property(
-        float, doc=r"The turn rate :math:`\omega`")
-    model_list = Property(
-        [LinearGaussianTransitionModel], doc="List of Transition Models.")
+    turn_rate: float = Property(
+        doc=r"The turn rate :math:`\omega`")
+    model_list: Sequence[LinearGaussianTransitionModel] = Property(
+        doc="List of Transition Models.")
 
     @property
     def ndim_state(self):

--- a/stonesoup/platform/base.py
+++ b/stonesoup/platform/base.py
@@ -3,9 +3,8 @@ import datetime
 import weakref
 from abc import abstractmethod, ABC
 from functools import lru_cache
-
 from math import cos, sin
-from typing import Sequence, Optional, List, TYPE_CHECKING
+from typing import Sequence, MutableSequence, Optional, TYPE_CHECKING
 
 from scipy.linalg import expm
 import numpy as np
@@ -15,6 +14,7 @@ from ..types.array import StateVector
 from ..base import Property
 from ..types.state import State, StateMutableSequence
 from ..models.transition import TransitionModel
+
 if TYPE_CHECKING:  # pragma: no cover
     from ..sensor.base import BaseSensor
 
@@ -37,31 +37,36 @@ class Platform(StateMutableSequence, ABC):
             :class:`~.MovingPlatform`
 
         """
-    states = Property([State], doc="A list of States which enables the platform's history to be "
-                                   "accessed in simulators and for plotting. Initiated as a "
-                                   "state, for a static platform, this would usually contain its "
-                                   "position coordinates in the form ``[x, y, z]``. For a moving "
-                                   "platform it would contain position and velocity interleaved: "
-                                   "``[x, vx, y, vy, z, vz]``")
-    position_mapping = Property(Sequence[int],
-                                doc="Mapping between platform position and state vector. For a "
-                                    "position-only 3d platform this might be ``[0, 1, 2]``. For a "
-                                    "position and velocity platform: ``[0, 2, 4]``")
-    rotation_offsets = Property(List[StateVector], default=None, readonly=True,
-                                doc="A list of StateVectors containing the sensor rotation "
-                                    "offsets from the platform's primary axis (defined as the "
-                                    "direction of motion). Defaults to a zero vector with the "
-                                    "same length as the Platform's :attr:`position_mapping`")
-    mounting_offsets = Property(List[StateVector], default=None, readonly=True,
-                                doc="A list of StateVectors containing the sensor translation "
-                                    "offsets from the platform's reference point. Defaults to "
-                                    "a zero vector with the same length as the Platform's "
-                                    ":attr:`position_mapping`")
-    sensors = Property(List["BaseSensor"],  default=None, readonly=True,
-                       doc="A list of N mounted sensors. Defaults to an empty list")
-    velocity_mapping = Property(Sequence[int], default=None,
-                                doc="Mapping between platform velocity and state dims. If not "
-                                    "set, it will default to ``[m+1 for m in position_mapping]``")
+    states: Sequence[State] = Property(
+        doc="A list of States which enables the platform's history to be "
+            "accessed in simulators and for plotting. Initiated as a "
+            "state, for a static platform, this would usually contain its "
+            "position coordinates in the form ``[x, y, z]``. For a moving "
+            "platform it would contain position and velocity interleaved: "
+            "``[x, vx, y, vy, z, vz]``")
+    position_mapping: Sequence[int] = Property(
+        doc="Mapping between platform position and state vector. For a "
+            "position-only 3d platform this might be ``[0, 1, 2]``. For a "
+            "position and velocity platform: ``[0, 2, 4]``")
+    rotation_offsets: MutableSequence[StateVector] = Property(
+        default=None, readonly=True,
+        doc="A list of StateVectors containing the sensor rotation "
+            "offsets from the platform's primary axis (defined as the "
+            "direction of motion). Defaults to a zero vector with the "
+            "same length as the Platform's :attr:`position_mapping`")
+    mounting_offsets: MutableSequence[StateVector] = Property(
+        default=None, readonly=True,
+        doc="A list of StateVectors containing the sensor translation "
+            "offsets from the platform's reference point. Defaults to "
+            "a zero vector with the same length as the Platform's "
+            ":attr:`position_mapping`")
+    sensors: MutableSequence['BaseSensor'] = Property(
+        default=None, readonly=True,
+        doc="A list of N mounted sensors. Defaults to an empty list")
+    velocity_mapping: Sequence[int] = Property(
+        default=None,
+        doc="Mapping between platform velocity and state dims. If not "
+            "set, it will default to ``[m+1 for m in position_mapping]``")
 
     # TODO: Determine where a platform coordinate frame should be maintained
 
@@ -305,9 +310,9 @@ class FixedPlatform(Platform):
 
         .. note:: Position and orientation are a read/write properties in this class.
         """
-    orientation = Property(StateVector, default=None,
-                           doc='A fixed orientation of the static platform. '
-                               'Defaults to the zero vector')
+    orientation: StateVector = Property(
+        default=None,
+        doc='A fixed orientation of the static platform. Defaults to the zero vector')
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -344,8 +349,7 @@ class MovingPlatform(Platform):
 
     .. note:: Position and orientation are a read only properties in this class.
     """
-    transition_model = Property(
-        TransitionModel, doc="Transition model")
+    transition_model: TransitionModel = Property(doc="Transition model")
 
     @property
     def velocity(self) -> StateVector:
@@ -467,9 +471,9 @@ class MultiTransitionMovingPlatform(MovingPlatform):
     movement behaviour of the platform for given durations.
     """
 
-    transition_models = Property([TransitionModel], doc="List of transition models")
-    transition_times = Property([datetime.timedelta], doc="Durations for each listed transition "
-                                                          "model")
+    transition_models: Sequence[TransitionModel] = Property(doc="List of transition models")
+    transition_times: Sequence[datetime.timedelta] = Property(doc="Durations for each listed "
+                                                                  "transition model")
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/stonesoup/predictor/base.py
+++ b/stonesoup/predictor/base.py
@@ -27,8 +27,8 @@ class Predictor(Base):
     transition and control model noise respectively.
     """
 
-    transition_model = Property(TransitionModel, doc="transition model")
-    control_model = Property(ControlModel, default=None, doc="control model")
+    transition_model: TransitionModel = Property(doc="transition model")
+    control_model: ControlModel = Property(default=None, doc="control model")
 
     @abstractmethod
     def predict(self, prior, timestamp=None, **kwargs):

--- a/stonesoup/predictor/kalman.py
+++ b/stonesoup/predictor/kalman.py
@@ -37,11 +37,9 @@ class KalmanPredictor(Predictor):
 
     """
 
-    transition_model = Property(
-        LinearGaussianTransitionModel,
+    transition_model: LinearGaussianTransitionModel = Property(
         doc="The transition model to be used.")
-    control_model = Property(
-        LinearControlModel,
+    control_model: LinearControlModel = Property(
         default=None,
         doc="The control model to be used. Default `None` where the predictor "
             "will create a zero-effect linear :class:`~.ControlModel`.")
@@ -214,11 +212,8 @@ class ExtendedKalmanPredictor(KalmanPredictor):
     # In this version the models can be non-linear, but must have access to the
     # :attr:`jacobian()` function
     # TODO: Enforce the presence of :attr:`jacobian()`
-    transition_model = Property(
-        TransitionModel,
-        doc="The transition model to be used.")
-    control_model = Property(
-        ControlModel,
+    transition_model: TransitionModel = Property(doc="The transition model to be used.")
+    control_model: ControlModel = Property(
         default=None,
         doc="The control model to be used. Default `None` where the predictor "
             "will create a zero-effect linear :class:`~.ControlModel`.")
@@ -293,26 +288,20 @@ class UnscentedKalmanPredictor(KalmanPredictor):
     Gaussian mean and covariance, then putting these through the (in general
     non-linear) transition function, then reconstructing the Gaussian.
     """
-    transition_model = Property(
-        TransitionModel,
-        doc="The transition model to be used.")
-    control_model = Property(
-        ControlModel,
+    transition_model: TransitionModel = Property(doc="The transition model to be used.")
+    control_model: ControlModel = Property(
         default=None,
         doc="The control model to be used. Default `None` where the predictor "
             "will create a zero-effect linear :class:`~.ControlModel`.")
-    alpha = Property(
-        float,
+    alpha: float = Property(
         default=0.5,
         doc="Primary sigma point spread scaling parameter. Default is 0.5.")
-    beta = Property(
-        float,
+    beta: float = Property(
         default=2,
         doc="Used to incorporate prior knowledge of the distribution. If the "
             "true distribution is Gaussian, the value of 2 is optimal. "
             "Default is 2")
-    kappa = Property(
-        float,
+    kappa: float = Property(
         default=0,
         doc="Secondary spread scaling parameter. Default is calculated as "
             "3-Ns")
@@ -419,9 +408,10 @@ class SqrtKalmanPredictor(KalmanPredictor):
        Springfield, VA.
 
     """
-    qr_method = Property(bool, default=False, doc="A switch to do the prediction via a QR "
-                                                  "decomposition, rather than using a Cholesky"
-                                                  "decomposition.")
+    qr_method: bool = Property(
+        default=False,
+        doc="A switch to do the prediction via a QR decomposition, rather than using a Cholesky "
+            "decomposition.")
 
     # This predictor returns a square root form of the Gaussian state prediction
     _prediction_class = SqrtGaussianStatePrediction

--- a/stonesoup/reader/file.py
+++ b/stonesoup/reader/file.py
@@ -8,9 +8,7 @@ from ..base import Property
 
 class FileReader(Reader):
     """Base class for file based readers."""
-    path = Property(
-        Path,
-        doc="Path to file to be opened. Str will be converted to path.")
+    path: Path = Property(doc="Path to file to be opened. Str will be converted to path.")
 
     def __init__(self, path, *args, **kwargs):
         if not isinstance(path, Path):
@@ -27,9 +25,8 @@ class BinaryFileReader(FileReader):
 
 class TextFileReader(FileReader):
     """Base class for text file readers."""
-    encoding = Property(
-        str, default="utf-8",
-        doc="File encoding. Must be valid coding. Default 'utf-8'.")
+    encoding: str = Property(
+        default="utf-8", doc="File encoding. Must be valid coding. Default 'utf-8'.")
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/stonesoup/reader/generic.py
+++ b/stonesoup/reader/generic.py
@@ -7,6 +7,8 @@ of data that is in common formats.
 
 import csv
 from datetime import datetime, timedelta
+from typing import Sequence, Collection, Mapping
+
 from math import modf
 
 import numpy as np
@@ -21,18 +23,18 @@ from ..types.groundtruth import GroundTruthPath, GroundTruthState
 
 
 class _CSVReader(TextFileReader):
-    state_vector_fields = Property(
-        [str], doc='List of columns names to be used in state vector')
-    time_field = Property(
-        str, doc='Name of column to be used as time field')
-    time_field_format = Property(
-        str, default=None, doc='Optional datetime format')
-    timestamp = Property(
-        bool, default=False, doc='Treat time field as a timestamp from epoch')
-    metadata_fields = Property(
-        [str], default=None, doc='List of columns to be saved as metadata, default all')
-    csv_options = Property(
-        dict, default={}, doc='Keyword arguments for the underlying csv reader')
+    state_vector_fields: Sequence[str] = Property(
+        doc='List of columns names to be used in state vector')
+    time_field: str = Property(
+        doc='Name of column to be used as time field')
+    time_field_format: str = Property(
+        default=None, doc='Optional datetime format')
+    timestamp: bool = Property(
+        default=False, doc='Treat time field as a timestamp from epoch')
+    metadata_fields: Collection[str] = Property(
+        default=None, doc='List of columns to be saved as metadata, default all')
+    csv_options: Mapping = Property(
+        default={}, doc='Keyword arguments for the underlying csv reader')
 
     def _get_metadata(self, row):
         if self.metadata_fields is None:
@@ -69,8 +71,7 @@ class CSVGroundTruthReader(GroundTruthReader, _CSVReader):
     Parameters
     ----------
     """
-    path_id_field = Property(
-        str, doc='Name of column to be used as path ID')
+    path_id_field: str = Property(doc='Name of column to be used as path ID')
 
     @BufferedGenerator.generator_method
     def groundtruth_paths_gen(self):

--- a/stonesoup/reader/yaml.py
+++ b/stonesoup/reader/yaml.py
@@ -11,7 +11,7 @@ from .file import FileReader
 
 class YAMLReader(FileReader, BufferedGenerator):
     """YAML Reader"""
-    path = Property(Path, doc="File to read data from")
+    path: Path = Property(doc="File to read data from")
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/stonesoup/sensor/passive.py
+++ b/stonesoup/sensor/passive.py
@@ -18,17 +18,14 @@ class PassiveElevationBearing(Sensor):
 
     """
 
-    ndim_state = Property(
-        int,
+    ndim_state: int = Property(
         doc="Number of state dimensions. This is utilised by (and follows in\
             format) the underlying :class:`~.CartesianToElevationBearing`\
             model")
-    mapping = Property(
-        [np.array],
+    mapping: np.ndarray = Property(
         doc="Mapping between the targets state space and the sensors\
             measurement capability")
-    noise_covar = Property(
-        CovarianceMatrix,
+    noise_covar: CovarianceMatrix = Property(
         doc="The sensor noise covariance matrix. This is utilised by\
             (and follow in format) the underlying \
             :class:`~.CartesianToElevationBearing` model")

--- a/stonesoup/sensor/radar/beam_pattern.py
+++ b/stonesoup/sensor/radar/beam_pattern.py
@@ -1,13 +1,13 @@
 # -*- coding: utf-8 -*-
 import datetime
-from typing import Sequence
+from typing import Sequence, Tuple
 
 from ...base import Property, Base
 
 
 class BeamTransitionModel(Base):
     """Base class for Beam Transition Model"""
-    centre = Property(list, doc="Centre of the beam pattern")
+    centre: Sequence = Property(doc="Centre of the beam pattern")
 
     def move_beam(self, timestamp, **kwargs):
         """Gives position of beam at given time"""
@@ -34,22 +34,18 @@ class StationaryBeam(BeamTransitionModel):
 
 class BeamSweep(BeamTransitionModel):
     """This describes a beam moving in a raster pattern"""
-    init_time = Property(
-        datetime.datetime, default=None,
-        doc="The time the frame is started")
-
-    angle_per_s = Property(float, doc="The speed that the beam scans at")
-    frame = Property(
-        Sequence[float], doc="Dimensions of search frame as [azimuth,elevation]")
-    separation = Property(float, doc="Separation of lines in elevation")
-    centre = Property(
-        Sequence[float], default=None,
+    init_time: datetime.datetime = Property(default=None, doc="The time the frame is started")
+    angle_per_s: float = Property(doc="The speed that the beam scans at")
+    frame: Tuple[float, float] = Property(doc="Dimensions of search frame as [azimuth,elevation]")
+    separation: float = Property(doc="Separation of lines in elevation")
+    centre: Tuple[float, float] = Property(
+        default=None,
         doc="Centre of the search frame in [azimuth,elevation]. Defaults to [0, 0]")
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         if self.centre is None:
-            self.centre = [0, 0]
+            self.centre = (0, 0)
 
     @property
     def length_frame(self):

--- a/stonesoup/sensor/radar/beam_shape.py
+++ b/stonesoup/sensor/radar/beam_shape.py
@@ -7,7 +7,7 @@ from ...base import Property, Base
 
 class BeamShape(Base):
     """Base class for beam shape"""
-    peak_power = Property(float, doc="peak power of the main lobe in Watts")
+    peak_power: float = Property(doc="peak power of the main lobe in Watts")
 
     def beam_power(self, azimuth, elevation, **kwargs):
         """beam power sent in the direction of the target.
@@ -28,8 +28,7 @@ class Beam2DGaussian(BeamShape):
      from the centre. :math:`B_w` is the beam width and :math:`P_p` is the peak
      power.
      """
-    beam_width = Property(float, default=None,
-                          doc='Width of the radar beam')
+    beam_width: float = Property(default=None, doc='Width of the radar beam')
 
     def beam_power(self, azimuth, elevation, **kwargs):
         """

--- a/stonesoup/sensor/radar/radar.py
+++ b/stonesoup/sensor/radar/radar.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import copy
 from math import erfc
+from typing import Tuple
 
 import scipy.constants as const
 import numpy as np
@@ -30,19 +31,17 @@ class RadarRangeBearing(Sensor):
 
     """
 
-    ndim_state = Property(
-        int, default=2,
+    ndim_state: int = Property(
+        default=2,
         doc="Number of state dimensions. This is utilised by (and follows in format) "
             "the underlying :class:`~.CartesianToBearingRange` model")
-    position_mapping = Property(
-        [np.array],
-        doc="Mapping between the targets state space and the sensors\
-            measurement capability")
-    noise_covar = Property(
-        CovarianceMatrix,
-        doc="The sensor noise covariance matrix. This is utilised by\
-            (and follow in format) the underlying \
-            :class:`~.CartesianToBearingRange` model")
+    position_mapping: Tuple[int, int] = Property(
+        doc="Mapping between the targets state space and the sensors "
+            "measurement capability")
+    noise_covar: CovarianceMatrix = Property(
+        doc="The sensor noise covariance matrix. This is utilised by "
+            "(and follow in format) the underlying "
+            ":class:`~.CartesianToBearingRange` model")
 
     def measure(self, ground_truth, noise=True, **kwargs):
         """Generate a measurement for a given state
@@ -89,24 +88,18 @@ class RadarRotatingRangeBearing(RadarRangeBearing):
 
     """
 
-    dwell_center = Property(
-        State, doc="A state object, whose `state_vector`\
-        property describes the rotation angle of the center of the sensor's\
-        current FOV (i.e. the dwell center) relative to the positive x-axis\
-        of the sensor frame/orientation. The angle is positive if the rotation\
-        is in the counter-clockwise direction when viewed by an observer\
-        looking down the z-axis of the sensor frame, towards the origin.\
-        Angle units are in radians"
+    dwell_center: State = Property(
+        doc="A state object, whose `state_vector` "
+            "property describes the rotation angle of the center of the sensor's "
+            "current FOV (i.e. the dwell center) relative to the positive x-axis "
+            "of the sensor frame/orientation. The angle is positive if the rotation "
+            "is in the counter-clockwise direction when viewed by an observer "
+            "looking down the z-axis of the sensor frame, towards the origin. "
+            "Angle units are in radians"
     )
-    rpm = Property(
-        float,
-        doc="The number of antenna rotations per minute (RPM)")
-    max_range = Property(
-        float,
-        doc="The maximum detection range of the radar (in meters)")
-    fov_angle = Property(
-        float,
-        doc="The radar field of view (FOV) angle (in radians).")
+    rpm: float = Property(doc="The number of antenna rotations per minute (RPM)")
+    max_range: float = Property(doc="The maximum detection range of the radar (in meters)")
+    fov_angle: float = Property(doc="The radar field of view (FOV) angle (in radians).")
 
     def measure(self, ground_truth, noise=True, **kwargs):
         """Generate a measurement for a given state
@@ -207,15 +200,14 @@ class RadarRangeBearingElevation(RadarRangeBearing):
 
     """
 
-    ndim_state = Property(
-        int, default=3,
+    ndim_state: int = Property(
+        default=3,
         doc="Number of state dimensions. This is utilised by (and follows in format) "
             "the underlying :class:`~.CartesianToBearingRange` model")
-    noise_covar = Property(
-        CovarianceMatrix,
-        doc="The sensor noise covariance matrix. This is utilised by\
-                (and follow in format) the underlying \
-                :class:`~.CartesianToElevationBearingRange` model")
+    noise_covar: CovarianceMatrix = Property(
+        doc="The sensor noise covariance matrix. This is utilised by "
+            "(and follow in format) the underlying "
+            ":class:`~.CartesianToElevationBearingRange` model")
 
     def measure(self, ground_truth, noise=True, **kwargs):
         """Generate a measurement for a given state
@@ -262,18 +254,17 @@ class RadarRangeRateBearing(RadarRangeBearing):
 
     """
 
-    velocity_mapping = Property(
-        np.array, default=(1, 3, 5),
+    velocity_mapping: Tuple[int, int, int] = Property(
+        default=(1, 3, 5),
         doc="Mapping to the target's velocity information within its state space")
-    ndim_state = Property(
-        int, default=3,
+    ndim_state: int = Property(
+        default=3,
         doc="Number of state dimensions. This is utilised by (and follows in format) "
             "the underlying :class:`~.CartesianToBearingRangeRate` model")
-    noise_covar = Property(
-        CovarianceMatrix,
-        doc="The sensor noise covariance matrix. This is utilised by\
-                    (and follow in format) the underlying \
-                    :class:`~.CartesianToBearingRangeRate` model")
+    noise_covar: CovarianceMatrix = Property(
+        doc="The sensor noise covariance matrix. This is utilised by "
+            "(and follow in format) the underlying "
+            ":class:`~.CartesianToBearingRangeRate` model")
 
     def measure(self, ground_truth, noise=True, **kwargs) -> Detection:
         """Generate a measurement for a given state
@@ -321,18 +312,17 @@ class RadarRangeRateBearingElevation(RadarRangeRateBearing):
 
     """
 
-    velocity_mapping = Property(
-        np.array, default=(1, 3, 5),
+    velocity_mapping: Tuple[int, int, int] = Property(
+        default=(1, 3, 5),
         doc="Mapping to the target's velocity information within its state space")
-    ndim_state = Property(
-        int, default=6,
+    ndim_state: int = Property(
+        default=6,
         doc="Number of state dimensions. This is utilised by (and follows in format) "
             "the underlying :class:`~.CartesianToElevationBearingRangeRate` model")
-    noise_covar = Property(
-        CovarianceMatrix,
-        doc="The sensor noise covariance matrix. This is utilised by\
-                        (and follow in format) the underlying \
-                        :class:`~.CartesianToElevationBearingRangeRate` model")
+    noise_covar: CovarianceMatrix = Property(
+        doc="The sensor noise covariance matrix. This is utilised by "
+            "(and follow in format) the underlying "
+            ":class:`~.CartesianToElevationBearingRangeRate` model")
 
     def measure(self, ground_truth, noise=True, **kwargs) -> Detection:
         """Generate a measurement for a given state
@@ -388,8 +378,7 @@ class RadarRasterScanRangeBearing(RadarRotatingRangeBearing):
 
     """
 
-    for_angle = Property(
-        float, doc="The radar field of regard (FoR) angle (in radians).")
+    for_angle: float = Property(doc="The radar field of regard (FoR) angle (in radians).")
 
     def rotate(self, timestamp):
         """Rotate the sensor's antenna
@@ -477,67 +466,51 @@ class AESARadar(Sensor):
     The current implementation of this class assumes a 3D Cartesian plane.
     This model does not generate false alarms.
     """
-    rotation_offset = Property(
-        StateVector, default=None,
+    rotation_offset: StateVector = Property(
+        default=None,
         doc="A 3x1 array of angles (rad), specifying the radar orientation in terms of the "
             "counter-clockwise rotation around the :math:`x,y,z` axis. i.e Roll, Pitch and Yaw. "
             "Default is ``StateVector([0, 0, 0])``")
-
-    position_mapping = Property(
-        np.array, default=(0, 1, 2),
+    position_mapping: Tuple[int, int, int] = Property(
+        default=(0, 1, 2),
         doc="Mapping between or positions and state "
             "dimensions. [x,y,z]")
-
-    measurement_model = Property(
-        MeasurementModel, default=None,
+    measurement_model: MeasurementModel = Property(
+        default=None,
         doc="The Measurement model used to generate "
             "measurements.")
-
-    beam_shape = Property(
-        BeamShape,
+    beam_shape: BeamShape = Property(
         doc="Object describing the shape of the beam.")
-
-    beam_transition_model = Property(
-        BeamTransitionModel,
-        doc="Object describing the "
-            "movement of the beam in azimuth and "
-            "elevation from the perspective of "
-            "the radar.")
+    beam_transition_model: BeamTransitionModel = Property(
+        doc="Object describing the movement of the beam in azimuth and elevation from the "
+            "perspective of the radar.")
     # SNR variables
-    number_pulses = Property(
-        int, default=1,
-        doc="The number of pulses in the"
-            " radar burst.")
-    duty_cycle = Property(
-        float,
-        doc="Duty cycle is the fraction of the time "
-            "the radar it transmitting.")
-    band_width = Property(
-        float, doc="Bandwidth of the receiver in hertz.")
-    receiver_noise = Property(
-        float, doc="Noise figure of the radar in decibels.")
-    frequency = Property(
-        float, doc="Transmitted frequency in hertz.")
-    antenna_gain = Property(
-        float, doc="Total Antenna gain in decibels.")
-    beam_width = Property(
-        float, doc="Radar beam width in radians.")
-    loss = Property(
-        float, default=0, doc="Loss in decibels.")
-
-    swerling_on = Property(
-        bool, default=False,
+    number_pulses: int = Property(
+        default=1, doc="The number of pulses in the radar burst.")
+    duty_cycle: float = Property(
+        doc="Duty cycle is the fraction of the time the radar it transmitting.")
+    band_width: float = Property(
+        doc="Bandwidth of the receiver in hertz.")
+    receiver_noise: float = Property(
+        doc="Noise figure of the radar in decibels.")
+    frequency: float = Property(
+        doc="Transmitted frequency in hertz.")
+    antenna_gain: float = Property(
+        doc="Total Antenna gain in decibels.")
+    beam_width: float = Property(
+        doc="Radar beam width in radians.")
+    loss: float = Property(
+        default=0, doc="Loss in decibels.")
+    swerling_on: bool = Property(
+        default=False,
         doc="Is the Swerling 1 case used. If True the RCS"
             " of the target will change for each timestep. "
             "The random RCS follows the probability "
             "distribution of the Swerling 1 case.")
-    rcs = Property(
-        float, default=None,
-        doc="The radar cross section of targets in meters squared.")
-
-    probability_false_alarm = Property(
-        Probability, default=1e-6,
-        doc="Probability of false alarm used in the North's approximation")
+    rcs: float = Property(
+        default=None, doc="The radar cross section of targets in meters squared.")
+    probability_false_alarm: Probability = Property(
+        default=1e-6, doc="Probability of false alarm used in the North's approximation")
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/stonesoup/serialise.py
+++ b/stonesoup/serialise.py
@@ -8,7 +8,6 @@ components and data types.
 .. _YAML: http://yaml.org/"""
 import datetime
 import warnings
-import sys
 from io import StringIO
 from collections import OrderedDict, deque
 from functools import lru_cache
@@ -27,31 +26,13 @@ from .sensor.sensor import Sensor
 
 __all__ = ['YAML']
 
-typ = 'stonesoup'
-
-
-def init_typ(yaml):
-
-    class _StoneSoupConstructor(yaml.Constructor):
-        if sys.version_info < (3, 6):  # pragma: no cover
-            from collections import OrderedDict
-            yaml_multi_constructors = OrderedDict(yaml.Constructor.yaml_multi_constructors)
-
-    class _StoneSoupRepresenter(yaml.Representer):
-        if sys.version_info < (3, 6):  # pragma: no cover
-            from collections import OrderedDict
-            yaml_multi_representers = OrderedDict(yaml.Representer.yaml_multi_representers)
-
-    yaml.Constructor = _StoneSoupConstructor
-    yaml.Representer = _StoneSoupRepresenter
-
 
 class YAML:
     """Class for YAML serialisation."""
     tag_prefix = '!{}.'.format(__name__.split('.', 1)[0])
 
     def __init__(self, typ='rt'):
-        self._yaml = ruamel.yaml.YAML(typ=[typ, 'stonesoup'], plug_ins=['stonesoup.serialise'])
+        self._yaml = ruamel.yaml.YAML(typ=[typ])
         self._yaml.default_flow_style = False
 
         # NumPy

--- a/stonesoup/simulator/platform.py
+++ b/stonesoup/simulator/platform.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from typing import Sequence
 
 from ..base import Property
 from ..reader import GroundTruthReader
@@ -14,12 +15,10 @@ class PlatformDetectionSimulator(DetectionSimulator):
     according to a list of platforms by calling each sensor in these platforms.
 
     """
-    groundtruth = Property(GroundTruthReader,
-                           doc='Source of ground truth tracks used to generate'
-                               ' detections for.')
-    platforms = Property([Platform],
-                         doc='List of platforms in :class:`~.Platform` to '
-                             'generate sensor detections from.')
+    groundtruth: GroundTruthReader = Property(
+        doc='Source of ground truth tracks used to generate detections for.')
+    platforms: Sequence[Platform] = Property(
+        doc='List of platforms in :class:`~.Platform` to generate sensor detections from.')
 
     @BufferedGenerator.generator_method
     def detections_gen(self):

--- a/stonesoup/simulator/simple.py
+++ b/stonesoup/simulator/simple.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import datetime
+from typing import Sequence
 
 import numpy as np
 
@@ -17,17 +18,13 @@ from stonesoup.buffered_generator import BufferedGenerator
 
 class SingleTargetGroundTruthSimulator(GroundTruthSimulator):
     """Target simulator that produces a single target"""
-    transition_model = Property(
-        TransitionModel, doc="Transition Model used as propagator for track.")
-    initial_state = Property(
-        State,
-        doc="Initial state to use to generate ground truth")
-    timestep = Property(
-        datetime.timedelta,
+    transition_model: TransitionModel = Property(
+        doc="Transition Model used as propagator for track.")
+    initial_state: State = Property(doc="Initial state to use to generate ground truth")
+    timestep: datetime.timedelta = Property(
         default=datetime.timedelta(seconds=1),
         doc="Time step between each state. Default one second.")
-    number_steps = Property(
-        int, default=100, doc="Number of time steps to run for")
+    number_steps: int = Property(default=100, doc="Number of time steps to run for")
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -57,10 +54,9 @@ class SwitchOneTargetGroundTruthSimulator(SingleTargetGroundTruthSimulator):
     """Target simulator that produces a single target. This target switches
     between multiple transition models based on a markov matrix
     (:attr:`model_probs`)"""
-    transition_models = Property(
-        [TransitionModel], doc="List of transition models to be used, ensure\
-        that they all have the same dimensions.")
-    model_probs = Property([float], doc="A matrix of probabilities.\
+    transition_models: Sequence[TransitionModel] = Property(
+        doc="List of transition models to be used, ensure that they all have the same dimensions.")
+    model_probs: np.ndarray = Property(doc="A matrix of probabilities.\
     The element in the ith row and the jth column is the probability of\
      switching from the ith transition model in :attr:`transition_models`\
      to the jth")
@@ -81,18 +77,14 @@ class MultiTargetGroundTruthSimulator(SingleTargetGroundTruthSimulator):
 
     Targets are created and destroyed randomly, as defined by the birth rate
     and death probability."""
-    transition_model = Property(
-        TransitionModel, doc="Transition Model used as propagator for track.")
-
-    initial_state = Property(
-        GaussianState,
-        doc="Initial state to use to generate states")
-    birth_rate = Property(
-        float, default=1.0, doc="Rate at which tracks are born. Expected "
-        "number of occurrences (λ) in Poisson distribution. Default 1.0.")
-    death_probability = Property(
-        Probability, default=0.1,
-        doc="Probability of track dying in each time step. Default 0.1.")
+    transition_model: TransitionModel = Property(
+        doc="Transition Model used as propagator for track.")
+    initial_state: GaussianState = Property(doc="Initial state to use to generate states")
+    birth_rate: float = Property(
+        default=1.0, doc="Rate at which tracks are born. Expected number of occurrences (λ) in "
+                         "Poisson distribution. Default 1.0.")
+    death_probability: Probability = Property(
+        default=0.1, doc="Probability of track dying in each time step. Default 0.1.")
 
     @BufferedGenerator.generator_method
     def groundtruth_paths_gen(self):
@@ -134,10 +126,9 @@ class SwitchMultiTargetGroundTruthSimulator(MultiTargetGroundTruthSimulator):
     """Functions identically to :class:`~.MultiTargetGroundTruthSimulator`,
     but has the transition model switching ability from
     :class:`.SwitchOneTargetGroundTruthSimulator`"""
-    transition_models = Property(
-        [TransitionModel], doc="List of transition models to be used, ensure\
-            that they all have the same dimensions.")
-    model_probs = Property([float], doc="A matrix of probabilities.\
+    transition_models: Sequence[TransitionModel] = Property(
+        doc="List of transition models to be used, ensure that they all have the same dimensions.")
+    model_probs: np.ndarray = Property(doc="A matrix of probabilities.\
         The element in the ith row and the jth column is the probability of\
          switching from the ith transition model in :attr:`transition_models`\
          to the jth")
@@ -163,11 +154,11 @@ class SimpleDetectionSimulator(DetectionSimulator):
     measurement_model : MeasurementModel
         Measurement model used in generating detections.
     """
-    groundtruth = Property(GroundTruthReader)
-    measurement_model = Property(MeasurementModel)
-    meas_range = Property(np.ndarray)
-    detection_probability = Property(Probability, default=0.9)
-    clutter_rate = Property(float, default=2.0)
+    groundtruth: GroundTruthReader = Property()
+    measurement_model: MeasurementModel = Property()
+    meas_range: np.ndarray = Property()
+    detection_probability: Probability = Property(default=0.9)
+    clutter_rate: float = Property(default=2.0)
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -226,9 +217,9 @@ class SwitchDetectionSimulator(SimpleDetectionSimulator):
     For example, if you wanted a higher detection probability when the
     simulated object makes a turn"""
 
-    detection_probabilities = Property([Probability], doc="List of\
-     probabilities that correspond to the detection probability of the\
-     simulated object while undergoing each transition model")
+    detection_probabilities: Sequence[Probability] = Property(
+        doc="List of probabilities that correspond to the detection probability of the simulated "
+            "object while undergoing each transition model")
 
     @property
     def detection_probability(self):
@@ -242,7 +233,7 @@ class DummyGroundTruthSimulator(GroundTruthSimulator):
      It returns an empty set at each time step.
     """
 
-    times = Property([datetime.datetime], doc='list of times to return')
+    times: Sequence[datetime.datetime] = Property(doc='list of times to return')
 
     @BufferedGenerator.generator_method
     def groundtruth_paths_gen(self):

--- a/stonesoup/smoother/base.py
+++ b/stonesoup/smoother/base.py
@@ -8,8 +8,7 @@ from ..models.transition import TransitionModel
 class Smoother(Base):
     """Smoother Base Class."""
 
-    transition_model = Property(
-        TransitionModel, default=None, doc="Transition Model.")
+    transition_model: TransitionModel = Property(default=None, doc="Transition Model.")
 
     @abstractmethod
     def smooth(self, *args, **kwargs):

--- a/stonesoup/tests/conftest.py
+++ b/stonesoup/tests/conftest.py
@@ -7,7 +7,7 @@ from ..base import Base, Property
 @pytest.fixture(scope='session')
 def base():
     class _TestBase(Base):
-        property_a = Property(int)
-        property_b = Property(str)
-        property_c = Property(int, default=123)
+        property_a: int = Property()
+        property_b: str = Property()
+        property_c: int = Property(default=123)
     return _TestBase

--- a/stonesoup/tests/test_declarative.py
+++ b/stonesoup/tests/test_declarative.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-import sys
-
 import pytest
 
 from ..base import Property, Base
@@ -80,7 +78,6 @@ def test_init_new(base):
     assert not hasattr(_TestNew(1, "2", property_d="10"), 'property_d')
 
 
-@pytest.mark.skipif(sys.version_info < (3, 6), reason="Requires Python >= 3.6")
 def test_non_base_property():
     with pytest.raises(RuntimeError):
         class _TestNonBase:

--- a/stonesoup/tests/test_declarative.py
+++ b/stonesoup/tests/test_declarative.py
@@ -210,68 +210,75 @@ def test_readonly():
 def test_type_hint_checking():
     """ Check that errors are raised for some common type hint errors """
     # no error
-    class TestCorrect1(Base):
+    class TestClass(Base):
         i: int = Property(doc='Test')
-    _ = TestCorrect1(i=1)
+    _ = TestClass(i=1)
 
     # no error
-    class TestCorrect2(Base):
+    class TestClass(Base):
         i = Property(int, doc='Test')
-    _ = TestCorrect2(i=1)
+    _ = TestClass(i=1)
 
-    # specify both as a type hint AND and argument. Argument wins.
-    class TestCorrect2(Base):
-        i: float = Property(int, doc='Test')
-    obj = TestCorrect2(i=1)
-    assert obj._properties['i'].cls is int
+    # specify both as a type hint AND and argument
+    with pytest.raises(ValueError):
+        class TestClass(Base):
+            i: float = Property(int, doc='Test')
+        obj = TestClass(i=1)
+        assert obj._properties['i'].cls is int
+
+    with pytest.raises(ValueError):
+        # Type is not specified
+        class TestClass(Base):
+            i = Property(doc='Test')
+        _ = TestClass(i=1)
 
     # error for [int]
     with pytest.raises(ValueError):
-        class TestIncorrect1(Base):
+        class TestClass(Base):
             i: [int] = Property(doc='Test')
-        _ = TestIncorrect1(i=1)
+        _ = TestClass(i=1)
 
     with pytest.raises(ValueError):
-        class TestIncorrect1(Base):
+        class TestClass(Base):
             i = Property([int], doc='Test')
-        _ = TestIncorrect1(i=1)
+        _ = TestClass(i=1)
 
     # No error for List[int]
-    class TestCorrect1(Base):
+    class TestClass(Base):
         i: List[int] = Property(doc='Test')
-    _ = TestCorrect1(i=1)
+    _ = TestClass(i=1)
 
-    class TestCorrect2(Base):
+    class TestClass(Base):
         i = Property(List[int], doc='Test')
-    _ = TestCorrect2(i=1)
+    _ = TestClass(i=1)
 
     with pytest.raises(ValueError):
-        class TestCorrect1(Base):
+        class TestClass(Base):
             i: 'string' = Property(doc='Test')  # noqa: F821
-        _ = TestCorrect1(i=1)
+        _ = TestClass(i=1)
 
     with pytest.raises(ValueError):
-        class TestCorrect2(Base):
+        class TestClass(Base):
             i = Property('string', doc='Test')
-        _ = TestCorrect2(i=1)
+        _ = TestClass(i=1)
 
     # errors for any
     with pytest.raises(ValueError):
-        class TestCorrect1(Base):
+        class TestClass(Base):
             i: any = Property(doc='Test')
-        _ = TestCorrect1(i=1)
+        _ = TestClass(i=1)
 
     with pytest.raises(ValueError):
-        class TestCorrect1(Base):
+        class TestClass(Base):
             i = Property(any, doc='Test')
-        _ = TestCorrect1(i=1)
+        _ = TestClass(i=1)
 
     # no error for typing.Any
-    class TestCorrect1(Base):
+    class TestClass(Base):
         i: Any = Property(doc='Test')
-    _ = TestCorrect1(i=1)
+    _ = TestClass(i=1)
 
     # no error
-    class TestCorrect2(Base):
+    class TestClass(Base):
         i = Property(Any, doc='Test')
-    _ = TestCorrect2(i=1)
+    _ = TestClass(i=1)

--- a/stonesoup/tests/test_declarative.py
+++ b/stonesoup/tests/test_declarative.py
@@ -90,8 +90,8 @@ def test_non_base_property():
 def test_readonly_with_setter():
 
     class TestReadonly(Base):
-        readonly_property_default = Property(float, default=0)
-        readonly_property_no_default = Property(float)
+        readonly_property_default: float = Property(default=0)
+        readonly_property_no_default: float = Property()
 
         @readonly_property_default.setter
         def set_readonly_default(self, value):
@@ -136,7 +136,7 @@ def test_readonly_with_setter():
 def test_basic_setter():
 
     class TestSetter(Base):
-        times_two = Property(float, default=5)
+        times_two: float = Property(default=5)
 
         @times_two.setter
         def set_times_two(self, value):
@@ -157,8 +157,8 @@ def test_basic_getter():
     # be appropriate. This would be best done with a Python `property` in all
     # use cases I can see, but is tested here for completeness
     class TestGetter(Base):
-        times_two = Property(float, default=None)
-        base_value = Property(float, default=5)
+        times_two: float = Property(default=None)
+        base_value: float = Property(default=5)
 
         @times_two.getter
         def get_times_two(self):
@@ -185,8 +185,8 @@ def test_basic_getter():
 def test_readonly():
 
     class TestReadonly(Base):
-        readonly_property_default = Property(float, default=0, readonly=True)
-        readonly_property_no_default = Property(float, readonly=True)
+        readonly_property_default: float = Property(default=0, readonly=True)
+        readonly_property_no_default: float = Property(readonly=True)
 
     test_object = TestReadonly(readonly_property_default=10,
                                readonly_property_no_default=20)

--- a/stonesoup/tests/test_serialise.py
+++ b/stonesoup/tests/test_serialise.py
@@ -106,7 +106,7 @@ def test_probability(serialised_file):
 
 def test_numpy(base, serialised_file):
     class _TestNumpy(base):
-        property_d = Property(np.ndarray)
+        property_d: np.ndarray = Property()
 
     instance = _TestNumpy(1, "two",
                           property_d=np.array([[1, 2], [3, 4], [5, 6]]))
@@ -148,7 +148,7 @@ def test_datetime(base, serialised_file):
     import datetime
 
     class _TestNumpy(base):
-        property_d = Property(datetime.timedelta)
+        property_d: datetime.datetime = Property()
 
     instance = _TestNumpy(1, "two",
                           property_d=datetime.timedelta(seconds=500))

--- a/stonesoup/tracker/pointprocess.py
+++ b/stonesoup/tracker/pointprocess.py
@@ -17,24 +17,18 @@ class PointProcessMultiTargetTracker(Tracker):
     Base class for Gaussian Mixture (GM) style implementations of
     point process derived filters
     """
-    detector = Property(
-        DetectionReader,
+    detector: DetectionReader = Property(
         doc="Detector used to generate detection objects.")
-    updater = Property(
-        Updater,
+    updater: Updater = Property(
         doc="Updater used to update the objects to their new state.")
-    hypothesiser = Property(
-        GaussianMixtureHypothesiser,
+    hypothesiser: GaussianMixtureHypothesiser = Property(
         doc="Association algorithm to pair predictions to detections")
-    reducer = Property(
-        GaussianMixtureReducer,
+    reducer: GaussianMixtureReducer = Property(
         doc="Reducer used to reduce the number of components in the mixture.")
-    extraction_threshold = Property(
-        Probability,
+    extraction_threshold: Probability = Property(
         default=0.9,
         doc="Threshold to extract components from the mixture.")
-    birth_component = Property(
-        TaggedWeightedGaussianState,
+    birth_component: TaggedWeightedGaussianState = Property(
         default=None,
         doc="The birth component. The weight should be "
             "equal to the mean of the expected number of "

--- a/stonesoup/tracker/simple.py
+++ b/stonesoup/tracker/simple.py
@@ -36,21 +36,12 @@ class SingleTargetTracker(Tracker):
         Current track being maintained. Also accessible as the sole item in
         :attr:`tracks`
     """
-    initiator = Property(
-        Initiator,
-        doc="Initiator used to initialise the track.")
-    deleter = Property(
-        Deleter,
-        doc="Deleter used to delete the track")
-    detector = Property(
-        DetectionReader,
-        doc="Detector used to generate detection objects.")
-    data_associator = Property(
-        DataAssociator,
+    initiator: Initiator = Property(doc="Initiator used to initialise the track.")
+    deleter: Deleter = Property(doc="Deleter used to delete the track")
+    detector: DetectionReader = Property(doc="Detector used to generate detection objects.")
+    data_associator: DataAssociator = Property(
         doc="Association algorithm to pair predictions to detections")
-    updater = Property(
-        Updater,
-        doc="Updater used to update the track object to the new state.")
+    updater: Updater = Property(doc="Updater used to update the track object to the new state.")
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -93,21 +84,12 @@ class MultiTargetTracker(Tracker):
     Parameters
     ----------
     """
-    initiator = Property(
-        Initiator,
-        doc="Initiator used to initialise the track.")
-    deleter = Property(
-        Deleter,
-        doc="Initiator used to initialise the track.")
-    detector = Property(
-        DetectionReader,
-        doc="Detector used to generate detection objects.")
-    data_associator = Property(
-        DataAssociator,
+    initiator: Initiator = Property(doc="Initiator used to initialise the track.")
+    deleter: Deleter = Property(doc="Initiator used to initialise the track.")
+    detector: DetectionReader = Property(doc="Detector used to generate detection objects.")
+    data_associator: DataAssociator = Property(
         doc="Association algorithm to pair predictions to detections")
-    updater = Property(
-        Updater,
-        doc="Updater used to update the track object to the new state.")
+    updater: Updater = Property(doc="Updater used to update the track object to the new state.")
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -152,21 +134,12 @@ class MultiTargetMixtureTracker(Tracker):
     Parameters
     ----------
     """
-    initiator = Property(
-        Initiator,
-        doc="Initiator used to initialise the track.")
-    deleter = Property(
-        Deleter,
-        doc="Initiator used to initialise the track.")
-    detector = Property(
-        DetectionReader,
-        doc="Detector used to generate detection objects.")
-    data_associator = Property(
-        DataAssociator,
+    initiator: Initiator = Property(doc="Initiator used to initialise the track.")
+    deleter: Deleter = Property(doc="Initiator used to initialise the track.")
+    detector: DetectionReader = Property(doc="Detector used to generate detection objects.")
+    data_associator: DataAssociator = Property(
         doc="Association algorithm to pair predictions to detections")
-    updater = Property(
-        Updater,
-        doc="Updater used to update the track object to the new state.")
+    updater: Updater = Property(doc="Updater used to update the track object to the new state.")
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/stonesoup/types/association.py
+++ b/stonesoup/types/association.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import datetime
+from typing import Set
 
 from ..base import Property
 from .base import Type
@@ -13,7 +14,7 @@ class Association(Type):
     """
 
     # TODO: Should probably add a link to the associator that produced it
-    objects = Property(set, doc="Set of objects being associated")
+    objects: Set = Property(doc="Set of objects being associated")
 
 
 class AssociationPair(Association):
@@ -36,8 +37,9 @@ class SingleTimeAssociation(Association):
     time
     """
 
-    timestamp = Property(datetime.datetime, default=None,
-                         doc="Timestamp of the association. Default is None.")
+    timestamp: datetime.datetime = Property(
+        default=None,
+        doc="Timestamp of the association. Default is None.")
 
 
 class TimeRangeAssociation(Association):
@@ -47,9 +49,8 @@ class TimeRangeAssociation(Association):
     range of times
     """
 
-    time_range = Property(TimeRange, default=None,
-                          doc="Range of times that association exists over. "
-                              "Default is None")
+    time_range: TimeRange = Property(
+        default=None, doc="Range of times that association exists over. Default is None")
 
 
 class AssociationSet(Type):
@@ -60,13 +61,12 @@ class AssociationSet(Type):
     associations
     """
 
-    associations = Property(set, default=None,
-                            doc="Set of independant associations")
+    associations: Set[Association] = Property(default=None, doc="Set of independent associations")
 
     def __init__(self, associations=None, *args, **kwargs):
-        if associations is None:
-            associations = set()
         super().__init__(associations, *args, **kwargs)
+        if self.associations is None:
+            self.associations = set()
 
     def associations_at_timestamp(self, timestamp):
         """Return the associations that exist at a given timestamp

--- a/stonesoup/types/detection.py
+++ b/stonesoup/types/detection.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from typing import MutableMapping
+
 from ..base import Property
 from .groundtruth import GroundTruthPath
 from .state import State, GaussianState, StateVector
@@ -7,12 +9,12 @@ from ..models.measurement import MeasurementModel
 
 class Detection(State):
     """Detection type"""
-    measurement_model = Property(MeasurementModel, default=None,
-                                 doc="The measurement model used to generate the detection\
-                         (the default is ``None``)")
+    measurement_model: MeasurementModel = Property(
+        default=None,
+        doc="The measurement model used to generate the detection (the default is ``None``)")
 
-    metadata = Property(dict, default=None,
-                        doc='Dictionary of metadata items for Detections.')
+    metadata: MutableMapping = Property(
+        default=None, doc='Dictionary of metadata items for Detections.')
 
     def __init__(self, state_vector, *args, **kwargs):
         super().__init__(state_vector, *args, **kwargs)
@@ -39,8 +41,7 @@ class TrueDetection(Detection):
     detections for metrics and analysis purposes.
     """
 
-    groundtruth_path = Property(
-        GroundTruthPath,
+    groundtruth_path: GroundTruthPath = Property(
         doc="Ground truth path that this detection came from")
 
 
@@ -52,9 +53,7 @@ class MissedDetection(Detection):
     detections are associated with the specified track).
     """
 
-    state_vector = Property(
-        StateVector, default=None,
-        doc="State vector. Default `None`.")
+    state_vector: StateVector = Property(default=None, doc="State vector. Default `None`.")
 
     def __init__(self, state_vector=None, *args, **kwargs):
         super().__init__(state_vector, *args, **kwargs)

--- a/stonesoup/types/groundtruth.py
+++ b/stonesoup/types/groundtruth.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import uuid
+from typing import MutableSequence, MutableMapping
 
 from ..base import Property
 from .state import State, StateMutableSequence
@@ -7,8 +8,8 @@ from .state import State, StateMutableSequence
 
 class GroundTruthState(State):
     """Ground Truth State type"""
-    metadata = Property(dict, default=None,
-                        doc='Dictionary of metadata items for Detections.')
+    metadata: MutableMapping = Property(
+        default=None, doc='Dictionary of metadata items for Detections.')
 
     def __init__(self, state_vector, *args, **kwargs):
         super().__init__(state_vector, *args, **kwargs)
@@ -22,13 +23,11 @@ class GroundTruthPath(StateMutableSequence):
     A :class:`~.StateMutableSequence` representing a track.
     """
 
-    states = Property(
-        [GroundTruthState],
+    states: MutableSequence[GroundTruthState] = Property(
         default=None,
         doc="List of groundtruth states to initialise path with. Default "
             "`None` which initialises with an empty list.")
-    id = Property(
-        str,
+    id: str = Property(
         default=None,
         doc="The unique path ID. Default `None` where random UUID is "
             "generated.")

--- a/stonesoup/types/hypothesis.py
+++ b/stonesoup/types/hypothesis.py
@@ -29,16 +29,10 @@ class SingleHypothesis(Hypothesis):
     """A hypothesis based on a single measurement.
 
     """
-    prediction = Property(
-        Prediction,
-        doc="Predicted track state")
-    measurement = Property(
-        Detection,
-        doc="Detection used for hypothesis and updating")
-    measurement_prediction = Property(
-        MeasurementPrediction,
-        default=None,
-        doc="Optional track prediction in measurement space")
+    prediction: Prediction = Property(doc="Predicted track state")
+    measurement: Detection = Property(doc="Detection used for hypothesis and updating")
+    measurement_prediction: MeasurementPrediction = Property(
+        default=None, doc="Optional track prediction in measurement space")
 
     def __bool__(self):
         return (not isinstance(self.measurement, MissedDetection)) and \
@@ -54,9 +48,7 @@ class SingleDistanceHypothesis(SingleHypothesis):
     i.e. smaller distance is a greater likelihood.
     """
 
-    distance = Property(
-        float,
-        doc="Distance between detection and prediction")
+    distance: float = Property(doc="Distance between detection and prediction")
 
     def __lt__(self, other):
         return self.distance > other.distance
@@ -86,8 +78,7 @@ class SingleProbabilityHypothesis(SingleHypothesis):
 
     """
 
-    probability = Property(
-        Probability,
+    probability: Probability = Property(
         doc="Probability that detection is true location of prediction")
 
     def __lt__(self, other):
@@ -126,9 +117,7 @@ class JointHypothesis(Type, UserDict):
     Update, and Update imports Hypothesis, which is a circular import.
     """
 
-    hypotheses = Property(
-        Hypothesis,
-        doc='Association hypotheses')
+    hypotheses: Hypothesis = Property(doc='Association hypotheses')
 
     def __new__(cls, hypotheses):
         if all(isinstance(hypothesis, SingleDistanceHypothesis)
@@ -170,10 +159,7 @@ class ProbabilityJointHypothesis(JointHypothesis):
 
     """
 
-    probability = Property(
-        Probability,
-        default=None,
-        doc='Probability of the Joint Hypothesis')
+    probability: Probability = Property(default=None, doc='Probability of the Joint Hypothesis')
 
     def __init__(self, hypotheses, *args, **kwargs):
         super().__init__(hypotheses, *args, **kwargs)

--- a/stonesoup/types/metric.py
+++ b/stonesoup/types/metric.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 import datetime
 
+import typing
+
 from .base import Type
 from .time import TimeRange
 from ..base import Property
@@ -10,8 +12,8 @@ class Metric(Type):
     """Metric type"""
 
     title: str = Property(doc='Name of the metric')
-    value: any = Property(doc='Value of the metric')
-    generator: any = Property(doc='Generator used to create the metric')
+    value: typing.Any = Property(doc='Value of the metric')
+    generator: typing.Any = Property(doc='Generator used to create the metric')
 
 
 class PlottingMetric(Metric):

--- a/stonesoup/types/metric.py
+++ b/stonesoup/types/metric.py
@@ -9,9 +9,9 @@ from ..base import Property
 class Metric(Type):
     """Metric type"""
 
-    title = Property(str, doc='Name of the metric')
-    value = Property(any, doc='Value of the metric')
-    generator = Property(any, doc='Generator used to create the metric')
+    title: str = Property(doc='Name of the metric')
+    value: any = Property(doc='Value of the metric')
+    generator: any = Property(doc='Generator used to create the metric')
 
 
 class PlottingMetric(Metric):
@@ -22,16 +22,16 @@ class PlottingMetric(Metric):
 class SingleTimeMetric(Metric):
     """Metric for a specific timestamp"""
 
-    timestamp = Property(datetime.datetime, default=None,
-                         doc="Timestamp of the state. Default None.")
+    timestamp: datetime.datetime = Property(
+        default=None, doc="Timestamp of the state. Default None.")
 
 
 class TimeRangeMetric(Metric):
     """ Metric for a range of times (e.g. for example an entire run)"""
 
-    time_range = Property(TimeRange, default=None,
-                          doc="Time range over which metric assessment will be"
-                              "conducted over. Default is None")
+    time_range: TimeRange = Property(
+        default=None,
+        doc="Time range over which metric assessment will be conducted over. Default is None")
 
 
 class TimeRangePlottingMetric(TimeRangeMetric, PlottingMetric):

--- a/stonesoup/types/mixture.py
+++ b/stonesoup/types/mixture.py
@@ -1,4 +1,5 @@
 from collections.abc import Sized, Iterable, Container
+from typing import MutableSequence
 
 from .base import Type
 from ..base import Property
@@ -14,8 +15,7 @@ class GaussianMixture(Type, Sized, Iterable, Container):
     :class:`WeightedGaussianState`.
     """
 
-    components = Property(
-        [WeightedGaussianState],
+    components: MutableSequence[WeightedGaussianState] = Property(
         default=None,
         doc="""The initial list of :class:`WeightedGaussianState` components.
         Default `None` which initialises with empty list.""")

--- a/stonesoup/types/multihypothesis.py
+++ b/stonesoup/types/multihypothesis.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from collections.abc import Sized, Iterable, Container
+from typing import Sequence
 
 from ..base import Property
 from ..types import Type
@@ -16,16 +17,16 @@ class MultipleHypothesis(Type, Sized, Iterable, Container):
     A Multiple Hypothesis is a container to store a collection of hypotheses.
     """
 
-    single_hypotheses = Property(
-        [SingleHypothesis], default=None,
+    single_hypotheses: Sequence[SingleHypothesis] = Property(
+        default=None,
         doc="The initial list of :class:`~.SingleHypothesis`. Default `None` "
             "which initialises with empty list.")
-    normalise = Property(
-        bool, default=False,
+    normalise: bool = Property(
+        default=False,
         doc="Normalise probabilities of :class:`~.SingleHypothesis`. Default "
             "is `False`.")
-    total_weight = Property(
-        float, default=1,
+    total_weight: float = Property(
+        default=1,
         doc="When normalising, weights will sum to this. Default is 1.")
 
     def __init__(self, single_hypotheses=None, normalise=False, *args,

--- a/stonesoup/types/particle.py
+++ b/stonesoup/types/particle.py
@@ -11,9 +11,9 @@ class Particle(Type):
 
     A particle type which contains a state and weight
     """
-    state_vector = Property(StateVector, doc="State vector")
-    weight = Property(float, doc='Weight of particle')
-    parent = Property(None, default=None, doc='Parent particle')
+    state_vector: StateVector = Property(doc="State vector")
+    weight: float = Property(doc='Weight of particle')
+    parent: 'Particle' = Property(default=None, doc='Parent particle')
 
     def __init__(self, state_vector, weight, parent=None, *args, **kwargs):
         if parent:
@@ -25,4 +25,3 @@ class Particle(Type):
     @property
     def ndim(self):
         return self.state_vector.shape[0]
-Particle.parent.cls = Particle  # noqa:E305

--- a/stonesoup/types/prediction.py
+++ b/stonesoup/types/prediction.py
@@ -75,9 +75,8 @@ class GaussianMeasurementPrediction(MeasurementPrediction, GaussianState):
     suggests, is described by a Gaussian distribution.
     """
 
-    cross_covar = Property(CovarianceMatrix,
-                           doc="The state-measurement cross covariance matrix",
-                           default=None)
+    cross_covar: CovarianceMatrix = Property(
+        default=None, doc="The state-measurement cross covariance matrix")
 
     def __init__(self, state_vector, covar, timestamp=None,
                  cross_covar=None, *args, **kwargs):

--- a/stonesoup/types/sensordata.py
+++ b/stonesoup/types/sensordata.py
@@ -13,13 +13,10 @@ class SensorData(Type):
 class ImageFrame(SensorData):
     """ Image Frame type used to represent a simple image/video frame """
 
-    pixels = Property(np.ndarray,
-                      doc="An array of shape (w,h,x) containing the individual"
-                          " pixel values, where w:width, h:height and x may"
-                          " vary depending on the color format")
-    timestamp = Property(datetime,
-                         doc="An optional timestamp",
-                         default=None)
+    pixels: np.ndarray = Property(
+        doc="An array of shape (w,h,x) containing the individual pixel  values, where w:width, "
+            "h:height and x may vary depending on the color format")
+    timestamp: datetime = Property(doc="An optional timestamp", default=None)
 
     def __bool__(self):
         return len(self.pixels) > 0

--- a/stonesoup/types/state.py
+++ b/stonesoup/types/state.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import datetime
-from collections.abc import MutableSequence
+from collections import abc
+from typing import MutableSequence
 
 import numpy as np
 import uuid
@@ -16,9 +17,9 @@ class State(Type):
     """State type.
 
     Most simple state type, which only has time and a state vector."""
-    timestamp = Property(datetime.datetime, default=None,
-                         doc="Timestamp of the state. Default None.")
-    state_vector = Property(StateVector, doc='State vector.')
+    timestamp: datetime.datetime = Property(
+        default=None, doc="Timestamp of the state. Default None.")
+    state_vector: StateVector = Property(doc='State vector.')
 
     def __init__(self, state_vector, *args, **kwargs):
         # Don't cast away subtype of state_vector if not necessary
@@ -33,7 +34,7 @@ class State(Type):
         return self.state_vector.shape[0]
 
 
-class StateMutableSequence(Type, MutableSequence):
+class StateMutableSequence(Type, abc.MutableSequence):
     """A mutable sequence for :class:`~.State` instances
 
     This sequence acts like a regular list object for States, as well as
@@ -54,11 +55,9 @@ class StateMutableSequence(Type, MutableSequence):
     [[1]] 2018-01-01 14:01:00
     """
 
-    states = Property(
-        [State],
+    states: MutableSequence[State] = Property(
         default=None,
-        doc="The initial list of states. Default `None` which initialises"
-            "with empty list.")
+        doc="The initial list of states. Default `None` which initialises with empty list.")
 
     def __init__(self, states=None, *args, **kwargs):
         if states is None:
@@ -128,7 +127,7 @@ class GaussianState(State):
     This is a simple Gaussian state object, which, as the name suggests,
     is described by a Gaussian state distribution.
     """
-    covar = Property(CovarianceMatrix, doc='Covariance matrix of state.')
+    covar: CovarianceMatrix = Property(doc='Covariance matrix of state.')
 
     def __init__(self, state_vector, covar, *args, **kwargs):
         covar = CovarianceMatrix(covar)
@@ -151,7 +150,7 @@ class SqrtGaussianState(State):
     taste. No checks are undertaken to ensure that a sensible square root form has been chosen.
 
     """
-    sqrt_covar = Property(CovarianceMatrix, doc="A square root form of the Gaussian covariance "
+    sqrt_covar: CovarianceMatrix = Property(doc="A square root form of the Gaussian covariance "
                                                 "matrix.")
 
     def __init__(self, state_vector, sqrt_covar, *args, **kwargs):
@@ -184,7 +183,7 @@ class WeightedGaussianState(GaussianState):
     Gaussian State object with an associated weight.  Used as components
     for a GaussianMixtureState.
     """
-    weight = Property(Probability, default=0, doc="Weight of the Gaussian State.")
+    weight: Probability = Property(default=0, doc="Weight of the Gaussian State.")
 
 
 class TaggedWeightedGaussianState(WeightedGaussianState):
@@ -193,7 +192,7 @@ class TaggedWeightedGaussianState(WeightedGaussianState):
     Gaussian State object with an associated weight and tag. Used as components
     for a GaussianMixtureState.
     """
-    tag = Property(str, default=None, doc="Unique tag of the Gaussian State.")
+    tag: str = Property(default=None, doc="Unique tag of the Gaussian State.")
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -207,10 +206,9 @@ class ParticleState(Type):
     This is a particle state object which describes the state as a
     distribution of particles"""
 
-    particles = Property([Particle],
-                         doc='List of particles representing state')
-    timestamp = Property(datetime.datetime, default=None,
-                         doc="Timestamp of the state. Default None.")
+    particles: MutableSequence[Particle] = Property(doc='List of particles representing state')
+    timestamp: datetime.datetime = Property(default=None,
+                                            doc="Timestamp of the state. Default None.")
 
     @property
     def ndim(self):

--- a/stonesoup/types/time.py
+++ b/stonesoup/types/time.py
@@ -22,10 +22,8 @@ class TimeRange(Type):
     True
     """
 
-    start_timestamp = Property(datetime.datetime,
-                               doc="Start of the time range")
-    end_timestamp = Property(datetime.datetime,
-                             doc="End of the time range")
+    start_timestamp: datetime.datetime = Property(doc="Start of the time range")
+    end_timestamp: datetime.datetime = Property(doc="End of the time range")
 
     def __init__(self, start_timestamp, end_timestamp, *args, **kwargs):
         if end_timestamp < start_timestamp:

--- a/stonesoup/types/track.py
+++ b/stonesoup/types/track.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import uuid
+from typing import MutableSequence
 
 from ..base import Property
 from .multihypothesis import MultipleHypothesis
@@ -13,14 +14,12 @@ class Track(StateMutableSequence):
     A :class:`~.StateMutableSequence` representing a track.
     """
 
-    states = Property(
-        [State],
+    states: MutableSequence[State] = Property(
         default=None,
         doc="The initial states of the track. Default `None` which initialises"
             "with empty list.")
 
-    id = Property(
-        str,
+    id: str = Property(
         default=None,
         doc="The unique track ID")
 

--- a/stonesoup/types/update.py
+++ b/stonesoup/types/update.py
@@ -12,8 +12,7 @@ class Update(Type):
     The base update class. Updates are returned by :class:'~.Updater' objects
     and contain the information that was used to perform the updating"""
 
-    hypothesis = Property(Hypothesis,
-                          doc="Hypothesis used for updating")
+    hypothesis: Hypothesis = Property(doc="Hypothesis used for updating")
 
 
 class StateUpdate(Update, State):

--- a/stonesoup/updater/base.py
+++ b/stonesoup/updater/base.py
@@ -20,7 +20,7 @@ class Updater(Base):
 
     """
 
-    measurement_model = Property(MeasurementModel, doc="measurement model")
+    measurement_model: MeasurementModel = Property(doc="measurement model")
 
     @abstractmethod
     def predict_measurement(

--- a/stonesoup/updater/kalman.py
+++ b/stonesoup/updater/kalman.py
@@ -60,18 +60,16 @@ class KalmanUpdater(Updater):
 
     # TODO: at present this will throw an error if a measurement model is not
     # TODO: specified in either individual measurements or the Updater object
-    measurement_model = Property(
-        LinearGaussian, default=None,
+    measurement_model: LinearGaussian = Property(
+        default=None,
         doc="A linear Gaussian measurement model. This need not be defined if "
             "a measurement model is provided in the measurement. If no model "
             "specified on construction, or in the measurement, then error "
             "will be thrown.")
-
-    force_symmetric_covariance = Property(
-        bool, default=False, doc="A flag to force the output covariance matrix"
-                                 "to be symmetric by way of a simple geometric"
-                                 "combination of the matrix and transpose."
-                                 "Default is False.")
+    force_symmetric_covariance: bool = Property(
+        default=False,
+        doc="A flag to force the output covariance matrix to be symmetric by way of a simple "
+            "geometric combination of the matrix and transpose. Default is False.")
 
     # This attribute tells the :meth:`update()` method what class to return
     _update_class = GaussianStateUpdate
@@ -297,8 +295,8 @@ class ExtendedKalmanUpdater(KalmanUpdater):
     """
     # TODO: Enforce the fact that this version of MeasurementModel must be
     # TODO: capable of executing :attr:`jacobian()`
-    measurement_model = Property(
-        MeasurementModel, default=None,
+    measurement_model: MeasurementModel = Property(
+        default=None,
         doc="A measurement model. This need not be defined if a measurement "
             "model is provided in the measurement. If no model specified on "
             "construction, or in the measurement, then error will be thrown. "
@@ -346,25 +344,21 @@ class UnscentedKalmanUpdater(KalmanUpdater):
 
     """
     # Can be non-linear and non-differentiable
-    measurement_model = Property(
-        MeasurementModel,
+    measurement_model: MeasurementModel = Property(
         default=None,
         doc="The measurement model to be used. This need not be defined if a "
             "measurement model is provided in the measurement. If no model "
             "specified on construction, or in the measurement, then error "
             "will be thrown.")
-    alpha = Property(
-        float,
+    alpha: float = Property(
         default=0.5,
         doc="Primary sigma point spread scaling parameter. Default is 0.5.")
-    beta = Property(
-        float,
+    beta: float = Property(
         default=2,
         doc="Used to incorporate prior knowledge of the distribution. If the "
             "true distribution is Gaussian, the value of 2 is optimal. "
             "Default is 2")
-    kappa = Property(
-        float,
+    kappa: float = Property(
         default=0,
         doc="Secondary spread scaling parameter. Default is calculated as "
             "3-Ns")
@@ -430,9 +424,10 @@ class SqrtKalmanUpdater(KalmanUpdater):
        Journal, 6:6, 1165-1166
 
     """
-    qr_method = Property(bool, default=False, doc="A switch to do the update via a QR"
-                                                  "decomposition, rather than using the (vector"
-                                                  "form of) the Potter method.")
+    qr_method: bool = Property(
+        default=False,
+        doc="A switch to do the update via a QR decomposition, rather than using the (vector form "
+            "of) the Potter method.")
 
     # In this instance the square root form is returned by the :meth:`update()`
     _update_class = SqrtGaussianStateUpdate
@@ -591,17 +586,17 @@ class IteratedKalmanUpdater(ExtendedKalmanUpdater):
     function via the :meth:`_measurement_matrix()` function.
     """
 
-    tolerance = Property(float, default=1e-6,
-                         doc="The value of the difference in the measure used as a stopping "
-                             "criterion.")
-    measure = Property(Measure, default=Euclidean(), doc="The measure to use to test the "
-                                                         "iteration stopping criterion. Defaults "
-                                                         "to the Euclidean distance between "
-                                                         "current and prior posterior state "
-                                                         "estimate.")
-    max_iterations = Property(int, default=1000, doc="Number of iterations before while loop is"
-                                                     "exited and a non-convergence warning is "
-                                                     "returned")
+    tolerance: float = Property(
+        default=1e-6,
+        doc="The value of the difference in the measure used as a stopping criterion.")
+    measure: Measure = Property(
+        default=Euclidean(),
+        doc="The measure to use to test the iteration stopping criterion. Defaults to the "
+            "Euclidean distance between current and prior posterior state estimate.")
+    max_iterations: int = Property(
+        default=1000,
+        doc="Number of iterations before while loop is exited and a non-convergence warning is "
+            "returned")
 
     def update(self, hypothesis, **kwargs):
         r"""The iterated Kalman update method. Given a hypothesised association between a predicted

--- a/stonesoup/updater/particle.py
+++ b/stonesoup/updater/particle.py
@@ -16,8 +16,7 @@ class ParticleUpdater(Updater):
         Perform measurement update step in the standard Kalman Filter.
         """
 
-    resampler = Property(Resampler,
-                         doc='Resampler to prevent particle degeneracy')
+    resampler: Resampler = Property(doc='Resampler to prevent particle degeneracy')
 
     def update(self, hypothesis, **kwargs):
         """Particle Filter update step

--- a/stonesoup/updater/pointprocess.py
+++ b/stonesoup/updater/pointprocess.py
@@ -18,29 +18,20 @@ class PointProcessUpdater(Base):
     Cardinalised Probability Hypothesis Density (CPHD) or
     Linear Complexity with Cumulants (LCC) filters
     """
-    updater = Property(
-        KalmanUpdater,
+    updater: KalmanUpdater = Property(
         doc="Underlying updater used to perform the \
              single target Kalman Update.")
-
-    clutter_spatial_density = Property(
-        float,
+    clutter_spatial_density: float = Property(
         default=1e-26,
         doc="Spatial density of the clutter process uniformly\
              distributed across the state space.")
-
-    normalisation = Property(
-        bool,
+    normalisation: bool = Property(
         default=True,
         doc="Flag for normalisation")
-
-    prob_detection = Property(
-        Probability,
+    prob_detection: Probability = Property(
         default=1,
         doc="Probability of a target being detected at the current timestep")
-
-    prob_survival = Property(
-        Probability,
+    prob_survival: Probability = Property(
         default=1,
         doc="Probability of a target surviving until the next timestep")
 
@@ -159,16 +150,12 @@ class LCCUpdater(PointProcessUpdater):
         Information Fusion (FUSION). 2018. DOI: 10.
         23919/ICIF.2018.8455331. https://ieeexplore.ieee.org/document/8455331..
     """
-    mean_number_of_false_alarms = Property(
-        float,
+    mean_number_of_false_alarms: float = Property(
         default=1,
         doc="Mean number of false alarms (clutter) expected per timestep")
-
-    variance_of_false_alarms = Property(
-        float,
+    variance_of_false_alarms: float = Property(
         default=1,
-        doc="Variance on the number of false alarms (clutter) \
-             expected per timestep")
+        doc="Variance on the number of false alarms (clutter) expected per timestep")
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/stonesoup/writer/base.py
+++ b/stonesoup/writer/base.py
@@ -14,8 +14,7 @@ class MetricsWriter(Writer):
     Writes out metrics to some form of storage for analysis.
     """
 
-    metric_generator = Property(
-        MetricGenerator, doc="Source of metric to be written out")
+    metric_generator: MetricGenerator = Property(doc="Source of metric to be written out")
 
 
 class TrackWriter(Writer):
@@ -24,4 +23,4 @@ class TrackWriter(Writer):
     Writes out tracks to some form of storage for analysis.
     """
 
-    tracker = Property(Tracker, doc="Source of tracks to be written out")
+    tracker: Tracker = Property(doc="Source of tracks to be written out")

--- a/stonesoup/writer/tests/test_yaml.py
+++ b/stonesoup/writer/tests/test_yaml.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-import sys
 from textwrap import dedent
 
 import pytest
@@ -7,11 +6,6 @@ import pytest
 from ..yaml import YAMLWriter
 
 
-dict_order_skip = pytest.mark.skipif(
-    sys.version_info < (3, 6), reason="requires Python >= 3.6 for dict order")
-
-
-@dict_order_skip
 def test_detections_yaml(detection_reader, tmpdir):
     filename = tmpdir.join("detections.yaml")
 
@@ -58,7 +52,6 @@ def test_detections_yaml(detection_reader, tmpdir):
     assert generated_yaml == expected_yaml
 
 
-@dict_order_skip
 def test_groundtruth_paths_yaml(groundtruth_reader, tmpdir):
     filename = tmpdir.join("groundtruth_paths.yaml")
 
@@ -92,7 +85,6 @@ def test_groundtruth_paths_yaml(groundtruth_reader, tmpdir):
     assert generated_yaml == expected_yaml
 
 
-@dict_order_skip
 def test_tracks_yaml(tracker, tmpdir):
     filename = tmpdir.join("tracks.yaml")
 

--- a/stonesoup/writer/yaml.py
+++ b/stonesoup/writer/yaml.py
@@ -10,12 +10,11 @@ from .base import Writer
 
 class YAMLWriter(Writer):
     """YAML Writer"""
-    path = Property(Path,
-                    doc="File to save data to. Str will be converted to Path")
-    groundtruth_source = Property(GroundTruthReader, default=None)
-    sensor_data_source = Property(SensorDataReader, default=None)
-    detections_source = Property(DetectionReader, default=None)
-    tracks_source = Property(Tracker, default=None)
+    path: Path = Property(doc="File to save data to. Str will be converted to Path")
+    groundtruth_source: GroundTruthReader = Property(default=None)
+    sensor_data_source: SensorDataReader = Property(default=None)
+    detections_source: DetectionReader = Property(default=None)
+    tracks_source: Tracker = Property(default=None)
 
     def __init__(self, path, *args, **kwargs):
         if not isinstance(path, Path):


### PR DESCRIPTION
This overall doesn't change behaviour of the code or how Properties on classes are defined, but enabled type hints to be used instead. At the moment, this change is backwards compatible.

This is useful to aid IDE's, using more familiar syntax for typing, and possibly allow future use for type checking.