### PR TITLE
Close figures when finished processing file in Sphinx Gallery

### DIFF
--- a/docs/source/doc_extensions.py
+++ b/docs/source/doc_extensions.py
@@ -77,6 +77,7 @@ from sphinx_gallery.scrapers import (
 class gallery_scraper():
     def __init__(self):
         self.plotted_figures = set()
+        self.current_src_file = None
 
     def __call__(self, block, block_vars, gallery_conf, **kwargs):
         """Scrape Matplotlib images.
@@ -102,6 +103,13 @@ class gallery_scraper():
             The ReSTructuredText that will be rendered to HTML containing
             the images. This is often produced by :func:`figure_rst`.
         """
+        # New file, so close all currently open figures
+        if block_vars['src_file'] != self.current_src_file:
+            for fig in self.plotted_figures:
+                plt.close(fig)
+            self.plotted_figures = set()
+            self.current_src_file = block_vars['src_file']
+
         from matplotlib.animation import Animation
         from matplotlib.figure import Figure
         image_path_iterator = block_vars['image_path_iterator']


### PR DESCRIPTION
This avoids warnings being printed in docs, as well as reducing memory required (not that I think this is issue with figures in this case).