### PR TITLE
Fix caching issue with states/mutable-sequences with predictor

### DIFF
--- a/stonesoup/predictor/_utils.py
+++ b/stonesoup/predictor/_utils.py
@@ -1,0 +1,27 @@
+# coding: utf-8
+import functools
+
+from ..types.state import StateMutableSequence
+
+
+def predict_lru_cache(*args, **kwargs):
+    """LRU Cache decorator for :meth:`~.Predictor.predict` methods
+
+    This ensures the current state is extracted for the LRU cache to function
+    correctly, as caching should be on current state, not on mutable sequence.
+
+    This should function same as :class:`functools.lru_cache` otherwise.
+    """
+
+    lru_cache_instance = functools.lru_cache(*args, **kwargs)
+
+    def decorator(func):
+        func = lru_cache_instance(func)
+
+        @functools.wraps(func)
+        def predict(self, prior, *args, **kwargs):
+            if isinstance(prior, StateMutableSequence):
+                prior = prior.state
+            return func(self, prior, *args, **kwargs)
+        return predict
+    return decorator

--- a/stonesoup/predictor/kalman.py
+++ b/stonesoup/predictor/kalman.py
@@ -1,10 +1,11 @@
 # -*- coding: utf-8 -*-
 
 import numpy as np
-from functools import lru_cache, partial
+from functools import partial
 
-from ..base import Property
 from .base import Predictor
+from ._utils import predict_lru_cache
+from ..base import Property
 from ..types.prediction import GaussianStatePrediction
 from ..models.base import LinearModel
 from ..models.transition import TransitionModel
@@ -133,7 +134,7 @@ class KalmanPredictor(Predictor):
 
         return predict_over_interval
 
-    @lru_cache()
+    @predict_lru_cache()
     def predict(self, prior, timestamp=None, **kwargs):
         r"""The predict function
 
@@ -324,7 +325,7 @@ class UnscentedKalmanPredictor(KalmanPredictor):
         return (self.transition_model.function(prior_state, **kwargs)
                 + self.control_model.control_input())
 
-    @lru_cache()
+    @predict_lru_cache()
     def predict(self, prior, timestamp=None, **kwargs):
         r"""The unscented version of the predict step
 

--- a/stonesoup/predictor/particle.py
+++ b/stonesoup/predictor/particle.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
-from functools import lru_cache
-
 from .base import Predictor
+from ._utils import predict_lru_cache
 from ..types.particle import Particle
 from ..types.prediction import ParticleStatePrediction
 
@@ -12,7 +11,7 @@ class ParticlePredictor(Predictor):
     An implementation of a Particle Filter predictor.
     """
 
-    @lru_cache()
+    @predict_lru_cache()
     def predict(self, prior, control_input=None, timestamp=None, **kwargs):
         """Particle Filter prediction step
 


### PR DESCRIPTION
When passing a `StateMutableSequence` (e.g. a track) to a predictor using caching, the cache can incorrectly return results if same track and time stamp are passed in multiple times. This can be the case with multi-sensor example, where an update has occurred from one sensor, then a detection from another sensor is processed at the same time stamp.

This fixes the issue by using a custom lru_cache decorator that extracts the current state if input is mutable sequence.