### PR TITLE
Add bearing-only measurement model

### DIFF
--- a/stonesoup/initiator/simple.py
+++ b/stonesoup/initiator/simple.py
@@ -73,6 +73,7 @@ class SimpleMeasurementInitiator(GaussianInitiator):
     """
     prior_state = Property(GaussianState, doc="Prior state information")
     measurement_model = Property(MeasurementModel, doc="Measurement model")
+    skip_non_reversible = Property(bool, default=False)
 
     def initiate(self, detections, **kwargs):
         tracks = set()
@@ -90,6 +91,8 @@ class SimpleMeasurementInitiator(GaussianInitiator):
                     model_matrix = measurement_model.jacobian(State(
                         state_vector))
                     inv_model_matrix = np.linalg.pinv(model_matrix)
+                elif self.skip_non_reversible:
+                    continue
                 else:
                     raise Exception("Invalid measurement model used.\
                                     Must be instance of linear or reversible.")

--- a/stonesoup/models/base.py
+++ b/stonesoup/models/base.py
@@ -191,7 +191,10 @@ class GaussianModel(Model):
         noise = multivariate_normal.rvs(
             np.zeros(self.ndim), self.covar(**kwargs), num_samples)
 
-        noise = np.atleast_2d(noise).T
+        noise = np.atleast_2d(noise)
+
+        if self.ndim > 1:
+            noise = noise.T  # numpy.rvs method squeezes 1-dimensional matrices to integers
 
         if num_samples == 1:
             return noise.view(StateVector)

--- a/stonesoup/models/measurement/nonlinear.py
+++ b/stonesoup/models/measurement/nonlinear.py
@@ -554,6 +554,103 @@ class CartesianToElevationBearing(NonLinearGaussianMeasurement):
         return out
 
 
+class Cartesian2DToBearing(NonLinearGaussianMeasurement):
+    r"""This is a class implementation of a time-invariant measurement model, where measurements \
+    are assumed to be received in the form of bearing (:math:`\phi`) with Gaussian noise.
+
+    The model is described by the following equations:
+
+    .. math::
+
+      \phi_t = h(\vec{x}_t, v_t)
+
+    * :math:`h` is a non-linear model function of the form:
+
+    .. math::
+
+      h(\vec{x}_t,v_t) = atan2(\mathcal{y},\mathcal{x}) + v_t
+
+    * :math:`v_t` is Gaussian distributed with covariance :math:`R`, i.e.:
+
+    .. math::
+
+      v_t \sim \mathcal{N}(0,\sigma_{\phi}^2)
+
+    The :py:attr:`mapping` property of the model is a 2 element vector, whose first \
+    (i.e. :py:attr:`mapping[0]`) and second (i.e. :py:attr:`mapping[1]`) elements contain the \
+    state index of the :math:`x` and :math:`y` coordinates, respectively.
+
+    """  # noqa:E501
+
+    translation_offset = Property(StateVector, default=StateVector(np.array([[0], [0]])),
+                                  doc="A 2x1 array specifying the origin offset in terms of \
+                                  :math:`x,y` coordinates.")
+
+    def __init__(self, *args, **kwargs):
+        """
+        Ensure that the translation offset is initiated
+        """
+        super().__init__(*args, **kwargs)
+        # Set values to defaults if not provided
+        if self.translation_offset is None:
+            self.translation_offset = StateVector([0] * 2)
+
+    @property
+    def ndim_meas(self):
+        """ndim_meas getter method
+
+            Returns
+            -------
+            :class:`int`
+                The number of measurement dimensions
+            """
+        return 1
+
+    def function(self, state, noise=False, **kwargs):
+        r"""Model function :math:`h(\vec{x}_t,v_t)`
+
+            Parameters
+            ----------
+            state: :class:`~.State`
+                An input state
+            noise: :class:`numpy.ndarray` or bool
+                An externally generated random process noise sample (the default is `False`, in
+                which case no noise will be added.
+                If 'True', the output of :meth:`~.Model.rvs` is added)
+
+            Returns
+            -------
+            :class:`numpy.ndarray` of shape (:py:attr:`~ndim_state`, 1)
+                The model function evaluated given the provided time interval.
+            """
+
+        if isinstance(noise, bool) or noise is None:
+            if noise:
+                noise = self.rvs()
+            else:
+                noise = 0
+
+        # Account for origin offset
+        xyz = [[state.state_vector[self.mapping[0], 0]
+                - self.translation_offset[0, 0]],
+               [state.state_vector[self.mapping[1], 0]
+                - self.translation_offset[1, 0]],
+               [0]]
+
+        # Rotate coordinates
+        xyz_rot = self._rotation_matrix @ xyz
+
+        # Covert to polar
+        _, phi = cart2pol(*xyz_rot[:2, 0])
+
+        return StateVector([[Bearing(phi)]]) + noise
+
+    def rvs(self, num_samples=1, **kwargs) -> Union[StateVector, StateVectors]:
+        out = super().rvs(num_samples, **kwargs)
+        out = np.array([[Bearing(0.)]]) + out
+        return out
+
+
 class CartesianToBearingRangeRate(NonLinearGaussianMeasurement):
     r"""This is a class implementation of a time-invariant measurement model, \
     where measurements are assumed to be received in the form of bearing \

--- a/stonesoup/models/measurement/nonlinear.py
+++ b/stonesoup/models/measurement/nonlinear.py
@@ -582,7 +582,7 @@ class Cartesian2DToBearing(NonLinearGaussianMeasurement):
 
     """  # noqa:E501
 
-    translation_offset = Property(StateVector, default=StateVector(np.array([[0], [0]])),
+    translation_offset = Property(StateVector, default=None,
                                   doc="A 2x1 array specifying the origin offset in terms of \
                                   :math:`x,y` coordinates.")
 

--- a/stonesoup/models/measurement/nonlinear.py
+++ b/stonesoup/models/measurement/nonlinear.py
@@ -216,7 +216,7 @@ class CartesianToElevationBearingRange(NonLinearGaussianMeasurement, ReversibleM
         super().__init__(*args, **kwargs)
         # Set values to defaults if not provided
         if self.translation_offset is None:
-            self.translation_offset = StateVector([0] * self.ndim)
+            self.translation_offset = StateVector([0] * 3)
 
     @property
     def ndim_meas(self) -> int:
@@ -255,7 +255,7 @@ class CartesianToElevationBearingRange(NonLinearGaussianMeasurement, ReversibleM
                 noise = 0
 
         # Account for origin offset
-        xyz = state.state_vector[self.mapping] - self.translation_offset
+        xyz = state.state_vector[self.mapping, :] - self.translation_offset
 
         # Rotate coordinates
         xyz_rot = self._rotation_matrix @ xyz
@@ -351,7 +351,7 @@ class CartesianToBearingRange(NonLinearGaussianMeasurement, ReversibleModel):
         super().__init__(*args, **kwargs)
         # Set values to defaults if not provided
         if self.translation_offset is None:
-            self.translation_offset = StateVector([0] * self.ndim)
+            self.translation_offset = StateVector([0] * 2)
 
     @property
     def ndim_meas(self) -> int:
@@ -499,7 +499,7 @@ class CartesianToElevationBearing(NonLinearGaussianMeasurement):
         super().__init__(*args, **kwargs)
         # Set values to defaults if not provided
         if self.translation_offset is None:
-            self.translation_offset = StateVector([0] * self.ndim_state)
+            self.translation_offset = StateVector([0] * 3)
 
     @property
     def ndim_meas(self) -> int:


### PR DESCRIPTION
This model takes 2D positional cartesian coordinates and outputs bearing-only measurements.
Appropriate modifications to base class and measurement initiator were made to accommodate a 1D output.