### PR TITLE
Fix rounding error issues for int-based state vectors in gauss2sigma

### DIFF
--- a/stonesoup/functions.py
+++ b/stonesoup/functions.py
@@ -130,6 +130,11 @@ def gauss2sigma(state, alpha=1.0, beta=2.0, kappa=None):
 
     # Calculate sigma point locations
     sigma_points = StateVectors([state.state_vector for _ in range(2 * ndim_state + 1)])
+
+    # Cast dtype from int to float to avoid rounding errors
+    if np.issubdtype(sigma_points.dtype, np.integer):
+        sigma_points = sigma_points.astype(float)
+
     # Can't use in place addition/subtraction as casting issues may arise when mixing float/int
     sigma_points[:, 1:(ndim_state + 1)] = \
         sigma_points[:, 1:(ndim_state + 1)] + sqrt_sigma*np.sqrt(c)

--- a/stonesoup/tests/test_functions.py
+++ b/stonesoup/tests/test_functions.py
@@ -114,8 +114,14 @@ def test_elevation():
         assert rad_out[ind] == approx(mod_elevation(val))
 
 
-def test_gauss2sigma_float():
-    mean = 1.0
+@pytest.mark.parametrize(
+    "mean",
+    [
+        1,      # int
+        1.0     # float
+    ]
+)
+def test_gauss2sigma(mean):
     covar = 2.0
     state = GaussianState([[mean]], [[covar]])
 
@@ -123,19 +129,6 @@ def test_gauss2sigma_float():
 
     for n, sigma_point_state in zip((0, 1, -1), sigma_points_states):
         assert sigma_point_state.state_vector[0, 0] == approx(mean + n*covar**0.5)
-
-
-def test_gauss2sigma_int():
-    mean = 1
-    covar = 2.0
-    state = GaussianState([[mean]], [[covar]])
-
-    sigma_points_states, mean_weights, covar_weights = gauss2sigma(state, kappa=0)
-
-    for n, sigma_point_state in zip((0, 1, -1), sigma_points_states):
-        # Resultant sigma points are still ints
-        assert sigma_point_state.state_vector[0, 0] == int(mean + n*covar**0.5)
-        assert isinstance(sigma_point_state.state_vector[0, 0], np.integer)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR aims to fix the issue reported in #277 