### PR TITLE
Fix rotating radar to handle measuring empty sets

### DIFF
--- a/stonesoup/sensor/radar/radar.py
+++ b/stonesoup/sensor/radar/radar.py
@@ -132,7 +132,11 @@ class RadarRotatingBearingRange(RadarBearingRange):
         """
 
         # Read timestamp from ground truth
-        timestamp = next(iter(ground_truths.copy())).timestamp
+        try:
+            timestamp = next(iter(ground_truths.copy())).timestamp
+        except StopIteration:
+            # No ground truths to get timestamp from
+            return set()
 
         # Rotate the radar antenna and compute new heading
         self.rotate(timestamp)

--- a/stonesoup/sensor/radar/tests/test_radar.py
+++ b/stonesoup/sensor/radar/tests/test_radar.py
@@ -347,6 +347,8 @@ def test_rotating_radar():
         assert measurement.groundtruth_path in truth
         assert isinstance(measurement.groundtruth_path, GroundTruthPath)
 
+    assert radar.measure(set()) == set()
+
 
 def test_raster_scan_radar():
     # Input arguments


### PR DESCRIPTION
Previously, calling `measure` on an empty set would raise a StopIteration error as the method calculates a timestamp from the first truth in the set of truths passed in.