### PR TITLE
Fix animation control layout in Sphinx-Gallery examples

### DIFF
--- a/docs/source/_static/css/custom.css
+++ b/docs/source/_static/css/custom.css
@@ -1,3 +1,6 @@
+.anim-state label {
+    display: inline-block;
+}
 .sphx-glr-thumbcontainer {
     min-height: 320px !important;
     margin: 20px !important;


### PR DESCRIPTION
Originally suggested in https://github.com/dstl/Stone-Soup/pull/249#issuecomment-649062509

Can be seen on the *Multi-Sensor Moving Platform Simulation Example*.