### PR TITLE
PHD-EF Filter for soft-hard data fusion

### DIFF
--- a/stonesoup/hypothesiser/distance.py
+++ b/stonesoup/hypothesiser/distance.py
@@ -3,7 +3,7 @@ from .base import Hypothesiser
 from ..base import Property
 from ..measures import Measure
 from ..predictor import Predictor
-from ..types.detection import MissedDetection
+from ..types.detection import MissedDetection, GaussianMixtureDetection
 from ..types.hypothesis import SingleDistanceHypothesis
 from ..types.multihypothesis import MultipleHypothesis
 from ..updater import Updater
@@ -81,18 +81,34 @@ class DistanceHypothesiser(Hypothesiser):
             prediction = self.predictor.predict(
                 track, timestamp=detection.timestamp)
 
-            # Compute measurement prediction and distance measure
-            measurement_prediction = self.updater.predict_measurement(
-                prediction, detection.measurement_model)
-            distance = self.measure(measurement_prediction, detection)
+            if hasattr(detection, 'components') == True:              
+                # Compute measurement prediction and distance measure for Soft measurements (PHD-EF filter)
+                for sub_detection in detection.components:
+                    measurement_prediction = self.updater.predict_measurement(
+                            prediction, detection.measurement_model)
+                    distance = self.measure(measurement_prediction, sub_detection)
+                    
+                    if self.include_all or distance < self.missed_distance:
+                    # True detection hypothesis
+                        hypotheses.append(
+                            SingleDistanceHypothesis(
+                                prediction,
+                                GaussianMixtureDetection([sub_detection], timestamp=detection.timestamp, measurement_model=detection.measurement_model, metadata=detection.metadata),
+                                distance,
+                                measurement_prediction))
+            else:
+                # Compute measurement prediction and distance measure 
+                measurement_prediction = self.updater.predict_measurement(
+                        prediction, detection.measurement_model)
+                distance = self.measure(measurement_prediction, detection)
 
-            if self.include_all or distance < self.missed_distance:
-                # True detection hypothesis
-                hypotheses.append(
-                    SingleDistanceHypothesis(
-                        prediction,
-                        detection,
-                        distance,
-                        measurement_prediction))
+                if self.include_all or distance < self.missed_distance:
+                    # True detection hypothesis
+                    hypotheses.append(
+                        SingleDistanceHypothesis(
+                            prediction,
+                            detection,
+                            distance,
+                            measurement_prediction))
 
         return MultipleHypothesis(sorted(hypotheses, reverse=True))

--- a/stonesoup/hypothesiser/gaussianmixture.py
+++ b/stonesoup/hypothesiser/gaussianmixture.py
@@ -93,13 +93,25 @@ class GaussianMixtureHypothesiser(Hypothesiser):
             # Get miss detected components
             miss_detections_hypothesis = MultipleHypothesis(
                 [x for x in single_hypothesis_list if not x])
+            
+            # Get Soft detections
+            soft_detect_list = [x for x in single_hypothesis_list if x]
             for detection in detections:
-                # Create multiple hypothesis per detection
-                detection_multiple_hypothesis = \
-                    MultipleHypothesis(list([hypothesis for hypothesis in single_hypothesis_list
+                if hasattr(detection, 'components') == True:      
+                    for sub_detection in detection.components:
+                        # Create multiple hypothesis per GM component
+                        detection_multiple_hypothesis = \
+                            MultipleHypothesis(list([hypothesis for hypothesis in soft_detect_list
+                                                if hypothesis.measurement.components == sub_detection])) 
+                        # Add to new list
+                        reordered_hypotheses.append(detection_multiple_hypothesis)                
+                else:
+                    # Create multiple hypothesis per detection
+                    detection_multiple_hypothesis = \
+                        MultipleHypothesis(list([hypothesis for hypothesis in single_hypothesis_list
                                             if hypothesis.measurement == detection]))
-                # Add to new list
-                reordered_hypotheses.append(detection_multiple_hypothesis)
+                    # Add to new list
+                    reordered_hypotheses.append(detection_multiple_hypothesis)                    
             # Add miss detected hypothesis to end
             reordered_hypotheses.append(miss_detections_hypothesis)
             # Assign reordered list to original list

--- a/stonesoup/types/detection.py
+++ b/stonesoup/types/detection.py
@@ -2,6 +2,7 @@
 from ..base import Property
 from .groundtruth import GroundTruthPath
 from .state import State, GaussianState, StateVector
+from .mixture import GaussianMixture
 from ..models.measurement import MeasurementModel
 
 
@@ -22,6 +23,11 @@ class Detection(State):
 
 class GaussianDetection(Detection, GaussianState):
     """GaussianDetection type"""
+
+
+class GaussianMixtureDetection(Detection, GaussianMixture):
+    """GaussianMixtureDetection type"""
+    state_vector = None  # Remove state_vector inherited from Detection
 
 
 class Clutter(Detection):


### PR DESCRIPTION
The PHD evidential filter (PHD-EF) is able to accept and process hard data as well as specific type of human-generated soft data, i.e., fuzzy Dempster-Shafer measurements. The PHD-EF can be considered as the generalization of popular GM-PHD filter in the sense that the GM-PHD filter is only able to process hard data.

The PHD-EF is implemented by modifying GM-PHD codes. The attached file provides the algorithmic representation of the PHD-EF, which follows the algorithmic procedure of GM-PHD filter. 

[PHD-EF Algorithm.pdf](https://github.com/dstl/Stone-Soup/files/5123626/PHD-EF.Algorithm.pdf)

