### PR TITLE
Fix warnings raised for NumPy NEP34 and sensor reassignment

### DIFF
--- a/stonesoup/models/measurement/tests/test_models.py
+++ b/stonesoup/models/measurement/tests/test_models.py
@@ -18,9 +18,9 @@ from ....types.state import State, CovarianceMatrix
 
 
 def h1d(state_vector, pos_map, translation_offset, rotation_offset):
-    xyz = [[state_vector[0, 0] - translation_offset[0, 0]],
-           [state_vector[1, 0] - translation_offset[1, 0]],
-           [0]]
+    xyz = StateVector([[state_vector[0, 0] - translation_offset[0, 0]],
+                      [state_vector[1, 0] - translation_offset[1, 0]],
+                      [0]])
 
     # Get rotation matrix
     theta_x, theta_y, theta_z = - rotation_offset[:, 0]
@@ -35,9 +35,9 @@ def h1d(state_vector, pos_map, translation_offset, rotation_offset):
 
 def h2d(state_vector, pos_map, translation_offset, rotation_offset):
 
-    xyz = [[state_vector[0, 0] - translation_offset[0, 0]],
-           [state_vector[1, 0] - translation_offset[1, 0]],
-           [0]]
+    xyz = StateVector([[state_vector[0, 0] - translation_offset[0, 0]],
+                      [state_vector[1, 0] - translation_offset[1, 0]],
+                      [0]])
 
     # Get rotation matrix
     theta_x, theta_y, theta_z = - rotation_offset[:, 0]
@@ -304,9 +304,9 @@ def test_angle_pdf():
 
 def h2d_rr(state_vector, pos_map, vel_map, translation_offset, rotation_offset, velocity):
 
-    xyz = np.array([[state_vector[pos_map[0], 0] - translation_offset[0, 0]],
-                    [state_vector[pos_map[1], 0] - translation_offset[1, 0]],
-                    [0]])
+    xyz = StateVector([[state_vector[pos_map[0], 0] - translation_offset[0, 0]],
+                      [state_vector[pos_map[1], 0] - translation_offset[1, 0]],
+                      [0]])
 
     # Get rotation matrix
     theta_x, theta_y, theta_z = - rotation_offset[:, 0]

--- a/stonesoup/sensor/radar/tests/test_radar.py
+++ b/stonesoup/sensor/radar/tests/test_radar.py
@@ -18,9 +18,9 @@ from ....models.measurement.linear import LinearGaussian
 
 def h2d(state, pos_map, translation_offset, rotation_offset):
 
-    xyz = [[state.state_vector[pos_map[0], 0] - translation_offset[0, 0]],
-           [state.state_vector[pos_map[1], 0] - translation_offset[1, 0]],
-           [0]]
+    xyz = StateVector([[state.state_vector[pos_map[0], 0] - translation_offset[0, 0]],
+                      [state.state_vector[pos_map[1], 0] - translation_offset[1, 0]],
+                      [0]])
 
     # Get rotation matrix
     theta_z = -rotation_offset[2, 0]
@@ -108,9 +108,9 @@ def test_simple_radar(h, sensorclass, ndim_state, pos_mapping, noise_covar, posi
 
 def h2d_rr(state, pos_map, vel_map, translation_offset, rotation_offset, velocity):
 
-    xyz = np.array([[state.state_vector[pos_map[0], 0] - translation_offset[0, 0]],
-                    [state.state_vector[pos_map[1], 0] - translation_offset[1, 0]],
-                    [0]])
+    xyz = StateVector([[state.state_vector[pos_map[0], 0] - translation_offset[0, 0]],
+                      [state.state_vector[pos_map[1], 0] - translation_offset[1, 0]],
+                      [0]])
 
     # Get rotation matrix
     theta_z = - rotation_offset[2, 0]

--- a/stonesoup/sensor/tests/test_sensor.py
+++ b/stonesoup/sensor/tests/test_sensor.py
@@ -148,8 +148,9 @@ def test_sensor_assignment(radar_platform_target):
     radar_2 = copy.deepcopy(radar_1)
     radar_3 = copy.deepcopy(radar_1)
 
-    platform.add_sensor(radar_2)
-    platform.add_sensor(radar_3)
+    with pytest.warns(UserWarning, match="Sensor has been moved from one platform to another"):
+        platform.add_sensor(radar_2)
+        platform.add_sensor(radar_3)
 
     assert len(platform.sensors) == 3
     validate_lengths(platform)
@@ -166,7 +167,8 @@ def test_sensor_assignment(radar_platform_target):
     validate_lengths(platform)
     assert platform.sensors == (radar_1, radar_3)
 
-    platform.add_sensor(radar_2)
+    with pytest.warns(UserWarning, match="Sensor has been moved from one platform to another"):
+        platform.add_sensor(radar_2)
     assert len(platform.sensors) == 3
     validate_lengths(platform)
     assert platform.sensors == (radar_1, radar_3, radar_2)


### PR DESCRIPTION
Issue in tests was caused by have state vector which was just lists of lists, rather than `StateVector` or `numpy.ndarray` (warning currently, but future will raise error). Also catch expected warnings raised when reassigning sensors to another platform.