### PR TITLE
WIP: Add handling of various prior types predictors/updater

### DIFF
--- a/stonesoup/predictor/kalman.py
+++ b/stonesoup/predictor/kalman.py
@@ -7,7 +7,6 @@ from functools import partial
 from .base import Predictor
 from ._utils import predict_lru_cache
 from ..base import Property
-from ..types.prediction import GaussianStatePrediction, SqrtGaussianStatePrediction
 from ..models.base import LinearModel
 from ..models.transition import TransitionModel
 from ..models.transition.linear import LinearGaussianTransitionModel


### PR DESCRIPTION
This PR aims to add the ability for predictors/updaters to produce the appropriate Prediction/Update, depending on the type of the provided prior/prediction.

The code in this PR has stemmed from discussions with @jswright-dstl and @sgmranso. The idea is that if a predictor is provided with a prior that is not of a "base" state (e.g. GaussianState), but rather a subclass (e.g. WeightedGaussianState), the generated prediction should be of a prediction type that matched the type of the prior. The predictor will only modify the properties that it needs to, and will preserve all other properties that are members of the identified prediction type.

So far, only the code for the KalmanPredictor (and its subclasses has been coded), but the same concept can be applied to other predictors and updaters.  