### PR TITLE
Cast array type of StateVector when slicing

### DIFF
--- a/stonesoup/types/array.py
+++ b/stonesoup/types/array.py
@@ -70,6 +70,9 @@ class StateVector(Matrix):
 
     Note that code using the pattern `my_state_vector[1, 0]` will continue to work.
 
+    When slicing would result in return of a invalid shape for a StateVector (i.e. not `(n, 1)`)
+    then a :class:`~.Matrix` view will be returned.
+
     .. note ::
         It is not recommended to use a StateVector for indexing another vector. Doing so will lead
         to unexpected effects. Use a :class:`tuple`, :class:`list` or :class:`np.ndarray` for this.
@@ -100,7 +103,8 @@ class StateVector(Matrix):
         #   i.e. isinstance(np.array([1]), int) == True
         if isinstance(item, int):
             item = (item, 0)
-        return super().__getitem__(item)
+        # Cast here, so StateVector isn't returned with invalid shape (e.g. (n, ))
+        return self._cast(super().__getitem__(item))
 
     def __setitem__(self, key, value):
         if isinstance(key, int):

--- a/stonesoup/types/tests/test_array.py
+++ b/stonesoup/types/tests/test_array.py
@@ -31,15 +31,18 @@ def test_standard_statevector_indexing():
 
     # test Slicing
     assert state_vector[1:2, 0] == 2
-    assert isinstance(state_vector[1:2, 0], StateVector)
+    assert isinstance(state_vector[1:2, 0], Matrix)  # (n,)
+    assert isinstance(state_vector[1:2, :], StateVector)  # (n, 1)
     assert np.array_equal(state_vector[:], state_vector)
-    assert isinstance(state_vector[:, 0], StateVector)
+    assert isinstance(state_vector[:, 0], Matrix)  # (n,)
+    assert isinstance(state_vector[:, :], StateVector)  # (n, 1)
     assert np.array_equal(state_vector[0:], state_vector)
-    assert isinstance(state_vector[0:, 0], StateVector)
+    assert isinstance(state_vector[0:, 0], Matrix)  # (n,)
+    assert isinstance(state_vector[0:, :], StateVector)  # (n, 1)
 
     # test list indices
     assert np.array_equal(state_vector[[1, 3]], StateVector([2, 4]))
-    assert isinstance(state_vector[[1, 3], 0], StateVector)
+    assert isinstance(state_vector[[1, 3], 0], Matrix)
 
     # test int indexing
     assert state_vector[2] == 3


### PR DESCRIPTION
This means that a StateVector of an invalid shape can't be returned e.g. `(n, )`, where subsequent calls of `invalid_state_vector[n]` would raise error as this would attempt `invalid_state_vector[n, 0]`.