### PR TITLE
Add CombinedNonlinearGaussianTransitionModel

### DIFF
--- a/docs/source/stonesoup.models.transition.rst
+++ b/docs/source/stonesoup.models.transition.rst
@@ -12,3 +12,9 @@ Linear
 .. automodule:: stonesoup.models.transition.linear
     :show-inheritance:
     :inherited-members:
+
+NonLinear
+---------
+.. automodule:: stonesoup.models.transition.nonlinear
+    :show-inheritance:
+    :inherited-members:

--- a/stonesoup/models/transition/nonlinear.py
+++ b/stonesoup/models/transition/nonlinear.py
@@ -1,0 +1,45 @@
+
+import copy
+
+import numpy as np
+
+from ...types.state import StateVector
+from .base import _CombinedGaussianTransitionModel
+
+
+class CombinedNonlinearGaussianTransitionModel(_CombinedGaussianTransitionModel):
+    r"""Combine multiple models into a single model by stacking them.
+
+    The assumption is that all models are Gaussian.
+    Time Variant, and Time Invariant models can be combined together.
+    If any of the models are time variant the keyword argument "time_interval"
+    must be supplied to all methods
+    """
+
+    def function(self, state, **kwargs) -> StateVector:
+        """Applies each transition model in :py:attr:`~model_list` in turn to the state's
+        corresponding state vector components.
+        For example, in a 3D state space, with :py:attr:`~model_list` = [modelA(ndim_state=2),
+        modelB(ndim_state=1)], this would apply modelA to the state vector's 1st and 2nd elements,
+        then modelB to the remaining 3rd element.
+
+        Parameters
+        ----------
+        state : :class:`stonesoup.state.State`
+            The state to be transitioned according to the models in :py:attr:`~model_list`.
+
+        Returns
+        -------
+        state_vector: :class:`stonesoup.types.array.StateVector`
+            of shape (:py:attr:`~ndim_state, 1`). The resultant state vector of the transition.
+        """
+        temp_state = copy.copy(state)
+        ndim_count = 0
+        state_vector = np.zeros((self.ndim_state, 1)).view(StateVector)
+        for model in self.model_list:
+            temp_state.state_vector =\
+                state.state_vector[ndim_count:model.ndim_state + ndim_count, :]
+            state_vector[ndim_count:model.ndim_state + ndim_count, :] += model.function(temp_state,
+                                                                                        **kwargs)
+            ndim_count += model.ndim_state
+        return state_vector

--- a/stonesoup/models/transition/tests/test_combined.py
+++ b/stonesoup/models/transition/tests/test_combined.py
@@ -4,13 +4,13 @@ from numbers import Real
 
 import numpy as np
 
-from ..linear import (
-    LinearGaussianTimeInvariantTransitionModel, ConstantVelocity,
-    CombinedLinearGaussianTransitionModel)
+from ..linear import (LinearGaussianTimeInvariantTransitionModel, ConstantVelocity,
+                      CombinedLinearGaussianTransitionModel)
+from ..nonlinear import CombinedNonlinearGaussianTransitionModel
 from ....types.state import State
 
 
-def test_combined():
+def test__linear_combined():
     F = 3*np.eye(3)
     Q = 3*np.eye(3)
     model_1 = LinearGaussianTimeInvariantTransitionModel(
@@ -33,6 +33,36 @@ def test_combined():
     assert (DIM, DIM) == combined_model.covar(time_interval=t_delta).shape
     assert (DIM, 1) == combined_model.function(
         State(x_prior), noise=np.random.randn(DIM, 1),
+        time_interval=t_delta).shape
+    assert (DIM, 1) == combined_model.rvs(time_interval=t_delta).shape
+    assert isinstance(
+        combined_model.pdf(State(x_post), State(x_prior),
+                           time_interval=t_delta), Real)
+
+
+# TODO: Should use non-linear transition models when these are implemented in Stone Soup.
+def test_nonlinear_combined():
+    F = 3*np.eye(3)
+    Q = 3*np.eye(3)
+    model_1 = LinearGaussianTimeInvariantTransitionModel(
+        transition_matrix=F, covariance_matrix=Q)
+    model_2 = ConstantVelocity(noise_diff_coeff=3)
+    model_3 = ConstantVelocity(noise_diff_coeff=1)
+    model_4 = ConstantVelocity(noise_diff_coeff=1)
+
+    DIM = 9
+
+    combined_model = CombinedNonlinearGaussianTransitionModel(
+        [model_1, model_2, model_3, model_4])
+    t_delta = datetime.timedelta(0, 3)
+
+    x_prior = np.ones([DIM, 1])
+    x_post = np.ones([DIM, 1])
+
+    assert DIM == combined_model.ndim_state
+    assert (DIM, DIM) == combined_model.covar(time_interval=t_delta).shape
+    assert (DIM, 1) == combined_model.function(
+        State(x_prior), noise=True,
         time_interval=t_delta).shape
     assert (DIM, 1) == combined_model.rvs(time_interval=t_delta).shape
     assert isinstance(


### PR DESCRIPTION
To accommodate combinations of transition models that do not have matrix representations (or other non-linear aspects), a new combined model was needed.
This also adds a new base class for combined models to inherit from.

Notes:
-Test is currently a copy of the linear equivalent. This should be altered when non-linear transition models are added to Stone Soup.