### PR TITLE
Fix leftover open file handles.

### DIFF
--- a/stonesoup/reader/file.py
+++ b/stonesoup/reader/file.py
@@ -16,17 +16,6 @@ class FileReader(Reader):
         if not isinstance(path, Path):
             path = Path(path)  # Ensure Path
         super().__init__(path, *args, **kwargs)
-        self._file = None
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, *args):
-        if getattr(self, '_file', None):
-            self._file.close()
-
-    def __del__(self):
-        self.__exit__()
 
 
 class BinaryFileReader(FileReader):
@@ -34,7 +23,6 @@ class BinaryFileReader(FileReader):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self._file = self.path.open('rb')
 
 
 class TextFileReader(FileReader):
@@ -45,4 +33,3 @@ class TextFileReader(FileReader):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self._file = self.path.open('r', encoding=self.encoding)


### PR DESCRIPTION
This fix removes the dangling file handlers the were created on initialization inside the Reader classes. This generally wasn't an issue until to you changed git branches and git tried to modify the csv file that had an open file handle. I've left in the custom initialization for the Text and Binary subclasses because we will likely add something at some point.

Resolves #254.