### PR TITLE
Add dynamic UTM

### DIFF
--- a/docs/source/stonesoup.hypothesiser.rst
+++ b/docs/source/stonesoup.hypothesiser.rst
@@ -19,3 +19,8 @@ Probability
 .. automodule:: stonesoup.hypothesiser.probability
     :show-inheritance:
 
+Geo
+---
+
+.. automodule:: stonesoup.hypothesiser.geo
+    :show-inheritance:

--- a/stonesoup/feeder/geo.py
+++ b/stonesoup/feeder/geo.py
@@ -103,9 +103,10 @@ class LongLatToUTMConverter(Feeder):
             "zone based on the first detection if :attr:`dynamic` isn't set.")
     dynamic = Property(
         bool, default=False,
-        doc="In dynamic mode, each detection will be put into the UTM zone that it belongs, rather"
-            "than being assigned to the same zone. The `utm_zone` will be added to the detections"
-            "metadata. Default `False`.")
+        doc="In dynamic mode, each detection will be put into the UTM zone that it belongs, "
+            "rather than being assigned to the same zone. The `utm_zone` will be added to the "
+            "detections metadata. This is designed to be used in conjunction with the "
+            ":class:`~.DynamicUTMHypothesiserWrapper`. Default `False`.")
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/stonesoup/feeder/geo.py
+++ b/stonesoup/feeder/geo.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-import warnings
+import copy
 from abc import abstractmethod
 
 import utm
@@ -95,12 +95,22 @@ class LongLatToUTMConverter(Feeder):
         doc="Indexes of long, lat. Default (0, 1)")
     zone_number = Property(
         int, default=None,
-        doc="UTM zone number to carry out conversion. Default `None`, where it"
-            "will select the zone based on the first detection.")
-    northern = Property(
-        bool, default=None,
-        doc="UTM northern for northern or southern grid. Default `None`, where"
-            "it will be base on the first detection.")
+        doc="UTM zone number to carry out conversion. Default `None`, where it will select the "
+            "zone based on the first detection if :attr:`dynamic` isn't set.")
+    zone_letter = Property(
+        str, default=None,
+        doc="UTM zone letter to carry out conversion. Default `None`, where it will select the "
+            "zone based on the first detection if :attr:`dynamic` isn't set.")
+    dynamic = Property(
+        bool, default=False,
+        doc="In dynamic mode, each detection will be put into the UTM zone that it belongs, rather"
+            "than being assigned to the same zone. The `utm_zone` will be added to the detections"
+            "metadata. Default `False`.")
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if self.dynamic and (self.zone_number or self.zone_letter):
+            raise ValueError("Cannot have both dynamic and fixed zone")
 
     @BufferedGenerator.generator_method
     def detections_gen(self):
@@ -108,25 +118,22 @@ class LongLatToUTMConverter(Feeder):
 
             utm_detections = set()
             for detection in detections:
-                easting, northing, zone_num, northern = utm.from_latlon(
+                easting, northing, zone_number, zone_letter = utm.from_latlon(
                     *detection.state_vector[self.mapping[::-1], :],
-                    self.zone_number)
-                if self.zone_number is None:
-                    self.zone_number = zone_num
-                if self.northern is None:
-                    self.northern = northern >= 'N'
-                elif (self.northern and northern < 'N') or (
-                            not self.northern and northern >= 'N'):
-                    warnings.warn("Detection cannot be converted to UTM zone")
-                    continue
+                    self.zone_number, self.zone_letter)
+                if self.zone_number is None and not self.dynamic:
+                    self.zone_number = zone_number
+                if self.zone_letter is None and not self.dynamic:
+                    self.zone_letter = zone_letter
 
-                state_vector = detection.state_vector.copy()
-                state_vector[self.mapping, 0] = easting, northing
-                utm_detections.add(
-                    Detection(
-                        state_vector,
-                        timestamp=detection.timestamp,
-                        measurement_model=detection.measurement_model,
-                        metadata=detection.metadata))
+                utm_detection = copy.copy(detection)
+                # Update state vector
+                utm_detection.state_vector = detection.state_vector.copy()
+                utm_detection.state_vector[self.mapping, 0] = easting, northing
+                # Add meta data
+                utm_detection.metadata = detection.metadata.copy()
+                utm_detection.metadata['utm_zone'] = (zone_number, zone_letter)
+
+                utm_detections.add(utm_detection)
 
             yield time, utm_detections

--- a/stonesoup/feeder/tests/test_geo.py
+++ b/stonesoup/feeder/tests/test_geo.py
@@ -16,7 +16,7 @@ def detector():
         @BufferedGenerator.generator_method
         def detections_gen(self):
             for i in range(-3, 4):
-                detections = {Detection([[i], [50], [5000 + i*10]])}
+                detections = {Detection([[i], [50 + i], [5000 + i*10]])}
                 yield None, detections
 
     return Detector()
@@ -31,10 +31,12 @@ def detector():
 def test_lla_reference_converter(detector, converter_class, reverse_func):
     converter = converter_class(detector, reference_point=(0, 50, 5000))
 
-    for i, (time, detections) in zip(range(-3, 4), converter):
+    for long, (time, detections) in enumerate(converter, -3):
         detection = detections.pop()
+        lat = 50 + long
+        alt = 5000 + long * 10
 
-        assert pytest.approx((50, i, 5000 + i*10), abs=1e-2, rel=1e-3) == \
+        assert pytest.approx((lat, long, alt), abs=1e-2, rel=1e-3) == \
             reverse_func(*detection.state_vector, 50, 0, 5000)
 
 
@@ -43,15 +45,76 @@ def test_utm_converter(detector):
 
     p_east = float('-inf')
     assert converter.zone_number is None
+    assert converter.zone_letter is None
 
-    for long, (time, detections) in zip(range(-3, 4), converter):
+    for long, (time, detections) in enumerate(converter, -3):
         detection = detections.pop()
+        lat = 50 + long
 
         assert converter.zone_number == 30
-        assert converter.northern
+        assert converter.zone_letter == 'T'
+        assert detection.metadata['utm_zone'] == (30, 'T')
 
         assert p_east < detection.state_vector[0]
         p_east = detection.state_vector[0]
 
-        assert pytest.approx((50, long), rel=1e-2, abs=1e-4) == utm.to_latlon(
+        assert pytest.approx((lat, long), rel=1e-2, abs=1e-4) == utm.to_latlon(
             *detection.state_vector[0:2], zone_number=30, northern=True)
+
+
+def test_utm_set_zone(detector):
+    # Note, zone letter doesn't matter unless it's north vs. south of the equator
+    converter = LongLatToUTMConverter(detector, zone_number=31, zone_letter='U')
+
+    p_east = float('-inf')
+    assert converter.zone_number == 31
+    assert converter.zone_letter == 'U'
+
+    for long, (time, detections) in enumerate(converter, -3):
+        detection = detections.pop()
+        lat = 50 + long
+
+        assert converter.zone_number == 31
+        assert converter.zone_letter == 'U'
+        assert detection.metadata['utm_zone'] == (31, 'U')
+
+        assert p_east < detection.state_vector[0]
+        p_east = detection.state_vector[0]
+
+        assert pytest.approx((lat, long), rel=1e-2, abs=1e-4) == utm.to_latlon(
+            *detection.state_vector[0:2], zone_number=31, zone_letter='U', strict=False)
+
+        # Correct zone shouldn't match, as conversion is wrong
+        assert pytest.approx((lat, long)) != utm.to_latlon(
+            *detection.state_vector[0:2], zone_number=30, zone_letter='U', strict=False)
+
+
+def test_utm_converter_dynamic(detector):
+    converter = LongLatToUTMConverter(detector, dynamic=True)
+
+    p_east = float('-inf')
+    assert converter.zone_number is None
+    assert converter.zone_letter is None
+
+    for long, (time, detections) in enumerate(converter, -3):
+        detection = detections.pop()
+        lat = 50 + long
+
+        assert converter.zone_number is None
+        assert converter.zone_letter is None
+        if lat < 48:
+            assert detection.metadata['utm_zone'] == (30, 'T')
+        elif lat < 50:
+            assert detection.metadata['utm_zone'] == (30, 'U')
+        else:  # Long > 0, zone change
+            assert detection.metadata['utm_zone'] == (31, 'U')
+
+        if lat == 50:
+            # Switched zones, so east value will be smaller than previous
+            assert p_east > detection.state_vector[0]
+        else:
+            assert p_east < detection.state_vector[0]
+        p_east = detection.state_vector[0]
+
+        assert pytest.approx((lat, long), rel=1e-2, abs=1e-4) == utm.to_latlon(
+            *detection.state_vector[0:2], *detection.metadata['utm_zone'])

--- a/stonesoup/hypothesiser/geo.py
+++ b/stonesoup/hypothesiser/geo.py
@@ -28,7 +28,7 @@ class DynamicUTMHypothesiserWrapper(Hypothesiser):
 
     def _track_to_utm_zone(self, track, track_zone, detection_zone):
         return Track([self._state_to_utm_northern(
-            track.state, self.utm_mapping,
+            track.state, tuple(self.utm_mapping),
             track_zone[0], track_zone[1] >= 'N', detection_zone[0], detection_zone[1] >= 'N')])
 
     @staticmethod

--- a/stonesoup/hypothesiser/geo.py
+++ b/stonesoup/hypothesiser/geo.py
@@ -1,0 +1,88 @@
+# -*- coding: utf-8 -*-
+import copy
+from functools import lru_cache
+from itertools import groupby
+
+import utm
+
+from .base import Hypothesiser
+from ..base import Property
+from ..types.multihypothesis import MultipleHypothesis
+from ..types.track import Track
+
+
+class DynamicUTMHypothesiserWrapper(Hypothesiser):
+    """Distance hypothesiser aware of UTM zones
+
+    This hypothesiser utilises :attr:`.Track.metadata` and :attr:`.Detection.metadata` `utm_zone`
+    value to translate the :class:`~.Track` to the UTM zone of the :class:`~.Detection`. This will
+    mean the track's state space will change zones over time.
+
+    .. note::
+
+        This currently only works for :class:`~.State` and :class:`~.GaussianState` based states.
+    """
+
+    hypothesiser = Property(Hypothesiser, doc="Hypothesiser that is being wrapped.")
+    utm_mapping = Property((int, int), doc="Mapping of easting and northing")
+
+    def _track_to_utm_zone(self, track, track_zone, detection_zone):
+        return Track([self._state_to_utm_northern(
+            track.state, self.utm_mapping,
+            track_zone[0], track_zone[1] >= 'N', detection_zone[0], detection_zone[1] >= 'N')])
+
+    @staticmethod
+    @lru_cache()
+    def _state_to_utm_northern(
+            state, mapping,
+            track_zone_number, track_northern, detection_zone_number, detection_northern):
+
+        if track_zone_number != detection_zone_number:
+            lat, long = utm.to_latlon(
+                *state.state_vector[mapping, 0], track_zone_number, northern=track_northern)
+            easting, northing, _, _ = utm.from_latlon(
+                lat, long, detection_zone_number, force_northern=track_northern)
+        else:
+            # Same zone number, so not need to convert to lat, lon and back again.
+            easting, northing = state.state_vector[mapping, 0]
+
+        # Add/subtract equator offset for southern if northern value differs
+        northing += 10000000 * (track_northern - detection_northern)
+
+        # Shallow copy is fine...
+        state = copy.copy(state)
+        # as long as we also copy the state vector we are modifying
+        state.state_vector = state.state_vector.copy()
+        state.state_vector[mapping, 0] = easting, northing
+        return state
+
+    @staticmethod
+    def _utm_zone_getter(state):
+        return state.metadata['utm_zone']
+
+    def hypothesise(self, track, detections, timestamp):
+        hypotheses = list()
+
+        track_zone = self._utm_zone_getter(track)
+        track_zone_hit = False
+        for detection_zone, utm_detections in groupby(
+                sorted(detections, key=self._utm_zone_getter), self._utm_zone_getter):
+
+            if track_zone == detection_zone:
+                # Just run with existing track
+                hypotheses.extend(self.hypothesiser.hypothesise(track, utm_detections, timestamp))
+                track_zone_hit = True
+            else:
+                # TODO: Could gate detections out here using zone info
+                # Get track in detections UTM zone
+                utm_track = self._track_to_utm_zone(track, track_zone, detection_zone)
+                utm_hypotheses = self.hypothesiser.hypothesise(
+                    utm_track, utm_detections, timestamp)
+                # Extend with all but missed detection hypotheses
+                hypotheses.extend((hypothesis for hypothesis in utm_hypotheses if hypothesis))
+
+        # Need to keep sure we process track zone to get missed detection
+        if not track_zone_hit:
+            hypotheses.extend(self.hypothesiser.hypothesise(track, {}, timestamp))
+
+        return MultipleHypothesis(sorted(hypotheses, reverse=True))


### PR DESCRIPTION
This allows each detection to belong to a different zone.

This also allows tracks across multiple UTM zones to be compared to detections, and will then also allow tracks to transition UTM zones via the Updater, due to prediction being in UTM zone of detection.

This is dependent on Turbo87/utm#46 and Turbo87/utm#47 being fixed in cases where tracks pass equator and anti-meridian.

TODO:
- [ ] Add tests for hypothesiser wrapper.