### PR TITLE
Modify sensors to measure sets of ground truth states

### DIFF
--- a/stonesoup/sensor/passive.py
+++ b/stonesoup/sensor/passive.py
@@ -52,8 +52,9 @@ class PassiveElevationBearing(Sensor):
         Returns
         -------
         Set[:class:`~.Detection`]
-            A measurement generated from the given state. The timestamp of the\
-            measurement is set equal to that of the provided state.
+            A set of measurements generated from the given states. The timestamps of the
+            measurements are set equal to that of the corresponding states that they were
+            calculated from.
         """
 
         measurement_model = CartesianToElevationBearing(

--- a/stonesoup/sensor/passive.py
+++ b/stonesoup/sensor/passive.py
@@ -1,11 +1,14 @@
 # -*- coding: utf-8 -*-
 import numpy as np
 
-from stonesoup.sensor.sensor import Sensor
+from typing import Set, Union
+
 from ..base import Property
 from ..models.measurement.nonlinear import CartesianToElevationBearing
+from ..sensor.sensor import Sensor
 from ..types.array import CovarianceMatrix
 from ..types.detection import Detection
+from ..types.groundtruth import GroundTruthState
 
 
 class PassiveElevationBearing(Sensor):
@@ -33,12 +36,13 @@ class PassiveElevationBearing(Sensor):
             (and follow in format) the underlying \
             :class:`~.CartesianToElevationBearing` model")
 
-    def measure(self, ground_truths, noise=True, **kwargs):
+    def measure(self, ground_truths: Set[GroundTruthState], noise: Union[np.ndarray, bool] = True,
+                **kwargs) -> Set[Detection]:
         """Generate a measurement for a given state
 
         Parameters
         ----------
-        ground_truths : :class:`~.State`
+        ground_truths : Set[:class:`~.GroundTruthState`]
             A set of :class:`~.GroundTruthState`
         noise: :class:`numpy.ndarray` or bool
             An externally generated random process noise sample (the default is
@@ -47,7 +51,7 @@ class PassiveElevationBearing(Sensor):
 
         Returns
         -------
-        :class:`~.Detection`
+        Set[:class:`~.Detection`]
             A measurement generated from the given state. The timestamp of the\
             measurement is set equal to that of the provided state.
         """

--- a/stonesoup/sensor/passive.py
+++ b/stonesoup/sensor/passive.py
@@ -33,13 +33,13 @@ class PassiveElevationBearing(Sensor):
             (and follow in format) the underlying \
             :class:`~.CartesianToElevationBearing` model")
 
-    def measure(self, ground_truth, noise=True, **kwargs):
+    def measure(self, ground_truths, noise=True, **kwargs):
         """Generate a measurement for a given state
 
         Parameters
         ----------
-        ground_truth : :class:`~.State`
-            A ground-truth state
+        ground_truths : :class:`~.State`
+            A set of :class:`~.GroundTruthState`
         noise: :class:`numpy.ndarray` or bool
             An externally generated random process noise sample (the default is
             `True`, in which case :meth:`~.Model.rvs` is used
@@ -59,9 +59,13 @@ class PassiveElevationBearing(Sensor):
             translation_offset=self.position,
             rotation_offset=self.orientation)
 
-        measurement_vector = measurement_model.function(
-            ground_truth, noise=noise, **kwargs)
+        detections = set()
+        for truth in ground_truths:
 
-        return Detection(measurement_vector,
-                         measurement_model=measurement_model,
-                         timestamp=ground_truth.timestamp)
+            measurement_vector = measurement_model.function(truth, noise=noise, **kwargs)
+            detection = Detection(measurement_vector,
+                                  measurement_model=measurement_model,
+                                  timestamp=truth.timestamp)
+            detections.add(detection)
+
+        return detections

--- a/stonesoup/sensor/tests/test_passive.py
+++ b/stonesoup/sensor/tests/test_passive.py
@@ -16,9 +16,11 @@ def test_passive_sensor():
                                    [0, np.deg2rad(0.1)]])
     detector_position = StateVector([1, 1, 0])
     detector_orientation = StateVector([0, 0, 0])
+    truth = set()
     target_state = State(detector_position +
                          np.array([[1], [1], [0]]),
                          timestamp=datetime.datetime.now())
+    truth.add(target_state)
     measurement_mapping = np.array([0, 1, 2])
 
     # Create a radar object
@@ -33,7 +35,8 @@ def test_passive_sensor():
     assert (np.equal(detector.position, detector_position).all())
 
     # Generate a noiseless measurement for the given target
-    measurement = detector.measure(target_state, noise=False)
+    measurement = detector.measure(truth, noise=False)
+    measurement = next(iter(measurement))  # Get measurement from set
 
     # Account
     xyz = target_state.state_vector - detector_position
@@ -54,3 +57,14 @@ def test_passive_sensor():
     assert (measurement.timestamp == target_state.timestamp)
     assert (np.equal(measurement.state_vector,
                      StateVector([theta, phi])).all())
+
+    target_state = State(detector_position +
+                         np.array([[-1], [-1], [0]]),
+                         timestamp=datetime.datetime.now())
+    truth.add(target_state)
+
+    # Generate a noiseless measurement for each of the given target states
+    measurements = detector.measure(truth, noise=False)
+
+    # Two measurements for 2 truth states
+    assert len(measurements) == 2

--- a/stonesoup/simulator/platform.py
+++ b/stonesoup/simulator/platform.py
@@ -28,14 +28,8 @@ class PlatformDetectionSimulator(DetectionSimulator):
                 platform.move(time)
             for platform in self.platforms:
                 for sensor in platform.sensors:
-                    detections = set()
-                    for truth in truths.union(self.platforms):
-
-                        # Make sure platform's sensors do not measure itself
-                        if truth is platform:
-                            continue
-
-                        detection = sensor.measure(truth)
-                        if detection is not None:
-                            detections.add(detection)
+                    truths_to_be_measured = truths.union([other_platform for other_platform in
+                                                          self.platforms if other_platform is not
+                                                          platform])
+                    detections = sensor.measure(truths_to_be_measured)
                     yield time, detections

--- a/stonesoup/simulator/platform.py
+++ b/stonesoup/simulator/platform.py
@@ -28,8 +28,6 @@ class PlatformDetectionSimulator(DetectionSimulator):
                 platform.move(time)
             for platform in self.platforms:
                 for sensor in platform.sensors:
-                    truths_to_be_measured = truths.union([other_platform for other_platform in
-                                                          self.platforms if other_platform is not
-                                                          platform])
+                    truths_to_be_measured = truths.union(self.platforms) - {platform}
                     detections = sensor.measure(truths_to_be_measured)
                     yield time, detections

--- a/stonesoup/simulator/tests/conftest.py
+++ b/stonesoup/simulator/tests/conftest.py
@@ -40,9 +40,11 @@ def measurement_model():
 def sensor_model1():
     class TestSensor(Sensor):
 
-        def measure(self, ground_truth):
-            return Detection(ground_truth.state_vector[(0, 2), :],
-                             timestamp=ground_truth.timestamp)
+        def measure(self, ground_truths):
+            detections = set()
+            for truth in ground_truths:
+                detections.add(Detection(truth.state_vector[(0, 2), :], timestamp=truth.timestamp))
+            return detections
     return TestSensor()
 
 
@@ -50,7 +52,9 @@ def sensor_model1():
 def sensor_model2():
     class TestSensor(Sensor):
 
-        def measure(self, ground_truth):
-            return Detection(ground_truth.state_vector,
-                             timestamp=ground_truth.timestamp)
+        def measure(self, ground_truths):
+            detections = set()
+            for truth in ground_truths:
+                detections.add(Detection(truth.state_vector, timestamp=truth.timestamp))
+            return detections
     return TestSensor()

--- a/stonesoup/simulator/tests/test_platform.py
+++ b/stonesoup/simulator/tests/test_platform.py
@@ -40,6 +40,7 @@ def test_platform_detection_simulator(sensor_model1,
                                           [platform1, platform2])
 
     for n, (time, detections) in enumerate(detector):
+
         # Detection count at each step.
         assert len(detections) == 1
         # platform1 position.


### PR DESCRIPTION
Changes to sensor tests to account for ground truths being passed-in, and measurements being received, as sets.
As well as a bit of adjustment in state definitions in test files to account for larger character limit.