### PR TITLE
Change 'Ambiguity' metric to return 1 when there are no tracks/truths

### DIFF
--- a/stonesoup/metricgenerator/tracktotruthmetrics.py
+++ b/stonesoup/metricgenerator/tracktotruthmetrics.py
@@ -185,7 +185,7 @@ class SIAPMetrics(MetricGenerator):
         except ZeroDivisionError:
             self._warn_no_truth(manager)
             self._warn_no_tracks(manager)
-            A = 0
+            A = 1
         return TimeRangeMetric(
             title="SIAP A",
             value=A,


### PR DESCRIPTION
When there are no tracks or truths, there is no ambiguity as to track association. Therefore the target score of 1 makes more sense to return than the 'worst-case' of 0. [ci skip]