### PR TITLE
Change 2D sensor/platform orientations to 3D shape

### DIFF
--- a/stonesoup/platform/base.py
+++ b/stonesoup/platform/base.py
@@ -353,8 +353,8 @@ class MovingPlatform(Platform):
             _, bearing = cart2pol(*velocity.flat)
             return StateVector([0, 0, bearing])
         else:
-            raise ValueError('Orientation of a moving platform is only implemented for 2 and 3 '
-                             'dimensions')
+            raise NotImplementedError('Orientation of a moving platform is only implemented for 2'
+                                      'and 3 dimensions')
 
     @property
     def is_moving(self) -> bool:

--- a/stonesoup/platform/base.py
+++ b/stonesoup/platform/base.py
@@ -342,7 +342,8 @@ class MovingPlatform(Platform):
         this approximations and so raises an :class:`AttributeError`
         """
         if not self.is_moving:
-            raise AttributeError('Orientation of a zero-velocity moving platform is not defined')
+            raise NotImplementedError('Orientation of a zero-velocity moving platform is not'
+                                      'defined')
         velocity = self.velocity
 
         if self.ndim == 3:
@@ -350,7 +351,7 @@ class MovingPlatform(Platform):
             return StateVector([0, bearing, elevation])
         elif self.ndim == 2:
             _, bearing = cart2pol(*velocity.flat)
-            return StateVector([0, bearing])
+            return StateVector([0, 0, bearing])
         else:
             raise ValueError('Orientation of a moving platform is only implemented for 2 and 3 '
                              'dimensions')

--- a/stonesoup/platform/tests/test_platform_base.py
+++ b/stonesoup/platform/tests/test_platform_base.py
@@ -233,12 +233,12 @@ def test_orientation_dimensionality_error():
     platform = MovingPlatform(states=platform_state, position_mapping=[0, 1, 2, 3],
                               transition_model=None)
 
-    with pytest.raises(ValueError):
+    with pytest.raises(NotImplementedError):
         _ = platform.orientation
 
     platform = MovingPlatform(states=platform_state, position_mapping=[0], transition_model=None)
 
-    with pytest.raises(ValueError):
+    with pytest.raises(NotImplementedError):
         _ = platform.orientation
 
 

--- a/stonesoup/platform/tests/test_platform_base.py
+++ b/stonesoup/platform/tests/test_platform_base.py
@@ -294,16 +294,16 @@ def test_platform_orientation_3d(state, orientation):
     assert np.allclose(platform.orientation, orientation)
 
 
-orientation_tests_2d = [(StateVector([0, 1, 0, 0]), StateVector([0, 0])),
-                        (StateVector([0, 0, 0, 1]), StateVector([0, np.pi/2])),
-                        (StateVector([0, 2, 0, 0]), StateVector([0, 0])),
-                        (StateVector([0, 0, 0, 2]), StateVector([0, np.pi/2])),
-                        (StateVector([0, 1, 0, 1]), StateVector([0, np.pi/4])),
-                        (StateVector([0, -1, 0, 0]), StateVector([0, np.pi])),
-                        (StateVector([0, 0, 0, -1]), StateVector([0, -np.pi/2])),
-                        (StateVector([0, -2, 0, 0]), StateVector([0, np.pi])),
-                        (StateVector([0, 0, 0, -2]), StateVector([0, -np.pi/2])),
-                        (StateVector([0, -1, 0, -1]), StateVector([0, -3*np.pi/4])),
+orientation_tests_2d = [(StateVector([0, 1, 0, 0]), StateVector([0, 0, 0])),
+                        (StateVector([0, 0, 0, 1]), StateVector([0, 0, np.pi/2])),
+                        (StateVector([0, 2, 0, 0]), StateVector([0, 0, 0])),
+                        (StateVector([0, 0, 0, 2]), StateVector([0, 0, np.pi/2])),
+                        (StateVector([0, 1, 0, 1]), StateVector([0, 0, np.pi/4])),
+                        (StateVector([0, -1, 0, 0]), StateVector([0, 0, np.pi])),
+                        (StateVector([0, 0, 0, -1]), StateVector([0, 0, -np.pi/2])),
+                        (StateVector([0, -2, 0, 0]), StateVector([0, 0, np.pi])),
+                        (StateVector([0, 0, 0, -2]), StateVector([0, 0, -np.pi/2])),
+                        (StateVector([0, -1, 0, -1]), StateVector([0, 0, -3*np.pi/4])),
                         ]
 
 
@@ -345,7 +345,7 @@ def test_orientation_error():
                            timestamp)
     platform = MovingPlatform(states=platform_state, transition_model=None,
                               position_mapping=[0, 2, 4])
-    with pytest.raises(AttributeError):
+    with pytest.raises(NotImplementedError):
         _ = platform.orientation
 
     platform_state = State(np.array([[2],
@@ -356,7 +356,7 @@ def test_orientation_error():
     platform = MovingPlatform(states=platform_state,
                               transition_model=None,
                               position_mapping=[0, 2])
-    with pytest.raises(AttributeError):
+    with pytest.raises(NotImplementedError):
         _ = platform.orientation
 
 

--- a/stonesoup/platform/tests/test_platform_simple.py
+++ b/stonesoup/platform/tests/test_platform_simple.py
@@ -422,11 +422,11 @@ def test_3d_platform(state, expected, move, radars_3d, mounting_offsets_3d,
 @pytest.fixture(scope='session')
 def rotation_offsets_2d():
     # Generate sensor mounting offsets for testing purposes
-    offsets = [[0, 0],
-               [np.pi / 4, 0],
-               [0, np.pi / 4],
-               [-np.pi / 4, 0],
-               [0, -np.pi / 4]]
+    offsets = [[0, 0, 0],
+               [0, 0, np.pi / 4],
+               [0, 0, -np.pi / 4],
+               [0, 0, np.pi / 2],
+               [0, 0, -np.pi / 2]]
     return [StateVector(offset) for offset in offsets]
 
 
@@ -492,25 +492,26 @@ def expected_orientations_3d():
 def expected_orientations_2d():
     pi = np.pi
     return [
-        np.array([[0., 0.], [pi/4, 0.], [0., pi/4], [-pi/4, 0.], [0., -pi/4]]),
-        np.array([[0., pi/2], [pi/4, pi/2], [0., 3 * pi/4], [-pi/4, pi/2],
-                  [0., pi/4]]),
-        np.array([[0., 0.], [pi/4, 0.], [0., pi/4], [-pi/4, 0.],
-                  [0., -pi/4]]),
-        np.array([[0., pi/2], [pi/4, pi/2], [0., 3 * pi/4], [-pi/4, pi/2],
-                  [0., pi/4]]),
-        np.array([[0., pi/4], [pi/4, pi/4], [0., pi/2], [-pi/4, pi/4],
-                  [0., 0.]]),
-        np.array([[0., pi], [pi/4, pi], [0., 5*pi/4], [-pi/4, pi],
-                  [0., 3 * pi/4]]),
-        np.array([[0., -pi/2], [pi/4, -pi/2], [0., -pi/4], [-pi/4, -pi/2],
-                  [0., -3 * pi/4]]),
-        np.array([[0., pi], [pi/4, pi], [0., 5 * pi/4], [-pi/4, pi],
-                  [0., 3 * pi/4]]),
-        np.array([[0., -pi/2], [pi/4, -pi/2], [0., -pi/4], [-pi/4, -pi/2],
-                  [0., -3 * pi/4]]),
-        np.array([[0., -3 * pi/4], [pi/4, -3 * pi/4], [0., -pi/2], [-pi/4, -3 * pi/4],
-                  [0., -pi]])
+        np.array([[0., 0., 0.], [0., 0., pi/4],  [0., 0., -pi/4], [0., 0., pi/2],
+                  [0., 0., -pi/2]]),
+        np.array([[0., 0., pi/2],  [0., 0., 3 * pi/4], [0., 0., pi/4], [0., 0., pi],
+                  [0., 0., 0.]]),
+        np.array([[0., 0., 0.],  [0., 0., pi/4], [0., 0., -pi/4], [0., 0., pi/2],
+                  [0., 0., -pi/2]]),
+        np.array([[0., 0., pi/2],  [0., 0., 3 * pi/4], [0., 0., pi/4], [0., 0., pi],
+                  [0., 0., 0.]]),
+        np.array([[0., 0., pi/4], [0., 0., pi/2], [0., 0., 0.], [0., 0., 3 * pi/4],
+                  [0., 0., -pi/4]]),
+        np.array([[0., 0., pi],  [0., 0., 5*pi/4], [0., 0., 3 * pi/4], [0., 0., 3 * pi/2],
+                  [0., 0., pi/2]]),
+        np.array([[0., 0., -pi/2], [0., 0., -pi/4], [0., 0., -3 * pi/4], [0., 0., 0.],
+                  [0., 0., -pi]]),
+        np.array([[0., 0., pi], [0., 0., 5 * pi/4], [0., 0., 3 * pi/4], [0., 0., 3 * pi/2],
+                  [0., 0., pi/2]]),
+        np.array([[0., 0., -pi/2],  [0., 0., -pi/4], [0., 0., -3 * pi/4], [0., 0., 0.],
+                  [0., 0., -pi]]),
+        np.array([[0., 0., -3 * pi/4],  [0., 0., -pi/2], [0., 0., -pi], [0., 0., -pi/4],
+                  [0., 0., -5 * pi/4]])
     ]
 
 


### PR DESCRIPTION
Returning a length 2 vector sometimes led to casting errors with platform orientations and sensor rotation offsets.

Note: May be worth allowing an input of length 1 (user inputs single bearing for 2D sensor rotation offset)