### PR TITLE
Fix Sphinx-Gallery scraper animations

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -65,6 +65,7 @@ sphinx_gallery_conf = {
      'reference_url': {'stonesoup': None},
      'remove_config_comments': True,
      'ignore_repr_types': r'matplotlib.figure',
+     'matplotlib_animations': True,
 }
 
 intersphinx_mapping = {

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(name='stonesoup',
       extras_require={
           'dev': [
               'pytest-flake8', 'pytest-cov', 'Sphinx', 'sphinx_rtd_theme',
-              'setuptools>=30', 'sphinx-gallery', 'pillow', 'folium'],
+              'setuptools>=30', 'sphinx-gallery>=0.7', 'pillow', 'folium'],
           'video': [
               'ffmpeg-python', 'moviepy'],
       },


### PR DESCRIPTION
Apply upstream changes to _matplotlib_ scraper to enable animation support.

Longer term would be good to work with Sphinx-Gallery project so we don't need this custom scraper.