### PR TITLE
Modify metric manager add_data method to have separate kwargs

### DIFF
--- a/docs/examples/Metrics.py
+++ b/docs/examples/Metrics.py
@@ -144,7 +144,7 @@ metric_manager = SimpleManager([basic_generator, ospa_generator, siap_generator,
 # manager.
 for time, tracks in tracker.tracks_gen():
     metric_manager.add_data(
-        [groundtruth_sim.groundtruth_paths, detection_sim.detections, tracks],
+        groundtruth_sim.groundtruth_paths, tracks, detection_sim.detections,
         overwrite=False,  # Don't overwrite, instead add above as additional data
     )
 

--- a/stonesoup/metricgenerator/manager.py
+++ b/stonesoup/metricgenerator/manager.py
@@ -1,10 +1,11 @@
 # -*- coding: utf-8 -*-
 from itertools import chain
-from typing import Sequence
+from typing import Sequence, Iterable, Union
 
 from .base import MetricManager, MetricGenerator
 from ..base import Property
 from ..dataassociator import Associator
+from ..platform import Platform
 from ..types.detection import Detection
 from ..types.groundtruth import GroundTruthPath
 from ..types.track import Track
@@ -27,44 +28,34 @@ class SimpleManager(MetricManager):
         self.detections = set()
         self.association_set = None
 
-    def add_data(self, input_objects, overwrite=True):
+    def add_data(self, groundtruth_paths: Iterable[Union[GroundTruthPath, Platform]] = None,
+                 tracks: Iterable[Track] = None, detections: Iterable[Detection] = None,
+                 overwrite=True):
         """Adds data to the metric generator
 
         Parameters
         ----------
-        input_objects : list or set of objects
-            Objects to be added to the manager. The class of the object is used
-            to determine whether it is track, truth or detection
+        groundtruth_paths : list or set of :class:`~.GroundTruthPath`
+            Ground truth paths to be added to the manager.
+        tracks : list or set of :class:`~.Track`
+            Tracks objects to be added to the manager.
+        detections : list or set of :class:`~.Detection`
+            Detections to be added to the manager.
         overwrite: bool
             declaring whether pre-existing data will be overwritten. Note that
             overwriting one field (e.g. tracks) does not affect the others
         """
-        for in_obj in input_objects:
-            if not isinstance(in_obj, (list, set)):
-                raise TypeError('Inputs are expected as lists or sets only')
-            else:
-                if all(isinstance(x, Track) for x in in_obj):
-                    if overwrite:
-                        self.tracks = set(in_obj)
-                    else:
-                        self.tracks = self.tracks.union(set(in_obj))
-                elif all(isinstance(x, GroundTruthPath)
-                         for x in in_obj):
-                    if overwrite:
-                        self.groundtruth_paths = set(in_obj)
-                    else:
-                        self.groundtruth_paths = self.groundtruth_paths.union(
-                            set(in_obj))
-                elif all(isinstance(x, Detection) for x in in_obj):
-                    if overwrite:
-                        self.detections = set(in_obj)
-                    else:
-                        self.detections = self.detections.union(set(in_obj))
+
+        self._add(overwrite, groundtruth_paths=groundtruth_paths,
+                  tracks=tracks, detections=detections)
+
+    def _add(self, overwrite, **kwargs):
+        for key, value in kwargs.items():
+            if value is not None:
+                if overwrite:
+                    setattr(self, key, set(value))
                 else:
-                    raise TypeError(
-                        'Object of type {!r} not expected'.format(type()))
-                    # This error doesn't work if the first element of the list
-                    # is a sensible one but the later ones aren't.
+                    getattr(self, key).update(value)
 
     def associate_tracks(self):
         """Associate tracks to truth using the associator

--- a/stonesoup/metricgenerator/tests/test_basicmetrics.py
+++ b/stonesoup/metricgenerator/tests/test_basicmetrics.py
@@ -26,7 +26,7 @@ def test_basicmetrics():
                       timestamp=start_time + datetime.timedelta(seconds=i))
                 for i in range(5)]) for j in range(3))
 
-    manager.add_data([tracks, truths])
+    manager.add_data(truths, tracks)
 
     metrics = manager.generate_metrics()
 

--- a/stonesoup/metricgenerator/tests/test_manager.py
+++ b/stonesoup/metricgenerator/tests/test_manager.py
@@ -22,7 +22,7 @@ def test_adddata():
         states=State(np.array([[2]]), timestamp=datetime.datetime.now()))]
     dets = [Detection(np.array([[3]]), timestamp=datetime.datetime.now())]
 
-    manager.add_data([tracks, truths, dets])
+    manager.add_data(truths, tracks, dets)
 
     assert manager.tracks == set(tracks)
     assert manager.groundtruth_paths == set(truths)
@@ -36,7 +36,7 @@ def test_adddata():
         states=State(np.array([[22]]), timestamp=datetime.datetime.now()))]
     dets2 = [Detection(np.array([[23]]), timestamp=datetime.datetime.now())]
 
-    manager.add_data([tracks2, truths2, dets2], overwrite=False)
+    manager.add_data(truths2, tracks2, dets2, overwrite=False)
 
     assert manager.tracks == set(tracks + tracks2)
     assert manager.groundtruth_paths == set(truths + truths2)
@@ -44,9 +44,8 @@ def test_adddata():
 
     # Check adding additional data including repeated data
     manager = SimpleManager([])
-    manager.add_data([tracks, truths, dets])
-    manager.add_data([tracks + tracks2, truths + truths2, dets + dets2],
-                     overwrite=True)
+    manager.add_data(truths, tracks, dets)
+    manager.add_data(truths + truths2, tracks + tracks2, dets + dets2, overwrite=True)
 
     assert manager.tracks == set(tracks2 + tracks)
     assert manager.groundtruth_paths == set(truths2 + truths)
@@ -69,7 +68,7 @@ def test_associate_tracks():
         states=State(np.array([[1]]), timestamp=datetime.datetime.now()))}
     truths = {GroundTruthPath(
         states=State(np.array([[2]]), timestamp=datetime.datetime.now()))}
-    manager.add_data((tracks, truths))
+    manager.add_data(truths, tracks)
 
     manager.associate_tracks()
 
@@ -84,7 +83,7 @@ def test_listtimestamps():
         states=[State(np.array([[1]]), timestamp=timestamp1)])]
     truths = [GroundTruthPath(
         states=[State(np.array([[2]]), timestamp=timestamp2)])]
-    manager.add_data((tracks, truths))
+    manager.add_data(truths, tracks)
 
     assert manager.list_timestamps() == [timestamp1, timestamp2]
 

--- a/stonesoup/metricgenerator/tests/test_ospametric.py
+++ b/stonesoup/metricgenerator/tests/test_ospametric.py
@@ -151,7 +151,7 @@ def test_gospametric_computemetric():
               for i in range(5)}
 
     manager = SimpleManager([generator])
-    manager.add_data([tracks, truths])
+    manager.add_data(truths, tracks)
     main_metric = generator.compute_metric(manager)
 
     assert main_metric.title == "GOSPA Metrics"
@@ -281,7 +281,7 @@ def test_ospametric_computemetric(p):
               for i in range(5)}
 
     manager = SimpleManager([generator])
-    manager.add_data([tracks, truths])
+    manager.add_data(truths, tracks)
     main_metric = generator.compute_metric(manager)
     first_association, second_association = main_metric.value
 
@@ -323,7 +323,7 @@ def test_ospa_computemetric_cardinality_error(p, first_value, second_value):
               for i in range(5)}
 
     manager = SimpleManager([generator])
-    manager.add_data([tracks, truths])
+    manager.add_data(truths, tracks)
     main_metric = generator.compute_metric(manager)
     first_association, second_association = main_metric.value
 


### PR DESCRIPTION
This removes the need for multiple instance checks. The method will no longer throw an error with incorrect type inputs. This fixes the issue with a previously incorrect TypeError (#339). 