### PR TITLE
Add GaussianState initialization to WeightedGaussianState.

### DIFF
--- a/stonesoup/types/state.py
+++ b/stonesoup/types/state.py
@@ -130,7 +130,9 @@ class GaussianState(State):
     covar: CovarianceMatrix = Property(doc='Covariance matrix of state.')
 
     def __init__(self, state_vector, covar, *args, **kwargs):
-        covar = CovarianceMatrix(covar)
+        # Don't cast away subtype of covar if not necessary
+        if not isinstance(covar, CovarianceMatrix):
+            covar = CovarianceMatrix(covar)
         super().__init__(state_vector, covar, *args, **kwargs)
         if self.state_vector.shape[0] != self.covar.shape[0]:
             raise ValueError(
@@ -184,6 +186,48 @@ class WeightedGaussianState(GaussianState):
     for a GaussianMixtureState.
     """
     weight: Probability = Property(default=0, doc="Weight of the Gaussian State.")
+
+    @property
+    def gaussian_state(self):
+        """The Gaussian state."""
+        return GaussianState(self.state_vector,
+                             self.covar,
+                             timestamp=self.timestamp)
+
+    @classmethod
+    def from_gaussian_state(cls, gaussian_state, *args, copy=True, **kwargs):
+        r"""
+        Returns a WeightedGaussianState instance based on the gaussian_state.
+
+        Parameters
+        ----------
+        gaussian_state : :class:`~.GaussianState`
+            The guassian_state used to create the new WeightedGaussianState.
+        \*args : See main :class:`~.WeightedGaussianState`
+            args are passed to :class:`~.WeightedGaussianState` __init__()
+        copy : Boolean, optional
+            If True, the WeightedGaussianState is created with copies of the elements
+            of gaussian_state. The default is True.
+        \*\*kwargs : See main :class:`~.WeightedGaussianState`
+            kwargs are passed to :class:`~.WeightedGaussianState` __init__()
+
+        Returns
+        -------
+        :class:`~.WeightedGaussianState`
+            Instance of WeightedGaussianState.
+        """
+        state_vector = gaussian_state.state_vector
+        covar = gaussian_state.covar
+        timestamp = gaussian_state.timestamp
+        if copy:
+            state_vector = state_vector.copy()
+            covar = covar.copy()
+        return cls(
+            state_vector=state_vector,
+            covar=covar,
+            timestamp=timestamp,
+            *args, **kwargs
+        )
 
 
 class TaggedWeightedGaussianState(WeightedGaussianState):

--- a/stonesoup/types/tests/test_state.py
+++ b/stonesoup/types/tests/test_state.py
@@ -99,9 +99,33 @@ def test_weighted_gaussian_state():
     mean = StateVector([[1], [2], [3], [4]])  # 4D
     covar = CovarianceMatrix(np.diag([1, 2, 3]))  # 3D
     weight = 0.3
+    timestamp = datetime.datetime.now()
     with pytest.raises(ValueError):
-        a = WeightedGaussianState(mean, covar, weight)
-        assert a.weight == weight
+        WeightedGaussianState(mean, covar, timestamp, weight)
+
+    # Test initialization using a GuassianState
+    mean = StateVector([[1], [2], [3], [4]])  # 4D
+    covar = CovarianceMatrix(np.diag([1, 2, 3, 4]))
+    weight = 0.3
+    gs = GaussianState(mean, covar, timestamp=timestamp)
+    wgs = WeightedGaussianState.from_gaussian_state(gaussian_state=gs, weight=weight)
+    assert np.array_equal(gs.state_vector, wgs.state_vector)
+    assert np.array_equal(gs.covar, wgs.covar)
+    assert gs.timestamp == wgs.timestamp
+    assert weight == wgs.weight
+    assert wgs.state_vector is not gs.state_vector
+    assert wgs.covar is not gs.covar
+
+    # Test copy flag
+    wgs = WeightedGaussianState.from_gaussian_state(gaussian_state=gs, copy=False)
+    assert wgs.state_vector is gs.state_vector
+    assert wgs.covar is gs.covar
+
+    # Test gaussian_state property
+    gs2 = wgs.gaussian_state
+    assert np.array_equal(gs.state_vector, gs2.state_vector)
+    assert np.array_equal(gs.covar, gs2.covar)
+    assert gs.timestamp == gs2.timestamp
 
 
 def test_particlestate():


### PR DESCRIPTION
This change allows a WeightedGaussianState to be created from a GaussianState, rather than specifying, state, cover and timestamp individually. It throws an exception if you over specify i.e. give it a state and a GaussianState. 

There are a couple ways of doing this - I choose not to have the gaussian_state as a Property, because this could lead to an inconsistency in the Timestamps. Note - changes to the state_vector or covar would be linked i.e. changing one would change the other. 

Please check the generated documentation to see if the appropriate.

Note - I also fixed an issue in the unit test. It wasn't properly testing the weight Property.
