### PR TITLE
Modify Angle type average to use numpy.sum()

### DIFF
--- a/stonesoup/types/angle.py
+++ b/stonesoup/types/angle.py
@@ -6,7 +6,6 @@ from math import trunc, ceil, floor
 import numpy as np
 
 from ..functions import mod_bearing, mod_elevation
-from .numeric import Probability
 
 
 class Angle(Real):
@@ -158,7 +157,7 @@ class Angle(Real):
             weight_sum = 1
             weights = 1
         else:
-            weight_sum = Probability.sum(weights)
+            weight_sum = np.sum(weights)
 
         result = np.arctan2(
             float(np.sum(np.sin(angles) * weights) / weight_sum),


### PR DESCRIPTION
Use of `Probability.sum()` can cause issues with negative weights, and also is different sum method in default `numpy.average` method used for non-Angle types in the state vector (so chance sum could be different when near zero weights present).