### PR TITLE
Data Associator Class modifications

### DIFF
--- a/stonesoup/dataassociator/base.py
+++ b/stonesoup/dataassociator/base.py
@@ -1,9 +1,7 @@
 # -*- coding: utf-8 -*-
-import itertools
 from abc import abstractmethod
 
 from ..base import Base, Property
-from ..types.hypothesis import JointHypothesis
 from ..hypothesiser import Hypothesiser
 
 
@@ -38,65 +36,6 @@ class DataAssociator(Base):
             Mapping of track to Hypothesis
         """
         raise NotImplementedError
-
-    @staticmethod
-    def isvalid(joint_hypothesis):
-        """Determine whether a joint_hypothesis is valid.
-
-        Check the set of hypotheses that define a joint hypothesis to ensure a
-        single detection is not associated to more than one track.
-
-        Parameters
-        ----------
-        joint_hypothesis : :class:`JointHypothesis`
-            A set of hypotheses linking each prediction to a single detection
-
-        Returns
-        -------
-        bool
-            Whether joint_hypothesis is a valid set of hypotheses
-        """
-
-        number_hypotheses = len(joint_hypothesis)
-        unique_hypotheses = len(
-            {hyp.measurement for hyp in joint_hypothesis if hyp})
-        number_null_hypotheses = sum(not hyp for hyp in joint_hypothesis)
-
-        # joint_hypothesis is invalid if one detection is assigned to more than
-        # one prediction. Multiple missed detections are valid.
-        if unique_hypotheses + number_null_hypotheses == number_hypotheses:
-            return True
-        else:
-            return False
-
-    @classmethod
-    def enumerate_joint_hypotheses(cls, hypotheses):
-        """Enumerate the possible joint hypotheses.
-
-        Create a list of all possible joint hypotheses from the individual
-        hypotheses and determine whether each is valid.
-
-        Parameters
-        ----------
-        hypotheses : list of :class:`Hypothesis`
-            A list of all hypotheses linking predictions to detections,
-            including missed detections
-
-        Returns
-        -------
-        joint_hypotheses : list of :class:`JointHypothesis`
-            A list of all valid joint hypotheses with a score on each
-        """
-
-        # Create a list of dictionaries of valid track-hypothesis pairs
-        joint_hypotheses = [
-            JointHypothesis({
-                track: hypothesis
-                for track, hypothesis in zip(hypotheses, joint_hypothesis)})
-            for joint_hypothesis in itertools.product(*hypotheses.values())
-            if cls.isvalid(joint_hypothesis)]
-
-        return joint_hypotheses
 
 
 class Associator(Base):

--- a/stonesoup/dataassociator/base.py
+++ b/stonesoup/dataassociator/base.py
@@ -27,7 +27,7 @@ class DataAssociator(Base):
             Tracks which detections will be associated to.
         detections : set of :class:`~.Detection`
             Detections to be associated to tracks.
-        timestamp : :class:`datetime.datetime`
+        timestamp : datetime.datetime
             Timestamp to be used for missed detections.
 
         Returns

--- a/stonesoup/dataassociator/neighbour.py
+++ b/stonesoup/dataassociator/neighbour.py
@@ -20,7 +20,7 @@ class NearestNeighbour(DataAssociator):
     hypothesiser: Hypothesiser = Property(
         doc="Generate a set of hypotheses for each prediction-detection pair")
 
-    def associate(self, tracks, detections, time):
+    def associate(self, tracks, detections, timestamp):
         """Associate detections with predicted states.
 
         Parameters
@@ -29,7 +29,7 @@ class NearestNeighbour(DataAssociator):
             Current tracked objects
         detections : list of :class:`Detection`
             Retrieved measurements
-        time : datetime
+        timestamp : datetime.datetime
             Detection time to predict to
 
         Returns
@@ -40,7 +40,7 @@ class NearestNeighbour(DataAssociator):
 
         # Generate a set of hypotheses for each track on each detection
         hypotheses = {
-            track: self.hypothesiser.hypothesise(track, detections, time)
+            track: self.hypothesiser.hypothesise(track, detections, timestamp)
             for track in tracks}
 
         # Only associate tracks with one or more hypotheses
@@ -81,7 +81,7 @@ class GlobalNearestNeighbour(DataAssociator):
     hypothesiser: Hypothesiser = Property(
         doc="Generate a set of hypotheses for each prediction-detection pair")
 
-    def associate(self, tracks, detections, time):
+    def associate(self, tracks, detections, timestamp):
         """Associate a set of detections with predicted states.
 
         Parameters
@@ -90,7 +90,7 @@ class GlobalNearestNeighbour(DataAssociator):
             Current tracked objects
         detections : list of :class:`Detection`
             Retrieved measurements
-        time : datetime
+        timestamp : datetime.datetime
             Detection time to predict to
 
         Returns
@@ -101,7 +101,7 @@ class GlobalNearestNeighbour(DataAssociator):
 
         # Generate a set of hypotheses for each track on each detection
         hypotheses = {
-            track: self.hypothesiser.hypothesise(track, detections, time)
+            track: self.hypothesiser.hypothesise(track, detections, timestamp)
             for track in tracks}
 
         # Link hypotheses into a set of joint_hypotheses and evaluate
@@ -181,7 +181,7 @@ class GNNWith2DAssignment(DataAssociator):
     hypothesiser: Hypothesiser = Property(
         doc="Generate a set of hypotheses for each prediction-detection pair")
 
-    def associate(self, tracks, detections, time):
+    def associate(self, tracks, detections, timestamp):
         """Associate a set of detections with predicted states.
 
         Parameters
@@ -190,7 +190,7 @@ class GNNWith2DAssignment(DataAssociator):
             Current tracked objects
         detections : set of :class:`Detection`
             Retrieved measurements
-        time : datetime
+        timestamp : datetime.datetime
             Detection time to predict to
 
         Returns
@@ -201,7 +201,7 @@ class GNNWith2DAssignment(DataAssociator):
 
         # Generate a set of hypotheses for each track on each detection
         hypotheses = {
-            track: self.hypothesiser.hypothesise(track, detections, time)
+            track: self.hypothesiser.hypothesise(track, detections, timestamp)
             for track in tracks}
 
         # Create dictionary for associations

--- a/stonesoup/dataassociator/probability.py
+++ b/stonesoup/dataassociator/probability.py
@@ -22,7 +22,7 @@ class PDA(DataAssociator):
     hypothesiser: Hypothesiser = Property(
         doc="Generate a set of hypotheses for each prediction-detection pair")
 
-    def associate(self, tracks, detections, time):
+    def associate(self, tracks, detections, timestamp):
         """Associate detections with predicted states.
 
         Parameters
@@ -31,7 +31,7 @@ class PDA(DataAssociator):
             Current tracked objects
         detections : list of :class:`Detection`
             Retrieved measurements
-        time : datetime
+        timestamp : datetime.datetime
             Detection time to predict to
 
         Returns
@@ -42,7 +42,7 @@ class PDA(DataAssociator):
 
         # Generate a set of hypotheses for each track on each detection
         hypotheses = {
-            track: self.hypothesiser.hypothesise(track, detections, time)
+            track: self.hypothesiser.hypothesise(track, detections, timestamp)
             for track in tracks}
 
         # Ensure association probabilities are normalised
@@ -75,7 +75,7 @@ class JPDA(DataAssociator):
     hypothesiser: PDAHypothesiser = Property(
         doc="Generate a set of hypotheses for each prediction-detection pair")
 
-    def associate(self, tracks, detections, time):
+    def associate(self, tracks, detections, timestamp):
         """Associate detections with predicted states.
 
         Parameters
@@ -84,7 +84,7 @@ class JPDA(DataAssociator):
             Current tracked objects
         detections : list of :class:`Detection`
             Retrieved measurements
-        time : datetime
+        timestamp : datetime.datetime
             Detection time to predict to
 
         Returns
@@ -96,7 +96,7 @@ class JPDA(DataAssociator):
         # Calculate MultipleHypothesis for each Track over all
         # available Detections
         hypotheses = {
-            track: self.hypothesiser.hypothesise(track, detections, time)
+            track: self.hypothesiser.hypothesise(track, detections, timestamp)
             for track in tracks}
 
         # enumerate the Joint Hypotheses of track/detection associations
@@ -120,7 +120,7 @@ class JPDA(DataAssociator):
             single_measurement_hypotheses.append(
                 SingleProbabilityHypothesis(
                     hypotheses[track][0].prediction,
-                    MissedDetection(timestamp=time),
+                    MissedDetection(timestamp=timestamp),
                     measurement_prediction=hypotheses[track][0].measurement_prediction,
                     probability=prob_misdetect))
 

--- a/stonesoup/hypothesiser/base.py
+++ b/stonesoup/hypothesiser/base.py
@@ -8,7 +8,7 @@ class Hypothesiser(Base):
     Given a track and set of detections, generate hypothesis of association.
     """
 
-    def hypothesise(self, track, detections, **kwargs):
+    def hypothesise(self, track, detections, timestamp, **kwargs):
         """Hypothesise track and detection association
 
         Parameters
@@ -17,6 +17,12 @@ class Hypothesiser(Base):
             Track which hypotheses will be generated for.
         detections :
             Detections used to generate hypotheses.
+        timestamp: :class:`datetime.datetime`
+            A timestamp used when evaluating the state and measurement
+            predictions. Note that if a given detection has a non empty
+            timestamp, then prediction will be performed according to
+            the timestamp of the detection.
+
 
         Returns
         -------

--- a/stonesoup/tracker/tests/conftest.py
+++ b/stonesoup/tracker/tests/conftest.py
@@ -57,11 +57,11 @@ def detector():
 @pytest.fixture()
 def data_associator():
     class TestDataAssociator:
-        def associate(self, tracks, detections, time):
+        def associate(self, tracks, detections, timestamp):
             associations = {}
             for track in tracks:
                 prediction = GaussianStatePrediction(track.state_vector + 1,
-                                                     [[5]], time)
+                                                     [[5]], timestamp)
                 measurement_prediction = StateMeasurementPrediction(
                     prediction.state_vector)
                 for detection in detections:
@@ -81,11 +81,11 @@ def data_associator():
 @pytest.fixture()
 def data_mixture_associator():
     class TestDataMixtureAssociator:
-        def associate(self, tracks, detections, time):
+        def associate(self, tracks, detections, timestamp):
             associations = {}
             for track in tracks:
                 prediction = GaussianStatePrediction(track.state_vector + 1,
-                                                     [[5]], time)
+                                                     [[5]], timestamp)
                 measurement_prediction = StateMeasurementPrediction(
                     prediction.state_vector)
                 multihypothesis = []
@@ -100,7 +100,7 @@ def data_mixture_associator():
                             ))
                         multihypothesis.append(
                             SingleProbabilityHypothesis(
-                                prediction, MissedDetection(timestamp=time),
+                                prediction, MissedDetection(timestamp=timestamp),
                                 measurement_prediction=measurement_prediction,
                                 probability=0.1
                             ))
@@ -108,7 +108,7 @@ def data_mixture_associator():
                 else:
                     multihypothesis.append(
                         SingleProbabilityHypothesis(
-                            prediction, MissedDetection(timestamp=time),
+                            prediction, MissedDetection(timestamp=timestamp),
                             measurement_prediction=measurement_prediction,
                             probability=0.1
                         ))


### PR DESCRIPTION
* Move `DataAssociator` base class methods to `GlobalNearestNeighbour`
  * These methods are only used for GNN, and don't seem relevant to other
data associators, as they use brute force unoptimised approach (which in
part is what having the GNN is there to demonstrate).
* Rename `time` to `timestamp` on `DataAssociator.associate()` methods
  * This matches what was originally on the base class, more consistent with
use of `timestamp` elsewhere, and avoids using `time` name which is
standard library module.