### PR TITLE
Override StateVector.flatten() and StateVector.ravel() functions

### DIFF
--- a/stonesoup/types/array.py
+++ b/stonesoup/types/array.py
@@ -111,6 +111,12 @@ class StateVector(Matrix):
             key = (key, 0)
         return super().__setitem__(key, value)
 
+    def flatten(self, *args, **kwargs):
+        return self._cast(super().flatten(*args, **kwargs))
+
+    def ravel(self, *args, **kwargs):
+        return self._cast(super().ravel(*args, **kwargs))
+
 
 class StateVectors(Matrix):
     """Wrapper for :class:`numpy.ndarray for multiple State Vectors`

--- a/stonesoup/types/tests/test_array.py
+++ b/stonesoup/types/tests/test_array.py
@@ -48,6 +48,14 @@ def test_standard_statevector_indexing():
     assert state_vector[2] == 3
     assert not isinstance(state_vector[2], StateVector)
 
+    # test behaviour of ravel and flatten functions
+    state_vector_ravel = state_vector.ravel()
+    state_vector_flatten = state_vector.flatten()
+    assert isinstance(state_vector_ravel, Matrix)
+    assert isinstance(state_vector_flatten, Matrix)
+    assert state_vector_flatten[0] == 1
+    assert state_vector_ravel[0] == 1
+
 
 def test_setting():
     state_vector_array = np.array([[1], [2], [3], [4]])


### PR DESCRIPTION
This PR fixes the indexing issues reported in #268 