### PR TITLE
Fix rotating radar test

### DIFF
--- a/stonesoup/sensor/radar/tests/test_radar.py
+++ b/stonesoup/sensor/radar/tests/test_radar.py
@@ -308,7 +308,7 @@ def test_rotating_radar():
     truth.add(target_state)
 
     # Generate a noiseless measurement for each of the given target states
-    measurements = radar.measure(truth)
+    measurements = radar.measure(truth, noise=False)
 
     # Two measurements for 2 truth states
     assert len(measurements) == 2


### PR DESCRIPTION
Sometimes the addition of noise to the last measurement call led to a target being out of the fov of the radar.