### PR TITLE
AESA Radar and Beam Shape beam power method argument changes

### DIFF
--- a/stonesoup/sensor/radar/beam_pattern.py
+++ b/stonesoup/sensor/radar/beam_pattern.py
@@ -41,13 +41,8 @@ class BeamSweep(BeamTransitionModel):
     frame: Tuple[float, float] = Property(doc="Dimensions of search frame as [azimuth,elevation]")
     separation: float = Property(doc="Separation of lines in elevation")
     centre: Tuple[float, float] = Property(
-        default=None,
-        doc="Centre of the search frame in [azimuth,elevation]. Defaults to [0, 0]")
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        if self.centre is None:
-            self.centre = (0, 0)
+        default=(0, 0),
+        doc="Centre of the search frame in [azimuth,elevation]. Defaults to (0, 0)")
 
     @property
     def length_frame(self):

--- a/stonesoup/sensor/radar/beam_shape.py
+++ b/stonesoup/sensor/radar/beam_shape.py
@@ -30,6 +30,8 @@ class Beam2DGaussian(BeamShape):
      from the centre. :math:`B_w` is the beam width and :math:`P_p` is the peak
      power.
      """
+    # Full width half maximum
+    FWHM = 2 * np.sqrt(2 * np.log(2))
 
     def beam_power(self, azimuth, elevation, beam_width, **kwargs):
         """
@@ -50,5 +52,4 @@ class Beam2DGaussian(BeamShape):
             the power directed towards the target
         """
         return self.peak_power * np.exp(
-            -0.5 * ((azimuth / (beam_width / 2.35482)) ** 2 +
-                    (elevation / (beam_width / 2.35482)) ** 2))
+            -0.5 * ((azimuth/beam_width*self.FWHM)**2 + (elevation/beam_width*self.FWHM)**2))

--- a/stonesoup/sensor/radar/beam_shape.py
+++ b/stonesoup/sensor/radar/beam_shape.py
@@ -30,7 +30,7 @@ class Beam2DGaussian(BeamShape):
      from the centre. :math:`B_w` is the beam width and :math:`P_p` is the peak
      power.
      """
-    beam_width: float = Property(default=None, doc='Width of the radar beam')
+    beam_width: float = Property(doc='Width of the radar beam')
 
     def beam_power(self, azimuth, elevation, **kwargs):
         """

--- a/stonesoup/sensor/radar/beam_shape.py
+++ b/stonesoup/sensor/radar/beam_shape.py
@@ -11,7 +11,7 @@ class BeamShape(Base):
     peak_power: float = Property(doc="peak power of the main lobe in Watts")
 
     @abstractmethod
-    def beam_power(self, azimuth, elevation, **kwargs):
+    def beam_power(self, azimuth, elevation, beam_width, **kwargs):
         """beam power sent in the direction of the target.
         azimuth = elevation = 0 for center of beam"""
         raise NotImplementedError
@@ -30,9 +30,8 @@ class Beam2DGaussian(BeamShape):
      from the centre. :math:`B_w` is the beam width and :math:`P_p` is the peak
      power.
      """
-    beam_width: float = Property(doc='Width of the radar beam')
 
-    def beam_power(self, azimuth, elevation, **kwargs):
+    def beam_power(self, azimuth, elevation, beam_width, **kwargs):
         """
         Parameters
         ----------
@@ -42,6 +41,8 @@ class Beam2DGaussian(BeamShape):
         elevation : `float`
             The angle of the target away from the boresight of the radar in
             elevation
+        beam_width: `float`
+            The width of the radar beam
 
         Returns
         -------
@@ -49,5 +50,5 @@ class Beam2DGaussian(BeamShape):
             the power directed towards the target
         """
         return self.peak_power * np.exp(
-            -0.5 * ((azimuth / (self.beam_width / 2.35482)) ** 2 +
-                    (elevation / (self.beam_width / 2.35482)) ** 2))
+            -0.5 * ((azimuth / (beam_width / 2.35482)) ** 2 +
+                    (elevation / (beam_width / 2.35482)) ** 2))

--- a/stonesoup/sensor/radar/radar.py
+++ b/stonesoup/sensor/radar/radar.py
@@ -641,8 +641,7 @@ class AESARadar(Sensor):
         relative_az = pos_az - beam_az
         relative_el = pos_el - beam_el
         # calculate power directed towards target
-        self.beam_shape.beam_width = spoiled_width  # beam spoiling to width
-        directed_power = self.beam_shape.beam_power(relative_az, relative_el)
+        directed_power = self.beam_shape.beam_power(relative_az, relative_el, spoiled_width)
         # calculate signal to noise ratio
         snr = self._snr_constant * rcs * spoiled_gain ** 2 * directed_power / (r ** 4)
         # calculate probability of detection using the North's approximation

--- a/stonesoup/sensor/radar/radar.py
+++ b/stonesoup/sensor/radar/radar.py
@@ -547,7 +547,9 @@ class AESARadar(Sensor):
             "The random RCS follows the probability "
             "distribution of the Swerling 1 case.")
     rcs: float = Property(
-        default=None, doc="The radar cross section of targets in meters squared.")
+        default=None,
+        doc="The radar cross section of targets in meters squared. Used if rcs not present on "
+            "truth. Default `None`, where 'rcs' must be present on truth.")
     probability_false_alarm: Probability = Property(
         default=1e-6, doc="Probability of false alarm used in the North's approximation")
 
@@ -617,6 +619,9 @@ class AESARadar(Sensor):
             rcs = truth.rcs
         else:
             rcs = self.rcs
+        if rcs is None:
+            raise ValueError("Truth missing 'rcs' attribute and no default 'rcs' provided")
+
         # apply swerling 1 case?
         if self.swerling_on:
             rcs = self._swerling_1(rcs)

--- a/stonesoup/sensor/radar/radar.py
+++ b/stonesoup/sensor/radar/radar.py
@@ -516,7 +516,6 @@ class AESARadar(Sensor):
         doc="Mapping between or positions and state "
             "dimensions. [x,y,z]")
     measurement_model: MeasurementModel = Property(
-        default=None,
         doc="The Measurement model used to generate "
             "measurements.")
     beam_shape: BeamShape = Property(

--- a/stonesoup/sensor/radar/tests/test_beam_shape.py
+++ b/stonesoup/sensor/radar/tests/test_beam_shape.py
@@ -10,6 +10,6 @@ def test_abstract_beam_shape():
 
 
 def test_beam_shape():
-    two_dim_gaus = Beam2DGaussian(peak_power=100, beam_width=10)
-    assert approx(two_dim_gaus.beam_power(5, 5), 3) == 25
-    assert approx(two_dim_gaus.beam_power(0, 0), 3) == 100
+    two_dim_gaus = Beam2DGaussian(peak_power=100)
+    assert approx(two_dim_gaus.beam_power(5, 5, 10), 3) == 25
+    assert approx(two_dim_gaus.beam_power(0, 0, 10), 3) == 100

--- a/stonesoup/sensor/radar/tests/test_radar.py
+++ b/stonesoup/sensor/radar/tests/test_radar.py
@@ -618,3 +618,14 @@ def test_target_rcs():
     (det_prob, snr, swer_rcs, _, _, _) = radar.gen_probability(rcs_20)
     assert swer_rcs == 20
     assert round(snr, 3) == 2.125
+
+    with pytest.raises(
+            ValueError, match="Truth missing 'rcs' attribute and no default 'rcs' provided"):
+        rcs_none = (GroundTruthState([150e3, 0.0, 0.0], timestamp=None))
+        rcs_none.rcs = None
+        radar.gen_probability(rcs_none)
+
+    with pytest.raises(
+            ValueError, match="Truth missing 'rcs' attribute and no default 'rcs' provided"):
+        rcs_missing = (GroundTruthState([150e3, 0.0, 0.0], timestamp=None))
+        radar.gen_probability(rcs_missing)


### PR DESCRIPTION
- Fixes for some default arguments with radar sensors
- Change Radar `BeamShape` so `beam_width` is argument to `beam_power` method
- Add class constant for full width half maximum for `Beam2DGaussian`