### PR TITLE
Modify tracks to store metadata history

### DIFF
--- a/stonesoup/metricgenerator/tests/test_tracktotruthmetrics.py
+++ b/stonesoup/metricgenerator/tests/test_tracktotruthmetrics.py
@@ -407,13 +407,13 @@ def test_id(generator):
 
     track1 = Track(
         states=[State([[1], [0], [0], [0]], timestamp=tstart + datetime.timedelta(seconds=i))
-                for i in range(5)])
-    track1._metadata = {'ident': 'ally'}
+                for i in range(5)],
+        init_metadata={'ident': 'ally'})
 
     track2 = Track(
         states=[State([[2], [0], [0], [0]], timestamp=tstart + datetime.timedelta(seconds=i))
-                for i in range(5)])
-    track2._metadata = {'ident': 'enemy'}
+                for i in range(5)],
+        init_metadata={'ident': 'enemy'})
 
     track3 = Track(
         states=[State([[3], [0], [0], [0]], timestamp=tstart + datetime.timedelta(seconds=i))
@@ -465,31 +465,30 @@ def test_compute_metric(generator):
         for i in range(40)])
     track1 = Track(
         states=[State([[1], [0], [0], [0]], timestamp=tstart + datetime.timedelta(seconds=i))
-                for i in range(3)])
-    track1._metadata = {'ident': 'ally'}
+                for i in range(3)],
+        init_metadata={'ident': 'ally'})
     track2 = Track(
         states=[State([[2], [0], [0], [0]], timestamp=tstart + datetime.timedelta(seconds=i))
-                for i in range(5, 10)])
-    track2._metadata = {'ident': 'enemy'}
+                for i in range(5, 10)],
+        init_metadata={'ident': 'enemy'})
     track3 = Track(
         states=[State([[3], [0], [0], [0]], timestamp=tstart + datetime.timedelta(seconds=i))
                 for i in range(7, 15)])
-    track3._metadata = {}
     track4 = Track(
         states=[State([[4], [0], [0], [0]], timestamp=tstart + datetime.timedelta(seconds=i))
-                for i in range(13, 20)])
-    track4._metadata = {'ident': 'ally'}
+                for i in range(13, 20)],
+        init_metadata={'ident': 'ally'})
     track5 = Track(
         states=[State([[5], [0], [0], [0]], timestamp=tstart + datetime.timedelta(seconds=i))
-                for i in range(18, 28)])
-    track5._metadata = {'something': 'ally'}
+                for i in range(18, 28)],
+        init_metadata={'something': 'ally'})
     track6 = Track(
         states=[State([[6], [0], [0], [0]], timestamp=tstart + datetime.timedelta(seconds=i))
                 for i in range(22, 26)])
     track7 = Track(
         states=[State([[7], [0], [0], [0]], timestamp=tstart + datetime.timedelta(seconds=i))
-                for i in range(30, 40)])
-    track7._metadata = {'ident': None}
+                for i in range(30, 40)],
+        init_metadata={'ident': None})
     track8 = Track(
         states=[State([[8], [0], [0], [0]], timestamp=tstart + datetime.timedelta(seconds=i))
                 for i in range(30, 35)])
@@ -848,12 +847,12 @@ def test_absent_params():
         for i in range(40)])
     track1 = Track(
         states=[State([[1], [0], [0], [0]], timestamp=tstart + datetime.timedelta(seconds=i))
-                for i in range(3)])
-    track1._metadata = {'ident': 'ally'}
+                for i in range(3)],
+        init_metadata={'ident': 'ally'})
     track2 = Track(
         states=[State([[2], [0], [0], [0]], timestamp=tstart + datetime.timedelta(seconds=i))
-                for i in range(5, 10)])
-    track2._metadata = {'ident': 'enemy'}
+                for i in range(5, 10)],
+        init_metadata={'ident': 'enemy'})
 
     manager.tracks = {track1, track2}
     manager.groundtruth_paths = {truth}

--- a/stonesoup/types/track.py
+++ b/stonesoup/types/track.py
@@ -1,80 +1,121 @@
 # -*- coding: utf-8 -*-
 import uuid
-from typing import MutableSequence
+from typing import MutableSequence, MutableMapping
 
-from ..base import Property
 from .multihypothesis import MultipleHypothesis
 from .state import State, StateMutableSequence
 from .update import Update
+from ..base import Property
 
 
 class Track(StateMutableSequence):
     """Track type
 
     A :class:`~.StateMutableSequence` representing a track.
+
+    Notes:
+        Any manual modifications to :attr:`metadata` or :attr:`metadatas` will be overwritten if a
+        state is inserted at a point prior to where the modifications are made.
+        For example, inserting a state at the start of :attr:`states` will result in a
+        :attr:`metadatas` update that will update all subsequent metadata values, resulting in
+        manual metadata modifications being lost.
     """
 
     states: MutableSequence[State] = Property(
         default=None,
-        doc="The initial states of the track. Default `None` which initialises"
-            "with empty list.")
+        doc="The initial states of the track. Default `None` which initialises with empty list.")
 
-    id: str = Property(
-        default=None,
-        doc="The unique track ID")
+    id: str = Property(default=None, doc="The unique track ID")
+
+    init_metadata: MutableMapping = Property(
+        default={}, doc="Initial dictionary of metadata items for track. Default `None` which "
+                        "initialises track metadata as an empty dictionary.")
 
     def __init__(self, *args, **kwargs):
+
         super().__init__(*args, **kwargs)
-        # Initialise metadata
-        self._metadata = {}
+
+        self.metadatas = list()
+
         for state in self.states:
             self._update_metadata_from_state(state)
         if self.id is None:
             self.id = str(uuid.uuid4())
 
     def __setitem__(self, index, value):
-        # Update metadata
-        self._update_metadata_from_state(value)
-        return super().__setitem__(index, value)
+        super().__setitem__(index, value)
+        if index < 0:
+            index = len(self.states) + index
+        self._update_metadatas(index)
 
     def insert(self, index, value):
-        # Update metadata
-        self._update_metadata_from_state(value)
-        return super().insert(index, value)
+        """Insert value at index of :attr:`states`.
+
+        Parameters
+        ----------
+        index: int
+            Index of :attr:`states` to insert value at.
+        value: State
+            A state object to be inserted at the specified index of :attr:`states`.
+        """
+        super().insert(index, value)
+
+        if index < 0:
+            if index < -len(self.states):
+                index = 0
+            else:
+                index += len(self.states) - 1
+        elif index >= len(self.states):
+            index = len(self.states) - 1
+        self._update_metadatas(index)
 
     def append(self, value):
+        """Add value at end of :attr:`states`.
+
+        Parameters
+        ----------
+        value: State
+            A state object to be added at the end of :attr:`states`.
+        """
         # Update metadata
         self._update_metadata_from_state(value)
         return self.states.append(value)
 
     @property
     def metadata(self):
-        """Returns metadata associated with a track.
+        """Current metadata dictionary of track. If track contains no states, this is the initial
+        metadata dictionary :attr:`init_metadata`."""
+        if self.metadatas:
+            return self.metadatas[-1]
+        else:
+            return self.init_metadata
+
+    def _update_metadatas(self, index):
+        """Update track :attr:`metadatas` property, starting at specified index.
 
         Parameters
         ----------
-        None
-
-        Returns
-        -------
-        : :class:`dict` of variable size
-            All metadata associate with this track.
+        index: Int
+            Index of :attr:`metadatas` to update from.
         """
+        # Plus one for 0th initial track meta data
+        self.metadatas = self.metadatas[:index]
 
-        return self._metadata
+        for future_state in self.states[index:]:
+            self._update_metadata_from_state(future_state)
 
     def _update_metadata_from_state(self, state):
-        """ Extract and update track metadata, given a state
+        """Update :attr:`metadatas` with an updated metadata entry, accounting for extracted
+        metadata from state.
 
         Parameters
         ----------
         state: State
-            A state object from which to extract metadata. Metadata can only
-            be extracted from Update (or subclassed) objects. Calling this
-            method with a non-Update (subclass) object will NOT return an
-            error, but will have no effect on the metadata.
-
+            A state object from which to extract metadata. Metadata can only be extracted from
+            Update (or subclassed) objects. Calling this method with a non-Update (subclass) object
+            will NOT raise an error, but will have no effect on the metadata.
         """
+        self.metadatas.append(self.metadata.copy())
 
         if isinstance(state, Update):
             if isinstance(state.hypothesis, MultipleHypothesis):
@@ -86,8 +127,8 @@ class Track(StateMutableSequence):
                 for hypothesis in sorted(state.hypothesis, reverse=True):
                     if hypothesis \
                             and hypothesis.measurement.metadata is not None:
-                        self._metadata.update(hypothesis.measurement.metadata)
+                        self.metadata.update(hypothesis.measurement.metadata)
             else:
                 hypothesis = state.hypothesis
                 if hypothesis and hypothesis.measurement.metadata is not None:
-                    self._metadata.update(hypothesis.measurement.metadata)
+                    self.metadata.update(hypothesis.measurement.metadata)


### PR DESCRIPTION
Storing a track's metadata history will allow for metadata comparisons in metric generation.
Previously, calling `track.metadata` would return the track's metadata value at the end of its life.