### PR TITLE
Fix issue with version, effecting pip install with Read The Docs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,13 +24,15 @@ setup(name='stonesoup',
       packages=find_packages(exclude=('docs', '*.tests')),
       python_requires='>=3.6',
       setup_requires=['setuptools_scm', 'setuptools_scm_git_archive'],
-      use_scm_version={'write_to': 'stonesoup/_version.py'},
+      use_scm_version=True,
       install_requires=[
-          'ruamel.yaml>=0.15.45', 'numpy>=1.17', 'scipy', 'matplotlib', 'utm', 'pymap3d'],
+          'ruamel.yaml>=0.15.45', 'numpy>=1.17', 'scipy', 'matplotlib', 'utm', 'pymap3d',
+          'setuptools>=42',
+      ],
       extras_require={
           'dev': [
               'pytest-flake8', 'pytest-cov', 'Sphinx', 'sphinx_rtd_theme',
-              'setuptools>=42', 'sphinx-gallery>=0.8', 'pillow', 'folium'],
+              'sphinx-gallery>=0.8', 'pillow', 'folium'],
           'video': ['ffmpeg-python', 'moviepy'],
           'tensorflow': ['tensorflow>=2.2.0']
       },

--- a/stonesoup/__init__.py
+++ b/stonesoup/__init__.py
@@ -1,7 +1,14 @@
 # -*- coding: utf-8 -*-
 """Stone Soup framework: development and assessment of tracking algorithms."""
 
-from ._version import version as __version__  # noqa: F401
+from pkg_resources import get_distribution, DistributionNotFound
+
+try:
+    __version__ = get_distribution("stonesoup").version
+except DistributionNotFound:
+    # package is not installed
+    pass
+
 __copyright__ = '''\
 © Crown Copyright 2017-2020 Defence Science and Technology Laboratory UK
 © Crown Copyright 2018-2020 Defence Research and Development Canada / Recherche et développement pour la défense Canada


### PR DESCRIPTION
Version of Stone Soup is now dynamically fetch, which resolves issue when installing via pip install in non-editable mode from local directory.