### PR TITLE
Platform state mutable

### DIFF
--- a/docs/source/stonesoup.platform.rst
+++ b/docs/source/stonesoup.platform.rst
@@ -7,7 +7,3 @@ Platforms
 .. automodule:: stonesoup.platform.base
     :show-inheritance:
 
-.. automodule:: stonesoup.platform.simple
-    :show-inheritance:
-
-

--- a/stonesoup/platform/base.py
+++ b/stonesoup/platform/base.py
@@ -37,10 +37,12 @@ class Platform(StateMutableSequence, ABC):
             :class:`~.MovingPlatform`
 
         """
-    states = Property([State], doc="The platform state at any given point. For a static platform,"
-                                   " this would usually contain its position coordinates in the "
-                                   "form ``[x, y, z]``. For a moving platform it would contain "
-                                   "position and velocity interleaved: ``[x, vx, y, vy, z, vz]``")
+    states = Property([State], doc="A list of States which enables the platform's history to be "
+                                   "accessed in simulators and for plotting. Initiated as a "
+                                   "state, for a static platform, this would usually contain its "
+                                   "position coordinates in the form ``[x, y, z]``. For a moving "
+                                   "platform it would contain position and velocity interleaved: "
+                                   "``[x, vx, y, vy, z, vz]``")
     position_mapping = Property(Sequence[int],
                                 doc="Mapping between platform position and state vector. For a "
                                     "position-only 3d platform this might be ``[0, 1, 2]``. For a "

--- a/stonesoup/platform/tests/test_platform_base.py
+++ b/stonesoup/platform/tests/test_platform_base.py
@@ -543,7 +543,7 @@ def test_multi_transition():
     assert len(platform.transition_models) == 2
     assert len(platform.transition_times) == 2
 
-    #  Check that platform states lenght increases as platform moves
+    #  Check that platform states length increases as platform moves
     assert len(platform) == 1
     time = datetime.datetime.now()
     time += datetime.timedelta(seconds=1)

--- a/stonesoup/platform/tests/test_platform_base.py
+++ b/stonesoup/platform/tests/test_platform_base.py
@@ -22,7 +22,7 @@ def test_base():
     platform_state2d = State(np.array([[2],
                                        [2]]),
                              timestamp)
-    platform = FixedPlatform(state=platform_state2d, position_mapping=np.array([0, 1]))
+    platform = FixedPlatform(states=platform_state2d, position_mapping=np.array([0, 1]))
     platform.move(new_timestamp)
     new_statevector = np.array([[2],
                                 [2]])
@@ -39,7 +39,7 @@ def test_base():
                                        [2],
                                        [2]]),
                              timestamp)
-    platform = FixedPlatform(state=platform_state3d, position_mapping=[0, 1, 2])
+    platform = FixedPlatform(states=platform_state3d, position_mapping=[0, 1, 2])
     platform.move(new_timestamp)
     new_statevector = np.array([[2],
                                 [2],
@@ -61,7 +61,7 @@ def test_base():
                                        [2],
                                        [1]]),
                              timestamp)
-    platform = MovingPlatform(state=platform_state2d, transition_model=model_2d,
+    platform = MovingPlatform(states=platform_state2d, transition_model=model_2d,
                               position_mapping=[0, 2])
     platform.move(new_timestamp)
 
@@ -87,7 +87,7 @@ def test_base():
                                      [0],
                                      [1]]),
                            timestamp)
-    platform = MovingPlatform(state=platform_state, transition_model=model_3d,
+    platform = MovingPlatform(states=platform_state, transition_model=model_3d,
                               position_mapping=[0, 2, 4])
     platform.move(new_timestamp)
 
@@ -116,7 +116,7 @@ def test_add_sensor(class_):
     platform_args = {'transition_model': None} if class_ is MovingPlatform else {}
 
     sensor = DummySensor()
-    platform = class_(state=platform_state, position_mapping=[0, 2, 4],
+    platform = class_(states=platform_state, position_mapping=[0, 2, 4],
                       **platform_args)
     platform.add_sensor(sensor)
     assert (len(platform.mounting_offsets) == 1
@@ -151,7 +151,7 @@ def test_velocity_properties(velocity_mapping):
                                      [0],
                                      [0]]),
                            timestamp)
-    platform = MovingPlatform(state=platform_state, transition_model=model_3d,
+    platform = MovingPlatform(states=platform_state, transition_model=model_3d,
                               position_mapping=[0, 2, 4])
     old_position = platform.position
     assert not platform.is_moving
@@ -172,7 +172,7 @@ def test_velocity_properties(velocity_mapping):
                                      [0],
                                      [1]]),
                            timestamp)
-    platform = MovingPlatform(state=platform_state, transition_model=None,
+    platform = MovingPlatform(states=platform_state, transition_model=None,
                               position_mapping=[0, 2, 4])
     assert platform.is_moving
     assert np.array_equal(platform.velocity, StateVector([1, 1, 1]))
@@ -189,7 +189,7 @@ def test_velocity_properties(velocity_mapping):
                                      [2],
                                      [0]]),
                            timestamp)
-    platform = MovingPlatform(state=platform_state, transition_model=None,
+    platform = MovingPlatform(states=platform_state, transition_model=None,
                               position_mapping=[0, 2, 4])
     with pytest.raises(AttributeError):
         _ = platform.velocity
@@ -202,7 +202,7 @@ def test_velocity_properties(velocity_mapping):
                                      [0],
                                      [1]]),
                            timestamp)
-    platform = MovingPlatform(state=platform_state, transition_model=None,
+    platform = MovingPlatform(states=platform_state, transition_model=None,
                               position_mapping=[0, 2, 4], velocity_mapping=velocity_mapping)
     assert platform.is_moving
     assert np.array_equal(platform.velocity, StateVector([1, 1, 1]))
@@ -220,7 +220,7 @@ def test_velocity_properties(velocity_mapping):
                                      [0]]),
                            timestamp)
 
-    platform = MovingPlatform(state=platform_state, transition_model=None,
+    platform = MovingPlatform(states=platform_state, transition_model=None,
                               position_mapping=[0, 2, 4], velocity_mapping=velocity_mapping)
     with pytest.raises(AttributeError):
         _ = platform.velocity
@@ -230,13 +230,13 @@ def test_orientation_dimensionality_error():
     platform_state = State(StateVector([2, 1, 1, 1, 2, 0, 1, 0]),
                            timestamp=datetime.datetime.now())
 
-    platform = MovingPlatform(state=platform_state, position_mapping=[0, 1, 2, 3],
+    platform = MovingPlatform(states=platform_state, position_mapping=[0, 1, 2, 3],
                               transition_model=None)
 
     with pytest.raises(ValueError):
         _ = platform.orientation
 
-    platform = MovingPlatform(state=platform_state, position_mapping=[0], transition_model=None)
+    platform = MovingPlatform(states=platform_state, position_mapping=[0], transition_model=None)
 
     with pytest.raises(ValueError):
         _ = platform.orientation
@@ -247,7 +247,7 @@ def test_moving_with_no_initial_timestamp():
     platform_state = State(StateVector([2, 1, 1, 1, 2, 0]),
                            timestamp=None)
 
-    platform = MovingPlatform(state=platform_state, position_mapping=[0, 2, 4],
+    platform = MovingPlatform(states=platform_state, position_mapping=[0, 2, 4],
                               transition_model=None)
 
     assert platform.timestamp is None
@@ -286,7 +286,7 @@ def test_platform_orientation_3d(state, orientation):
     new_timestamp = timestamp + datetime.timedelta(seconds=timediff)
 
     platform_state = State(state, timestamp)
-    platform = MovingPlatform(state=platform_state, transition_model=model_3d,
+    platform = MovingPlatform(states=platform_state, transition_model=model_3d,
                               position_mapping=[0, 2, 4])
     assert np.allclose(platform.orientation, orientation)
     # moving with a constant velocity model should not change the orientation
@@ -317,7 +317,7 @@ def test_platform_orientation_2d(state, orientation):
     new_timestamp = timestamp + datetime.timedelta(seconds=timediff)
 
     platform_state = State(state, timestamp)
-    platform = MovingPlatform(state=platform_state, transition_model=model_2d,
+    platform = MovingPlatform(states=platform_state, transition_model=model_2d,
                               position_mapping=[0, 2])
     assert np.allclose(platform.orientation, orientation)
     # moving with a constant velocity model should not change the orientation
@@ -332,7 +332,7 @@ def test_orientation_error():
                                      [2],
                                      [0]]),
                            timestamp)
-    platform = MovingPlatform(state=platform_state, transition_model=None,
+    platform = MovingPlatform(states=platform_state, transition_model=None,
                               position_mapping=[0, 1, 2])
     with pytest.raises(AttributeError):
         _ = platform.orientation
@@ -343,7 +343,7 @@ def test_orientation_error():
                                      [2],
                                      [0]]),
                            timestamp)
-    platform = MovingPlatform(state=platform_state, transition_model=None,
+    platform = MovingPlatform(states=platform_state, transition_model=None,
                               position_mapping=[0, 2, 4])
     with pytest.raises(AttributeError):
         _ = platform.orientation
@@ -353,7 +353,9 @@ def test_orientation_error():
                                      [2],
                                      [0]]),
                            timestamp)
-    platform = MovingPlatform(state=platform_state, transition_model=None, position_mapping=[0, 2])
+    platform = MovingPlatform(states=platform_state,
+                              transition_model=None,
+                              position_mapping=[0, 2])
     with pytest.raises(AttributeError):
         _ = platform.orientation
 
@@ -369,7 +371,7 @@ def test_setting_position():
     model_3d = CombinedLinearGaussianTransitionModel(
         [model_1d, model_1d, model_1d])
 
-    platform = MovingPlatform(state=platform_state, transition_model=model_3d,
+    platform = MovingPlatform(states=platform_state, transition_model=model_3d,
                               position_mapping=[0, 1, 2])
     with pytest.raises(AttributeError):
         platform.position = [0, 0, 0]
@@ -380,7 +382,7 @@ def test_setting_position():
                                      [2],
                                      [0]]),
                            timestamp)
-    platform = MovingPlatform(state=platform_state, transition_model=None,
+    platform = MovingPlatform(states=platform_state, transition_model=None,
                               position_mapping=[0, 1, 2])
     assert np.array_equal(platform.position, StateVector([2, 2, 0]))
     platform.position = StateVector([0, 0, 0])
@@ -392,7 +394,7 @@ def test_setting_position():
                                      [2],
                                      [0]]),
                            timestamp)
-    platform = FixedPlatform(state=platform_state, position_mapping=[0, 1, 2])
+    platform = FixedPlatform(states=platform_state, position_mapping=[0, 1, 2])
     assert np.array_equal(platform.position, StateVector([2, 2, 0]))
     platform.position = StateVector([0, 0, 0])
     assert np.array_equal(platform.position, StateVector([0, 0, 0]))
@@ -408,7 +410,7 @@ def test_setting_position():
                                      [2],
                                      [0]]),
                            timestamp)
-    platform = MovingPlatform(state=platform_state, transition_model=model_3d,
+    platform = MovingPlatform(states=platform_state, transition_model=model_3d,
                               position_mapping=[0, 2, 4])
     with pytest.raises(AttributeError):
         platform.position = [0, 0, 0]
@@ -420,7 +422,7 @@ def test_setting_position():
                                      [2],
                                      [0]]),
                            timestamp)
-    platform = FixedPlatform(state=platform_state, position_mapping=[0, 2, 4])
+    platform = FixedPlatform(states=platform_state, position_mapping=[0, 2, 4])
     assert np.array_equal(platform.position, StateVector([2, 2, 2]))
     platform.position = StateVector([0, 0, 1])
     assert np.array_equal(platform.position, StateVector([0, 0, 1]))
@@ -436,7 +438,7 @@ def test_setting_position():
                                      [2],
                                      [0]]),
                            timestamp)
-    platform = MovingPlatform(state=platform_state, transition_model=None,
+    platform = MovingPlatform(states=platform_state, transition_model=None,
                               position_mapping=[0, 2, 4])
     assert np.array_equal(platform.position, StateVector([2, 2, 2]))
     platform.position = StateVector([0, 0, 1])
@@ -454,7 +456,7 @@ def test_setting_orientation():
                                      [2],
                                      [0]]),
                            timestamp)
-    platform = MovingPlatform(state=platform_state, transition_model=None,
+    platform = MovingPlatform(states=platform_state, transition_model=None,
                               position_mapping=[0, 1, 2])
     with pytest.raises(AttributeError):
         platform.orientation = [0, 0, 0]
@@ -464,7 +466,7 @@ def test_setting_orientation():
                                      [0]]),
                            timestamp)
     platform_orientation = StateVector([0, 0, 0])
-    platform = FixedPlatform(state=platform_state, position_mapping=[0, 1, 2],
+    platform = FixedPlatform(states=platform_state, position_mapping=[0, 1, 2],
                              orientation=platform_orientation)
     assert np.array_equal(platform.orientation, StateVector([0, 0, 0]))
     platform.orientation = StateVector([0, 1, 0])
@@ -477,7 +479,7 @@ def test_setting_orientation():
                                      [2],
                                      [0]]),
                            timestamp)
-    platform = MovingPlatform(state=platform_state, transition_model=None,
+    platform = MovingPlatform(states=platform_state, transition_model=None,
                               position_mapping=[0, 1, 2])
     with pytest.raises(AttributeError):
         platform.orientation = [0, 0]
@@ -490,7 +492,7 @@ def test_setting_orientation():
                                      [0]]),
                            timestamp)
     platform_orientation = StateVector([0, 0, 0])
-    platform = FixedPlatform(state=platform_state, position_mapping=[0, 2, 4],
+    platform = FixedPlatform(states=platform_state, position_mapping=[0, 2, 4],
                              orientation=platform_orientation)
     assert np.array_equal(platform.orientation, StateVector([0, 0, 0]))
     platform.orientation = StateVector([0, 1, 0])
@@ -504,7 +506,7 @@ def test_mapping_types(mapping_type):
                                      [2],
                                      [0]]),
                            timestamp)
-    platform = FixedPlatform(state=platform_state, position_mapping=mapping_type([0, 1, 2]))
+    platform = FixedPlatform(states=platform_state, position_mapping=mapping_type([0, 1, 2]))
     assert np.array_equal(platform.position, StateVector([2, 2, 0]))
     platform.position = StateVector([0, 0, 1])
     assert np.array_equal(platform.position, StateVector([0, 0, 1]))
@@ -516,7 +518,7 @@ def test_mapping_types(mapping_type):
                                      [2],
                                      [0]]),
                            timestamp)
-    platform = MovingPlatform(state=platform_state, transition_model=None,
+    platform = MovingPlatform(states=platform_state, transition_model=None,
                               position_mapping=mapping_type([0, 2, 4]))
     assert np.array_equal(platform.position, StateVector([2, 2, 2]))
     assert np.array_equal(platform.velocity, StateVector([1, -1, 0]))
@@ -534,19 +536,32 @@ def test_multi_transition():
 
     platform = MultiTransitionMovingPlatform(transition_models=transition_models,
                                              transition_times=transition_times,
-                                             state=platform_state,
+                                             states=platform_state,
                                              position_mapping=[0, 2],
                                              sensors=None)
 
     assert len(platform.transition_models) == 2
     assert len(platform.transition_times) == 2
 
-    px, py = platform.position[0], platform.position[1]
+    #  Check that platform states lenght increases as platform moves
+    assert len(platform) == 1
     time = datetime.datetime.now()
+    time += datetime.timedelta(seconds=1)
+    platform.move(timestamp=time)
+    assert len(platform) == 2
+    time += datetime.timedelta(seconds=1)
+    platform.move(timestamp=time)
+    assert len(platform) == 3
+    time += datetime.timedelta(seconds=1)
+    platform.move(timestamp=time)
+    assert len(platform) == 4
+
+    px, py = platform.position[0], platform.position[1]
+
     # Starting transition model is index 0
     assert platform.transition_index == 0
 
-    time += datetime.timedelta(seconds=10)
+    time += datetime.timedelta(seconds=7)
     platform.move(timestamp=time)
     x, y = platform.position[0], platform.position[1]
     # Platform initially moves horizontally

--- a/stonesoup/platform/tests/test_platform_simple.py
+++ b/stonesoup/platform/tests/test_platform_simple.py
@@ -328,7 +328,7 @@ def test_2d_platform(state, expected, move, radars_2d,
     # create a platform with the simple radar mounted
     if add_sensor:
         platform = MovingPlatform(
-            state=platform_state,
+            states=platform_state,
             transition_model=trans_model,
             sensors=[],
             mounting_offsets=[],
@@ -338,7 +338,7 @@ def test_2d_platform(state, expected, move, radars_2d,
             platform.add_sensor(sensor, offset)
     else:
         platform = MovingPlatform(
-            state=platform_state,
+            states=platform_state,
             transition_model=trans_model,
             sensors=radars_2d,
             mounting_offsets=mounting_offsets_2d,
@@ -397,7 +397,7 @@ def test_3d_platform(state, expected, move, radars_3d, mounting_offsets_3d,
     # create a platform with the simple radar mounted
     if add_sensor:
         platform = MovingPlatform(
-            state=platform_state,
+            states=platform_state,
             transition_model=trans_model,
             sensors=[],
             mounting_offsets=[],
@@ -407,7 +407,7 @@ def test_3d_platform(state, expected, move, radars_3d, mounting_offsets_3d,
             platform.add_sensor(sensor, offset)
     else:
         platform = MovingPlatform(
-            state=platform_state,
+            states=platform_state,
             transition_model=trans_model,
             sensors=radars_3d,
             mounting_offsets=mounting_offsets_3d,
@@ -531,7 +531,7 @@ def test_rotation_offsets_2d(state, expected_platform_orientation, expected_sens
     mounting_mapping = np.array([0, 2])
     # create a platform with the simple radar mounted
     platform = MovingPlatform(
-        state=platform_state,
+        states=platform_state,
         transition_model=trans_model,
         sensors=radars_2d,
         rotation_offsets=rotation_offsets_2d,
@@ -561,7 +561,7 @@ def test_rotation_offsets_3d(state, expected_platform_orientation, expected_sens
     mounting_mapping = np.array([0, 2, 4])
     # create a platform with the simple radar mounted
     platform = MovingPlatform(
-        state=platform_state,
+        states=platform_state,
         transition_model=trans_model,
         sensors=radars_3d,
         rotation_offsets=rotation_offsets_3d,
@@ -593,12 +593,12 @@ def test_defaults(radars_3d, platform_type, add_sensor):
         platform_args['transition_model'] = None
 
     if add_sensor:
-        platform = platform_type(state=platform_state, sensors=[], position_mapping=[0, 2, 4],
+        platform = platform_type(states=platform_state, sensors=[], position_mapping=[0, 2, 4],
                                  **platform_args)
         for sensor in radars_3d:
             platform.add_sensor(sensor)
     else:
-        platform = platform_type(state=platform_state, sensors=radars_3d,
+        platform = platform_type(states=platform_state, sensors=radars_3d,
                                  position_mapping=[0, 2, 4], **platform_args)
 
     for i, sensor in enumerate(radars_3d):
@@ -619,11 +619,11 @@ def test_sensor_offset_error(radars_3d, platform_type):
 
     offsets = [offset] * (len(radars_3d) - 1)
     with pytest.raises(ValueError):
-        _ = platform_type(state=platform_state, sensors=radars_3d, position_mapping=[0, 2, 4],
+        _ = platform_type(states=platform_state, sensors=radars_3d, position_mapping=[0, 2, 4],
                           mounting_offsets=offsets, **platform_args)
 
     with pytest.raises(ValueError):
-        _ = platform_type(state=platform_state, sensors=radars_3d, position_mapping=[0, 2, 4],
+        _ = platform_type(states=platform_state, sensors=radars_3d, position_mapping=[0, 2, 4],
                           rotation_offsets=offsets, **platform_args)
 
 
@@ -635,7 +635,7 @@ def test_missing_sensors(radars_3d, platform_type):
         platform_args['transition_model'] = None
 
     # add all but the last sensor
-    platform = platform_type(state=platform_state, sensors=radars_3d[:-2],
+    platform = platform_type(states=platform_state, sensors=radars_3d[:-2],
                              position_mapping=[0, 2, 4], **platform_args)
 
     # finding the position/orientation of a sensor that is not on the platform

--- a/stonesoup/sensor/sensor.py
+++ b/stonesoup/sensor/sensor.py
@@ -33,7 +33,7 @@ class Sensor(BaseSensor, ABC):
             if orientation is None:
                 orientation = StateVector([0, 0, 0])
             self._internal_platform = FixedPlatform(
-                state=State(state_vector=position),
+                states=State(state_vector=position),
                 position_mapping=list(range(len(position))),
                 orientation=orientation,
                 sensors=[self])

--- a/stonesoup/sensor/tests/test_sensor.py
+++ b/stonesoup/sensor/tests/test_sensor.py
@@ -33,7 +33,7 @@ def test_sensor_position_orientation_setting():
     position = StateVector([0, 0, 1])
     sensor = DummySensor()
     platform_state = State(state_vector=position + 1, timestamp=datetime.datetime.now())
-    platform = FixedPlatform(state=platform_state, position_mapping=[0, 1, 2])
+    platform = FixedPlatform(states=platform_state, position_mapping=[0, 1, 2])
     platform.add_sensor(sensor)
     with pytest.raises(AttributeError):
         sensor.position = StateVector([0, 1, 0])
@@ -44,8 +44,8 @@ def test_sensor_position_orientation_setting():
 def test_warning_on_moving_sensor():
     sensor = DummySensor()
     platform_state = State(StateVector([0, 1, 0]), timestamp=datetime.datetime.now())
-    platform1 = FixedPlatform(state=platform_state, position_mapping=[0, 1, 2])
-    platform2 = FixedPlatform(state=platform_state, position_mapping=[0, 1, 2])
+    platform1 = FixedPlatform(states=platform_state, position_mapping=[0, 1, 2])
+    platform2 = FixedPlatform(states=platform_state, position_mapping=[0, 1, 2])
     platform1.add_sensor(sensor)
     with pytest.warns(UserWarning):
         platform2.add_sensor(sensor)
@@ -77,7 +77,7 @@ def test_changing_platform_from_default():
     sensor = DummySensor(position=StateVector([0, 0, 1]))
 
     platform_state = State(state_vector=position+1, timestamp=datetime.datetime.now())
-    platform = FixedPlatform(state=platform_state, position_mapping=[0, 1, 2])
+    platform = FixedPlatform(states=platform_state, position_mapping=[0, 1, 2])
     with pytest.raises(AttributeError):
         platform.add_sensor(sensor)
 

--- a/stonesoup/simulator/simple.py
+++ b/stonesoup/simulator/simple.py
@@ -232,7 +232,7 @@ class DummyGroundTruthSimulator(GroundTruthSimulator):
      It returns an empty set at each time step.
     """
 
-    times = Property([datetime], doc='list to times to return')
+    times = Property([datetime.datetime], doc='list to times to return')
 
     @BufferedGenerator.generator_method
     def groundtruth_paths_gen(self):

--- a/stonesoup/simulator/simple.py
+++ b/stonesoup/simulator/simple.py
@@ -223,3 +223,18 @@ class SwitchDetectionSimulator(SimpleDetectionSimulator):
     @property
     def detection_probability(self):
         return self.detection_probabilities[self.index]
+
+
+class DummyGroundTruthSimulator(GroundTruthSimulator):
+    """A Dummy Ground Truth Simulator which allows simulations to be built
+     where platform, rather than ground truth objects, motions are simulated.
+
+     It returns an empty set at each time step.
+    """
+
+    times = Property([datetime], doc='list to times to return')
+
+    @BufferedGenerator.generator_method
+    def groundtruth_paths_gen(self):
+        for time in self.times:
+            yield time, set()

--- a/stonesoup/simulator/simple.py
+++ b/stonesoup/simulator/simple.py
@@ -232,7 +232,7 @@ class DummyGroundTruthSimulator(GroundTruthSimulator):
      It returns an empty set at each time step.
     """
 
-    times = Property([datetime.datetime], doc='list to times to return')
+    times = Property([datetime.datetime], doc='list of times to return')
 
     @BufferedGenerator.generator_method
     def groundtruth_paths_gen(self):

--- a/stonesoup/simulator/tests/test_platform.py
+++ b/stonesoup/simulator/tests/test_platform.py
@@ -19,7 +19,7 @@ def build_platform(sensors, x_velocity):
     trans_model = CombinedLinearGaussianTransitionModel([model_1d] * 2)
     mounting_offsets = np.zeros((len(sensors), 2))
     position_mapping = np.array([[0, 2]])
-    platform = MovingPlatform(state=state, sensors=sensors,
+    platform = MovingPlatform(states=state, sensors=sensors,
                               transition_model=trans_model,
                               mounting_offsets=mounting_offsets,
                               position_mapping=position_mapping)


### PR DESCRIPTION
This merge changes the state property within the Platform object to be a StateMutableSequence rather than an individual State. All original behaviours remain the same however Platforms now maintain history of States. 

This has application in simulations, plotting and metric assessment (when using platforms rather than ground truth simulations). A Dummy simulation class has also been added which returns an empty set, this can be used in conjunction with the PlatformDetectionSimulator to produce simulations with only defined platform objects. 