### PR TITLE
Fix issues with copying platforms

### DIFF
--- a/stonesoup/base.py
+++ b/stonesoup/base.py
@@ -321,8 +321,9 @@ class Base(metaclass=BaseMeta):
                 try:
                     # if we are copying the parent as well, the copy should be in memodict
                     copy_of_target = memodict[id(original_target)]
-                    new.__setattr__(name, weakref.ref(copy_of_target))
                 except KeyError:
                     # if we can't find the parent, then leave the original ref in place
                     pass
+                else:
+                    new.__setattr__(name, weakref.ref(copy_of_target))
         return new

--- a/stonesoup/platform/base.py
+++ b/stonesoup/platform/base.py
@@ -47,17 +47,17 @@ class Platform(StateMutableSequence, ABC):
                                 doc="Mapping between platform position and state vector. For a "
                                     "position-only 3d platform this might be ``[0, 1, 2]``. For a "
                                     "position and velocity platform: ``[0, 2, 4]``")
-    rotation_offsets = Property(List[StateVector], default=None,
+    rotation_offsets = Property(List[StateVector], default=None, readonly=True,
                                 doc="A list of StateVectors containing the sensor rotation "
                                     "offsets from the platform's primary axis (defined as the "
                                     "direction of motion). Defaults to a zero vector with the "
                                     "same length as the Platform's :attr:`position_mapping`")
-    mounting_offsets = Property(List[StateVector], default=None,
+    mounting_offsets = Property(List[StateVector], default=None, readonly=True,
                                 doc="A list of StateVectors containing the sensor translation "
                                     "offsets from the platform's reference point. Defaults to "
                                     "a zero vector with the same length as the Platform's "
                                     ":attr:`position_mapping`")
-    sensors = Property(List["BaseSensor"],  default=None,
+    sensors = Property(List["BaseSensor"],  default=None, readonly=True,
                        doc="A list of N mounted sensors. Defaults to an empty list")
     velocity_mapping = Property(Sequence[int], default=None,
                                 doc="Mapping between platform velocity and state dims. If not "
@@ -74,16 +74,16 @@ class Platform(StateMutableSequence, ABC):
         # Set values to defaults if not provided
 
         if self.sensors is None:
-            self.sensors = []
+            self._property_sensors = []
 
         if self.velocity_mapping is None:
             self.velocity_mapping = [p + 1 for p in self.position_mapping]
 
         if self.mounting_offsets is None:
-            self.mounting_offsets = [StateVector([0] * self.ndim)] * len(self.sensors)
+            self._property_mounting_offsets = [StateVector([0] * self.ndim)] * len(self.sensors)
 
         if self.rotation_offsets is None:
-            self.rotation_offsets = [StateVector([0] * 3)] * len(self.sensors)
+            self._property_rotation_offsets = [StateVector([0] * 3)] * len(self.sensors)
 
         if len(self.sensors) != len(self.mounting_offsets):
             raise ValueError(
@@ -112,6 +112,22 @@ class Platform(StateMutableSequence, ABC):
     @position.setter
     def position(self, value: StateVector) -> None:
         self._set_position(value)
+
+    @staticmethod
+    def _tuple_or_none(value):
+        return None if value is None else tuple(value)
+
+    @sensors.getter
+    def get_sensors(self):
+        return self._tuple_or_none(self._property_sensors)
+
+    @mounting_offsets.getter
+    def get_mounting_offsets(self):
+        return self._tuple_or_none(self._property_mounting_offsets)
+
+    @rotation_offsets.getter
+    def get_rotation_offsets(self):
+        return self._tuple_or_none(self._property_rotation_offsets)
 
     @property
     def ndim(self) -> int:
@@ -186,7 +202,7 @@ class Platform(StateMutableSequence, ABC):
             A StateVector with the rotation offset of the new sensor. If not supplied, defaults to
             a zero vector.
         """
-        self.sensors.append(sensor)
+        self._property_sensors.append(sensor)
         sensor.platform_system = weakref.ref(self)
 
         if mounting_offset is None:
@@ -194,8 +210,30 @@ class Platform(StateMutableSequence, ABC):
         if rotation_offset is None:
             rotation_offset = StateVector([0] * 3)
 
-        self.mounting_offsets.append(mounting_offset)
-        self.rotation_offsets.append(rotation_offset)
+        self._property_mounting_offsets.append(mounting_offset)
+        self._property_rotation_offsets.append(rotation_offset)
+
+    def remove_sensor(self, sensor: "BaseSensor") -> None:
+        """ Remove a sensor from the platform
+
+        Parameters
+        ----------
+        sensor : :class:`~.BaseSensor`
+            The sensor object to remove
+        """
+        self.pop_sensor(self._property_sensors.index(sensor))
+
+    def pop_sensor(self, index: int):
+        """ Remove a sensor from the platform by index
+
+                Parameters
+                ----------
+                index : int
+                    The index of the sensor to remove
+                """
+        self._property_sensors.pop(index)
+        self._property_mounting_offsets.pop(index)
+        self._property_rotation_offsets.pop(index)
 
     def get_sensor_position(self, sensor: "BaseSensor") -> StateVector:
         """Return the position of the given sensor, which should be already attached to the

--- a/stonesoup/sensor/tests/test_sensor.py
+++ b/stonesoup/sensor/tests/test_sensor.py
@@ -1,11 +1,13 @@
+import copy
 import datetime
 
 import pytest
 
+from stonesoup.sensor.radar.radar import RadarRangeRateBearingElevation
 from ...platform.base import FixedPlatform
 from ..base import BaseSensor
 from ..sensor import Sensor
-from ...types.array import StateVector
+from ...types.array import StateVector, CovarianceMatrix
 from ...types.state import State
 
 import numpy as np
@@ -86,3 +88,95 @@ def test_changing_platform_from_default():
 def test_sensor_measure(sensor):
     # needed for test coverage... Does no harm
     assert sensor().measure() is None
+
+
+@pytest.fixture
+def radar_platform_target():
+    pos_mapping = np.array([0, 2, 4])
+    vel_mapping = np.array([1, 3, 5])
+    noise_covar = CovarianceMatrix(np.eye(4))
+
+    radar = RadarRangeRateBearingElevation(ndim_state=6,
+                                           position_mapping=pos_mapping,
+                                           velocity_mapping=vel_mapping,
+                                           noise_covar=noise_covar)
+
+    # create a platform with the simple radar mounted
+    timestamp_init = datetime.datetime.now()
+    platform_1_prior_state_vector = StateVector([[5], [0], [0], [0.25], [0], [0]])
+    platform_1_state = State(platform_1_prior_state_vector, timestamp_init)
+
+    mounting_offsets = [StateVector([[0], [0], [0]])]
+    rotation_offsets = [StateVector([[0], [0], [0]])]
+
+    platform = FixedPlatform(states=platform_1_state,
+                             position_mapping=pos_mapping,
+                             velocity_mapping=vel_mapping,
+                             sensors=[radar],
+                             mounting_offsets=mounting_offsets,
+                             rotation_offsets=rotation_offsets)
+
+    target = State(StateVector([[0], [0], [0], [0], [0], [0]]), timestamp_init)
+
+    return radar, platform, target
+
+
+def test_platform_deepcopy(radar_platform_target):
+    # Set up Radar Model
+    radar_1, platform_1, target_state = radar_platform_target
+
+    # Make a measurement with a platform
+    _ = platform_1.sensors[0].measure(target_state)
+
+    assert platform_1.sensors[0] is radar_1
+
+    # 1st Error - Try and create another platform and make a measurement
+    platform_2 = copy.deepcopy(platform_1)
+
+    assert platform_2 is not platform_1
+    assert platform_2.sensors[0] is not platform_1.sensors[0]
+
+    assert platform_2.sensors[0].platform is platform_2
+    # check no error in measurement
+    _ = platform_2.sensors[0].measure(target_state)
+
+
+def test_sensor_assignment(radar_platform_target):
+    radar_1, platform, target_state = radar_platform_target
+
+    # platform_2 = copy.deepcopy(platform)
+    radar_2 = copy.deepcopy(radar_1)
+    radar_3 = copy.deepcopy(radar_1)
+
+    platform.add_sensor(radar_2)
+    platform.add_sensor(radar_3)
+
+    assert len(platform.sensors) == 3
+    validate_lengths(platform)
+    assert platform.sensors == (radar_1, radar_2, radar_3)
+
+    with pytest.raises(AttributeError):
+        platform.sensors = []
+
+    with pytest.raises(TypeError):
+        platform.sensors[0] = radar_3
+
+    platform.pop_sensor(1)
+    assert len(platform.sensors) == 2
+    validate_lengths(platform)
+    assert platform.sensors == (radar_1, radar_3)
+
+    platform.add_sensor(radar_2)
+    assert len(platform.sensors) == 3
+    validate_lengths(platform)
+    assert platform.sensors == (radar_1, radar_3, radar_2)
+
+    platform.remove_sensor(radar_3)
+    assert len(platform.sensors) == 2
+    validate_lengths(platform)
+    assert platform.sensors == (radar_1, radar_2)
+
+
+def validate_lengths(platform):
+    assert len(platform.sensors) == len(platform.mounting_offsets)
+    assert len(platform.sensors) == len(platform.rotation_offsets)


### PR DESCRIPTION
This commit makes two changes to address the issues raised by @gawebb-dstl in #262 :

1. Modify the `sensors` Property of a `Platform` to make it read-only (including making it effectively immutable)
2. Add a `__deepcopy__` method to the `Base` class to allow deep copying of a platform. This needs some thought as it may have unintended consequences. I can't see that it will, but I'd appreciate more eye on this. 

Thanks to @sdhiscocks for the idea of a getter returning a tuple and @gawebb-dstl for the test scenarios!