### PR TITLE
Sensor-Measurement model consistency change

### DIFF
--- a/stonesoup/platform/tests/test_platform_simple.py
+++ b/stonesoup/platform/tests/test_platform_simple.py
@@ -9,7 +9,7 @@ from ...types.state import State
 from ..base import MovingPlatform, FixedPlatform
 from ...models.transition.linear import (
     ConstantVelocity, CombinedLinearGaussianTransitionModel)
-from ...sensor.radar.radar import RadarRangeBearing
+from ...sensor.radar.radar import RadarBearingRange
 from ...types.array import StateVector, CovarianceMatrix
 
 
@@ -144,29 +144,29 @@ def radars_2d():
     measurement_mapping = np.array([0, 2])
 
     # Create 5 simple radar sensor objects
-    radar1 = RadarRangeBearing(
+    radar1 = RadarBearingRange(
         ndim_state=4,
         position_mapping=measurement_mapping,
         noise_covar=noise_covar,
     )
 
-    radar2 = RadarRangeBearing(
+    radar2 = RadarBearingRange(
         ndim_state=4,
         position_mapping=measurement_mapping,
         noise_covar=noise_covar
     )
-    radar3 = RadarRangeBearing(
+    radar3 = RadarBearingRange(
         ndim_state=4,
         position_mapping=measurement_mapping,
         noise_covar=noise_covar
     )
 
-    radar4 = RadarRangeBearing(
+    radar4 = RadarBearingRange(
         ndim_state=4,
         position_mapping=measurement_mapping,
         noise_covar=noise_covar
     )
-    radar5 = RadarRangeBearing(
+    radar5 = RadarBearingRange(
         ndim_state=4,
         position_mapping=measurement_mapping,
         noise_covar=noise_covar
@@ -184,39 +184,39 @@ def radars_3d():
     measurement_mapping = np.array([0, 2, 4])
 
     # Create 5 simple radar sensor objects
-    radar1 = RadarRangeBearing(
+    radar1 = RadarBearingRange(
         ndim_state=6,
         position_mapping=measurement_mapping,
         noise_covar=noise_covar
     )
 
-    radar2 = RadarRangeBearing(
+    radar2 = RadarBearingRange(
         ndim_state=6,
         position_mapping=measurement_mapping,
         noise_covar=noise_covar
     )
-    radar3 = RadarRangeBearing(
+    radar3 = RadarBearingRange(
         ndim_state=6,
         position_mapping=measurement_mapping,
         noise_covar=noise_covar
     )
 
-    radar4 = RadarRangeBearing(
+    radar4 = RadarBearingRange(
         ndim_state=6,
         position_mapping=measurement_mapping,
         noise_covar=noise_covar
     )
-    radar5 = RadarRangeBearing(
+    radar5 = RadarBearingRange(
         ndim_state=6,
         position_mapping=measurement_mapping,
         noise_covar=noise_covar
     )
-    radar6 = RadarRangeBearing(
+    radar6 = RadarBearingRange(
         ndim_state=6,
         position_mapping=measurement_mapping,
         noise_covar=noise_covar
     )
-    radar7 = RadarRangeBearing(
+    radar7 = RadarBearingRange(
         ndim_state=6,
         position_mapping=measurement_mapping,
         noise_covar=noise_covar

--- a/stonesoup/sensor/radar/__init__.py
+++ b/stonesoup/sensor/radar/__init__.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
-from .radar import RadarRangeBearing, RadarRotatingRangeBearing, AESARadar
+from .radar import RadarBearingRange, RadarRotatingBearingRange, AESARadar
 from .beam_shape import Beam2DGaussian, BeamShape
 from .beam_pattern import BeamTransitionModel, BeamSweep, StationaryBeam
 
 
-__all__ = ['RadarRangeBearing', 'RadarRotatingRangeBearing', 'AESARadar',
+__all__ = ['RadarBearingRange', 'RadarRotatingBearingRange', 'AESARadar',
            'Beam2DGaussian', 'BeamShape', 'BeamTransitionModel', 'BeamSweep',
            'StationaryBeam']

--- a/stonesoup/sensor/radar/radar.py
+++ b/stonesoup/sensor/radar/radar.py
@@ -22,7 +22,7 @@ from ...types.numeric import Probability
 import scipy.constants as const
 
 
-class RadarRangeBearing(Sensor):
+class RadarBearingRange(Sensor):
     """A simple radar sensor that generates measurements of targets, using a
     :class:`~.CartesianToBearingRange` model, relative to its position.
 
@@ -79,7 +79,7 @@ class RadarRangeBearing(Sensor):
                          timestamp=ground_truth.timestamp)
 
 
-class RadarRotatingRangeBearing(RadarRangeBearing):
+class RadarRotatingBearingRange(RadarBearingRange):
     """A simple rotating radar, with set field-of-view (FOV) angle, range and\
      rotations per minute (RPM), that generates measurements of targets, using\
      a :class:`~.CartesianToBearingRange` model, relative to its\
@@ -202,9 +202,9 @@ class RadarRotatingRangeBearing(RadarRangeBearing):
         )
 
 
-class RadarRangeBearingElevation(RadarRangeBearing):
+class RadarElevationBearingRange(RadarBearingRange):
     """A  radar sensor that generates measurements of targets, using a
-    :class:`~.CartesianToBearingElevationRange` model, relative to its position.
+    :class:`~.CartesianToElevationBearingRange` model, relative to its position.
 
     Note
     ----
@@ -255,7 +255,7 @@ class RadarRangeBearingElevation(RadarRangeBearing):
                          timestamp=ground_truth.timestamp)
 
 
-class RadarRangeRateBearing(RadarRangeBearing):
+class RadarBearingRangeRate(RadarBearingRange):
     """ A radar sensor that generates measurements of targets, using a
     :class:`~.CartesianToBearingRangeRate` model, relative to its position
     and velocity.
@@ -315,7 +315,7 @@ class RadarRangeRateBearing(RadarRangeBearing):
                          timestamp=ground_truth.timestamp)
 
 
-class RadarRangeRateBearingElevation(RadarRangeRateBearing):
+class RadarElevationBearingRangeRate(RadarBearingRangeRate):
     """ A radar sensor that generates measurements of targets, using a
     :class:`~.CartesianToElevationBearingRangeRate` model, relative to its position
     and velocity.
@@ -374,13 +374,13 @@ class RadarRangeRateBearingElevation(RadarRangeRateBearing):
                          timestamp=ground_truth.timestamp)
 
 
-class RadarRasterScanRangeBearing(RadarRotatingRangeBearing):
+class RadarRasterScanBearingRange(RadarRotatingBearingRange):
     """A simple raster scan radar, with set field-of-regard (FoR) angle, \
      field-of-view (FoV) angle, range and rotations per minute (RPM), that \
      generates measurements of targets, using a \
-     :class:`~.RangeBearingGaussianToCartesian` model, relative to its position
+     :class:`~.CartesianToBearingRange` model, relative to its position
 
-     This is a simple extension of the RadarRotatingRangeBearing class with \
+     This is a simple extension of the RadarRotatingBearingRange class with \
      the rotate function changed to restrict the  dwell-center to within the \
      field of regard.
      It's important to note that this only works (has  been tested) in an 2D \

--- a/stonesoup/sensor/radar/tests/test_radar.py
+++ b/stonesoup/sensor/radar/tests/test_radar.py
@@ -66,7 +66,7 @@ def h3d(state, pos_map, translation_offset, rotation_offset):
                 2,
                 np.array([0, 1]),  # pos_mapping
                 np.array([[0.015, 0],
-                      [0, 0.1]]),  # noise_covar
+                          [0, 0.1]]),  # noise_covar
                 StateVector([[1], [1]]),  # position
                 np.array([[200], [10]])  # target
          ),
@@ -76,8 +76,8 @@ def h3d(state, pos_map, translation_offset, rotation_offset):
                 3,
                 np.array([0, 1, 2]),  # pos_mapping
                 np.array([[0.015, 0, 0],
-                      [0, 0.015, 0],
-                      [0, 0, 0.1]]),  # noise_covar
+                          [0, 0.015, 0],
+                          [0, 0, 0.1]]),  # noise_covar
                 StateVector([[1], [1], [0]]),  # position
                 np.array([[200], [10], [10]])  # target
         )
@@ -167,8 +167,8 @@ def h3d_rr(state, pos_map, vel_map, translation_offset, rotation_offset, velocit
                 np.array([0, 2, 4]),  # pos_mapping
                 np.array([1, 3, 5]),  # vel_mapping
                 np.array([[0.05, 0, 0],
-                      [0, 0.015, 0],
-                      [0, 0, 10]]),  # noise_covar
+                          [0, 0.015, 0],
+                          [0, 0, 10]]),  # noise_covar
                 StateVector([[100], [0], [0]])  # position
          ),
         (
@@ -177,9 +177,9 @@ def h3d_rr(state, pos_map, vel_map, translation_offset, rotation_offset, velocit
                 np.array([0, 2, 4]),  # pos_mapping
                 np.array([1, 3, 5]),  # vel_mapping
                 np.array([[0.05, 0, 0, 0],
-                      [0, 0.05, 0, 0],
-                      [0, 0, 0.015, 0],
-                      [0, 0, 0, 10]]),  # noise_covar
+                          [0, 0.05, 0, 0],
+                          [0, 0, 0.015, 0],
+                          [0, 0, 0, 10]]),  # noise_covar
                 StateVector([[100], [0], [0]])  # position
         )
     ],

--- a/stonesoup/sensor/radar/tests/test_radar.py
+++ b/stonesoup/sensor/radar/tests/test_radar.py
@@ -9,8 +9,8 @@ from ....types.angle import Bearing, Elevation
 from ....types.array import StateVector, CovarianceMatrix
 from ....types.state import State
 from ....types.groundtruth import GroundTruthState
-from ..radar import RadarRangeBearing, RadarRangeBearingElevation, RadarRotatingRangeBearing, \
-    AESARadar, RadarRasterScanRangeBearing, RadarRangeRateBearing, RadarRangeRateBearingElevation
+from ..radar import RadarBearingRange, RadarElevationBearingRange, RadarRotatingBearingRange, \
+    AESARadar, RadarRasterScanBearingRange, RadarBearingRangeRate, RadarElevationBearingRangeRate
 from ..beam_pattern import StationaryBeam
 from ..beam_shape import Beam2DGaussian
 from ....models.measurement.linear import LinearGaussian
@@ -61,28 +61,28 @@ def h3d(state, pos_map, translation_offset, rotation_offset):
     "h, sensorclass, ndim_state, pos_mapping, noise_covar, position, target",
     [
         (
-            h2d,  # h
-            RadarRangeBearing,  # sensorclass
-            2,
-            np.array([0, 1]),  # pos_mapping
-            np.array([[0.015, 0],
+                h2d,  # h
+                RadarBearingRange,  # sensorclass
+                2,
+                np.array([0, 1]),  # pos_mapping
+                np.array([[0.015, 0],
                       [0, 0.1]]),  # noise_covar
-            StateVector([[1], [1]]),  # position
-            np.array([[200], [10]])  # target
+                StateVector([[1], [1]]),  # position
+                np.array([[200], [10]])  # target
          ),
         (
-            h3d,  # h
-            RadarRangeBearingElevation,  # sensorclass
-            3,
-            np.array([0, 1, 2]),  # pos_mapping
-            np.array([[0.015, 0, 0],
+                h3d,  # h
+                RadarElevationBearingRange,  # sensorclass
+                3,
+                np.array([0, 1, 2]),  # pos_mapping
+                np.array([[0.015, 0, 0],
                       [0, 0.015, 0],
                       [0, 0, 0.1]]),  # noise_covar
-            StateVector([[1], [1], [0]]),  # position
-            np.array([[200], [10], [10]])  # target
+                StateVector([[1], [1], [0]]),  # position
+                np.array([[200], [10], [10]])  # target
         )
     ],
-    ids=["RadarRangeBearing", "RadarRangeBearingElevation"]
+    ids=["RadarBearingRange", "RadarElevationBearingRange"]
 )
 def test_simple_radar(h, sensorclass, ndim_state, pos_mapping, noise_covar, position, target):
     # Instantiate the rotating radar
@@ -162,28 +162,28 @@ def h3d_rr(state, pos_map, vel_map, translation_offset, rotation_offset, velocit
     "h, sensorclass, pos_mapping, vel_mapping, noise_covar, position",
     [
         (
-            h2d_rr,  # h
-            RadarRangeRateBearing,  # sensorclass
-            np.array([0, 2, 4]),  # pos_mapping
-            np.array([1, 3, 5]),  # vel_mapping
-            np.array([[0.05, 0, 0],
+                h2d_rr,  # h
+                RadarBearingRangeRate,  # sensorclass
+                np.array([0, 2, 4]),  # pos_mapping
+                np.array([1, 3, 5]),  # vel_mapping
+                np.array([[0.05, 0, 0],
                       [0, 0.015, 0],
                       [0, 0, 10]]),  # noise_covar
-            StateVector([[100], [0], [0]])  # position
+                StateVector([[100], [0], [0]])  # position
          ),
         (
-            h3d_rr,
-            RadarRangeRateBearingElevation,
-            np.array([0, 2, 4]),  # pos_mapping
-            np.array([1, 3, 5]),  # vel_mapping
-            np.array([[0.05, 0, 0, 0],
+                h3d_rr,
+                RadarElevationBearingRangeRate,
+                np.array([0, 2, 4]),  # pos_mapping
+                np.array([1, 3, 5]),  # vel_mapping
+                np.array([[0.05, 0, 0, 0],
                       [0, 0.05, 0, 0],
                       [0, 0, 0.015, 0],
                       [0, 0, 0, 10]]),  # noise_covar
-            StateVector([[100], [0], [0]])  # position
+                StateVector([[100], [0], [0]])  # position
         )
     ],
-    ids=["RadarRangeRateBearing", "RadarRangeRateBearingElevation"]
+    ids=["RadarBearingRangeRate", "RadarElevationBearingRangeRate"]
 )
 def test_range_rate_radar(h, sensorclass, pos_mapping, vel_mapping, noise_covar, position):
 
@@ -238,7 +238,7 @@ def test_rotating_radar():
     measurement_mapping = np.array([0, 1])
 
     # Create a radar object
-    radar = RadarRotatingRangeBearing(position=radar_position,
+    radar = RadarRotatingBearingRange(position=radar_position,
                                       orientation=radar_orientation,
                                       ndim_state=2,
                                       position_mapping=measurement_mapping,
@@ -300,7 +300,7 @@ def test_raster_scan_radar():
     measurement_mapping = np.array([0, 1])
 
     # Create a radar object
-    radar = RadarRasterScanRangeBearing(position=radar_position,
+    radar = RadarRasterScanBearingRange(position=radar_position,
                                         orientation=radar_orientation,
                                         ndim_state=2,
                                         position_mapping=measurement_mapping,


### PR DESCRIPTION
Modification to change the sensor names to match that of the measurement models they use, this reduces potential for confusion when configuring sensors. 

For example: `class RadarRangeElevationBearing(RadarRangeBearing)` becomes `class RadarElevationBearingRange(RadarBearingRange)`  and matches `CartesianToElevationBearingRange` measurement method.

Suggested that this is not merged until after tutorials are finished