### PR TITLE
Fix SIAP metric component _nu_j

### DIFF
--- a/stonesoup/metricgenerator/tests/test_tracktotruthmetrics.py
+++ b/stonesoup/metricgenerator/tests/test_tracktotruthmetrics.py
@@ -314,7 +314,7 @@ def test_tt_j(generator):
 @pytest.mark.parametrize("generator", metric_generators(), ids=["SIAP"])
 def test_nu_j(generator):
     manager = SimpleManager()
-    tstart = datetime.datetime.now()
+    tstart = datetime.datetime(2020, 1, 1, 0)
     truth = GroundTruthPath(states=[
         GroundTruthState([[1], [0], [0], [0]], timestamp=tstart + datetime.timedelta(
             seconds=i))


### PR DESCRIPTION
Previously, having multiple states in a ground truth path with the same timestamp would lead the the _nu_j method entering an infinite loop.