### PR TITLE
Fix StateVectors average method with custom types

### DIFF
--- a/stonesoup/types/array.py
+++ b/stonesoup/types/array.py
@@ -174,8 +174,8 @@ class StateVectors(Matrix):
                     # Check if type has custom average method
                     state_vector[dim, 0] = type_.average(row, weights=weights)
                 else:
-                    # Else use numpy built in
-                    state_vector[dim, 0] = type_(np.average(np.asarray(row), weights=weights))
+                    # Else use numpy built in, converting to float array
+                    state_vector[dim, 0] = type_(np.average(np.asfarray(row), weights=weights))
         else:
             return NotImplemented
 


### PR DESCRIPTION
This resolves an issue where average would fail when passing custom
types in state vectors.