### PR TITLE
Modify gaussian models to raise errors with None covariances

### DIFF
--- a/stonesoup/models/base.py
+++ b/stonesoup/models/base.py
@@ -190,7 +190,8 @@ class GaussianModel(Model):
 
         covar = self.covar(**kwargs)
 
-        if covar is None:
+        # If model has None-type covariance or contains None, it does not represent a Gaussian
+        if covar is None or None in covar:
             raise ValueError("Cannot generate rvs from None-type covariance")
 
         noise = multivariate_normal.rvs(
@@ -234,7 +235,8 @@ class GaussianModel(Model):
 
         covar = self.covar(**kwargs)
 
-        if covar is None:
+        # If model has None-type covariance or contains None, it does not represent a Gaussian
+        if covar is None or None in covar:
             raise ValueError("Cannot generate pdf from None-type covariance")
 
         # Calculate difference before to handle custom types (mean defaults to zero)

--- a/stonesoup/models/base.py
+++ b/stonesoup/models/base.py
@@ -188,8 +188,13 @@ class GaussianModel(Model):
             distribution.
         """
 
+        covar = self.covar(**kwargs)
+
+        if covar is None:
+            raise ValueError("Cannot generate rvs from None-type covariance")
+
         noise = multivariate_normal.rvs(
-            np.zeros(self.ndim), self.covar(**kwargs), num_samples)
+            np.zeros(self.ndim), covar, num_samples)
 
         noise = np.atleast_2d(noise)
 
@@ -227,11 +232,16 @@ class GaussianModel(Model):
             The likelihood of ``state1``, given ``state2``
         """
 
+        covar = self.covar(**kwargs)
+
+        if covar is None:
+            raise ValueError("Cannot generate pdf from None-type covariance")
+
         # Calculate difference before to handle custom types (mean defaults to zero)
         # This is required as log pdf coverts arrays to floats
         likelihood = multivariate_normal.logpdf(
             (state1.state_vector - self.function(state2, **kwargs)).ravel(),
-            cov=self.covar(**kwargs)
+            cov=covar
         )
         return Probability(likelihood, log_value=True)
 

--- a/stonesoup/models/measurement/nonlinear.py
+++ b/stonesoup/models/measurement/nonlinear.py
@@ -38,6 +38,8 @@ class CombinedReversibleGaussianMeasurementModel(ReversibleModel, GaussianModel,
         for model in self.model_list:
             if model.ndim_state != self.ndim_state:
                 raise ValueError("Models must all have the same `ndim_state`")
+            if model.covar(**kwargs) is None:
+                raise ValueError("Gaussian models must have defined covariances")
 
     @property
     def ndim_state(self) -> int:

--- a/stonesoup/models/measurement/nonlinear.py
+++ b/stonesoup/models/measurement/nonlinear.py
@@ -38,8 +38,6 @@ class CombinedReversibleGaussianMeasurementModel(ReversibleModel, GaussianModel,
         for model in self.model_list:
             if model.ndim_state != self.ndim_state:
                 raise ValueError("Models must all have the same `ndim_state`")
-            if model.covar(**kwargs) is None:
-                raise ValueError("Gaussian models must have defined covariances")
 
     @property
     def ndim_state(self) -> int:

--- a/stonesoup/models/measurement/tests/test_combined.py
+++ b/stonesoup/models/measurement/tests/test_combined.py
@@ -110,8 +110,12 @@ def test_mismatch_ndim_state():
 
 
 def test_none_covar():
-    with pytest.raises(ValueError, match="Gaussian models must have defined covariances"):
-        CombinedReversibleGaussianMeasurementModel([
-            CartesianToBearingRange(3, [0, 1], None),
-            CartesianToBearingRange(4, [0, 1], np.diag([1, 10]))
-        ])
+    new_model = CombinedReversibleGaussianMeasurementModel([
+        CartesianToBearingRange(4, [0, 1], None),
+        CartesianToBearingRange(4, [0, 1], np.diag([1, 10]))
+    ])
+
+    with pytest.raises(ValueError, match="Cannot generate rvs from None-type covariance"):
+        new_model.rvs()
+    with pytest.raises(ValueError, match="Cannot generate pdf from None-type covariance"):
+        new_model.pdf(State([0, 0, 0, 0]), State([0, 0, 0, 0]))

--- a/stonesoup/models/measurement/tests/test_combined.py
+++ b/stonesoup/models/measurement/tests/test_combined.py
@@ -107,3 +107,11 @@ def test_mismatch_ndim_state():
             CartesianToBearingRange(3, [0, 1], np.diag([1, 10])),
             CartesianToBearingRange(4, [0, 1], np.diag([1, 10])),
         ])
+
+
+def test_none_covar():
+    with pytest.raises(ValueError, match="Gaussian models must have defined covariances"):
+        CombinedReversibleGaussianMeasurementModel([
+            CartesianToBearingRange(3, [0, 1], None),
+            CartesianToBearingRange(4, [0, 1], np.diag([1, 10]))
+        ])

--- a/stonesoup/models/measurement/tests/test_models.py
+++ b/stonesoup/models/measurement/tests/test_models.py
@@ -9,6 +9,7 @@ from ..nonlinear import (
     CartesianToElevationBearing, Cartesian2DToBearing, CartesianToBearingRangeRate,
     CartesianToElevationBearingRangeRate)
 from ...base import ReversibleModel
+from ...measurement.linear import LinearGaussian
 from ....functions import jacobian as compute_jac
 from ....functions import pol2cart
 from ....functions import rotz, rotx, roty, cart2sphere
@@ -77,6 +78,22 @@ def hbearing(state_vector, pos_map, translation_offset, rotation_offset):
     _, phi, theta = cart2sphere(*xyz_rot)
 
     return StateVector([Elevation(theta), Bearing(phi)])
+
+
+@pytest.mark.parametrize(
+    "model_class",
+    [LinearGaussian,
+     CartesianToElevationBearingRange,
+     CartesianToBearingRange,
+     CartesianToElevationBearing,
+     Cartesian2DToBearing,
+     CartesianToBearingRangeRate,
+     CartesianToElevationBearingRangeRate]
+)
+def test_none_covar(model_class):
+    model = model_class(ndim_state=0, mapping=None, noise_covar=None)
+    with pytest.raises(ValueError, match="Cannot generate pdf from None-type covariance"):
+        model.pdf(State([0]), State([0]))
 
 
 @pytest.mark.parametrize(

--- a/stonesoup/models/transition/tests/test_time_invariant.py
+++ b/stonesoup/models/transition/tests/test_time_invariant.py
@@ -5,6 +5,7 @@ import numpy as np
 
 from ..linear import LinearGaussianTimeInvariantTransitionModel
 from ....types.state import State
+import pytest
 
 
 def test_linear_gaussian():
@@ -23,3 +24,9 @@ def test_linear_gaussian():
                                               noise=np.zeros([3, 1])))
     assert isinstance(model.rvs(), np.ndarray)
     assert isinstance(model.pdf(State(x_2), State(x_1)), Real)
+
+    model = LinearGaussianTimeInvariantTransitionModel(transition_matrix=F, covariance_matrix=None)
+    with pytest.raises(ValueError, match="Cannot generate rvs from None-type covariance"):
+        model.rvs()
+    with pytest.raises(ValueError, match="Cannot generate pdf from None-type covariance"):
+        model.pdf(State([0]), State([0]))


### PR DESCRIPTION
Rather than attempting to handle covariance arguments being None on instantiation, since some models have their own covariance methods, it seemed more appropriate to simply raise an error when rvs and pdf methods are called.
Closes #343 
Note: Only models with unmodified covariance methods are affected/tested