### PR TITLE
Add abstractmethod decorator to Radar Beam Pattern/Shape

### DIFF
--- a/stonesoup/sensor/radar/beam_pattern.py
+++ b/stonesoup/sensor/radar/beam_pattern.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import datetime
+from abc import abstractmethod
 from typing import Sequence, Tuple
 
 from ...base import Property, Base
@@ -9,6 +10,7 @@ class BeamTransitionModel(Base):
     """Base class for Beam Transition Model"""
     centre: Sequence = Property(doc="Centre of the beam pattern")
 
+    @abstractmethod
     def move_beam(self, timestamp, **kwargs):
         """Gives position of beam at given time"""
         raise NotImplementedError

--- a/stonesoup/sensor/radar/beam_shape.py
+++ b/stonesoup/sensor/radar/beam_shape.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from abc import abstractmethod
 
 import numpy as np
 
@@ -9,6 +10,7 @@ class BeamShape(Base):
     """Base class for beam shape"""
     peak_power: float = Property(doc="peak power of the main lobe in Watts")
 
+    @abstractmethod
     def beam_power(self, azimuth, elevation, **kwargs):
         """beam power sent in the direction of the target.
         azimuth = elevation = 0 for center of beam"""

--- a/stonesoup/sensor/radar/tests/test_beam_pattern.py
+++ b/stonesoup/sensor/radar/tests/test_beam_pattern.py
@@ -1,9 +1,15 @@
 # -*- coding: utf-8 -*-
 import datetime
-from pytest import approx
-import numpy as np
 
-from ..beam_pattern import StationaryBeam, BeamSweep
+import numpy as np
+from pytest import approx, raises
+
+from ..beam_pattern import BeamTransitionModel, StationaryBeam, BeamSweep
+
+
+def test_abstract_beam_pattern():
+    with raises(TypeError):
+        BeamTransitionModel()
 
 
 def test_stationary_beam():

--- a/stonesoup/sensor/radar/tests/test_beam_shape.py
+++ b/stonesoup/sensor/radar/tests/test_beam_shape.py
@@ -1,6 +1,12 @@
 # -*- coding: utf-8 -*-
-from ..beam_shape import Beam2DGaussian
-from pytest import approx
+from pytest import approx, raises
+
+from ..beam_shape import BeamShape, Beam2DGaussian
+
+
+def test_abstract_beam_shape():
+    with raises(TypeError):
+        BeamShape()
 
 
 def test_beam_shape():


### PR DESCRIPTION
Abstract method decorators were missing, mean erroneous use of classes not caught on initialisation.