### PR TITLE
Fix initiator covariance issue.

### DIFF
--- a/stonesoup/initiator/simple.py
+++ b/stonesoup/initiator/simple.py
@@ -70,13 +70,23 @@ class SimpleMeasurementInitiator(GaussianInitiator):
 
     This then replaces mapped values in the :attr:`prior_state` to form the
     initial :class:`~.GaussianState` of the :class:`~.Track`.
+
+    The diagonal loading value is used to try to ensure that the estimated
+    covariance matrix is positive definite, especially for subsequent Cholesky
+    decompositions.
     """
     prior_state = Property(GaussianState, doc="Prior state information")
     measurement_model = Property(MeasurementModel, doc="Measurement model")
     skip_non_reversible = Property(bool, default=False)
     diag_load = Property(float,
                          default=0.0,
-                         doc="Float value for diagonal loading")
+                         doc="Positive float value for diagonal loading")
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if self.diag_load < 0:
+            raise ValueError(
+                "diag_load value can't be less than 0.0")
 
     def initiate(self, detections, **kwargs):
         tracks = set()

--- a/stonesoup/initiator/simple.py
+++ b/stonesoup/initiator/simple.py
@@ -75,7 +75,7 @@ class SimpleMeasurementInitiator(GaussianInitiator):
     measurement_model = Property(MeasurementModel, doc="Measurement model")
     skip_non_reversible = Property(bool, default=False)
     diag_load = Property(float,
-                         default = 0.0,
+                         default=0.0,
                          doc="Float value for diagonal loading")
 
     def initiate(self, detections, **kwargs):
@@ -115,7 +115,7 @@ class SimpleMeasurementInitiator(GaussianInitiator):
             prior_covar[mapped_dimensions, :] = 0
             C0 = inv_model_matrix @ model_covar @ inv_model_matrix.T
             C0 = C0 + prior_covar + \
-                 np.diag(np.array([self.diag_load]*C0.shape[0]))
+                np.diag(np.array([self.diag_load]*C0.shape[0]))
             tracks.add(Track([GaussianStateUpdate(
                 prior_state_vector + state_vector,
                 C0,

--- a/stonesoup/initiator/tests/test_simple.py
+++ b/stonesoup/initiator/tests/test_simple.py
@@ -135,7 +135,7 @@ def test_nonlinear_measurement():
         assert track.timestamp == timestamp
         Ry = measurement_model.jacobian(track.state) @ track.covar @ \
             measurement_model.jacobian(track.state).T
-        assert  Ry == approx(measurement_model.covar())
+        assert Ry == approx(measurement_model.covar())
 
 
 def test_linear_measurement_non_direct():
@@ -182,6 +182,7 @@ def test_linear_measurement_non_direct():
         assert np.diag([12.5, 10]) == approx(track.covar)
         assert measurement_model.matrix() @ track.covar @ \
             measurement_model.matrix().T == approx(measurement_model.covar())
+
 
 def test_linear_measurement_extra_state_dim():
     class _LinearMeasurementModel:

--- a/stonesoup/initiator/tests/test_simple.py
+++ b/stonesoup/initiator/tests/test_simple.py
@@ -2,6 +2,7 @@ import datetime
 
 import numpy as np
 import pytest
+from pytest import approx
 
 from ...models.base import LinearModel
 from ...models.measurement.linear import LinearGaussian
@@ -109,7 +110,9 @@ def test_linear_measurement():
 
         assert track.timestamp == timestamp
 
-        assert np.array_equal(track.covar, np.diag([50, 10]))
+        assert np.diag([50, 10]) == approx(track.covar)
+        assert measurement_model.matrix() @ track.covar @ \
+            measurement_model.matrix().T == approx(measurement_model.covar())
 
 
 def test_nonlinear_measurement():
@@ -130,6 +133,9 @@ def test_nonlinear_measurement():
 
     for track in tracks:
         assert track.timestamp == timestamp
+        Ry = measurement_model.jacobian(track.state) @ track.covar @ \
+            measurement_model.jacobian(track.state).T
+        assert  Ry == approx(measurement_model.covar())
 
 
 def test_linear_measurement_non_direct():
@@ -173,8 +179,9 @@ def test_linear_measurement_non_direct():
 
         assert track.timestamp == timestamp
 
-        assert np.array_equal(track.covar, np.diag([25, 10]))
-
+        assert np.diag([12.5, 10]) == approx(track.covar)
+        assert measurement_model.matrix() @ track.covar @ \
+            measurement_model.matrix().T == approx(measurement_model.covar())
 
 def test_linear_measurement_extra_state_dim():
     class _LinearMeasurementModel:
@@ -221,7 +228,9 @@ def test_linear_measurement_extra_state_dim():
 
         assert track.timestamp == timestamp
 
-        assert np.array_equal(track.covar, np.diag([10, 10, 50]))
+        assert np.diag([10, 10, 50]) == approx(track.covar)
+        assert measurement_model.matrix() @ track.covar @ \
+            measurement_model.matrix().T == approx(measurement_model.covar())
 
 
 def test_multi_measurement():


### PR DESCRIPTION
Fixed the covariance calculation in the SimpleMeasurementInitiator.  A diag_load parameter was added to the initiator (default =0) which adds a diagonal load value to the resulting covariance matrix. This was due to the Cholesky factorization complaining that the matrix was not positive definite.

The test code was also updated and corrected to test the returned covariance matrix i.e. some additional assert are tested.

I tested this with the UAV tutorial and the Sensor_Platform_Simulation example, which were having problems using the SimpleMeasurementInitiator. They both work now, however the Sensor_Platform_Simulation requires a small diag_load value to be supplied i.e. 1e-16.