### PR TITLE
Adding link to TransitionModel in the Prediction

### DIFF
--- a/stonesoup/predictor/kalman.py
+++ b/stonesoup/predictor/kalman.py
@@ -192,7 +192,8 @@ class KalmanPredictor(Predictor):
         p_pred = self._predicted_covariance(prior, predict_over_interval)
 
         # And return the state in the correct form
-        return Prediction.from_state(prior, x_pred, p_pred, timestamp=timestamp)
+        return Prediction.from_state(prior, x_pred, p_pred, timestamp=timestamp,
+                                     transition_model=self.transition_model)
 
 
 class ExtendedKalmanPredictor(KalmanPredictor):
@@ -380,7 +381,8 @@ class UnscentedKalmanPredictor(KalmanPredictor):
         )
 
         # and return a Gaussian state based on these parameters
-        return Prediction.from_state(prior, x_pred, p_pred, timestamp=timestamp)
+        return Prediction.from_state(prior, x_pred, p_pred, timestamp=timestamp,
+                                     transition_model=self.transition_model)
 
 
 class SqrtKalmanPredictor(KalmanPredictor):

--- a/stonesoup/predictor/particle.py
+++ b/stonesoup/predictor/particle.py
@@ -50,4 +50,5 @@ class ParticlePredictor(Predictor):
                          weight=particle.weight,
                          parent=particle.parent))
 
-        return Prediction.from_state(prior, particles=new_particles, timestamp=timestamp)
+        return Prediction.from_state(prior, particles=new_particles, timestamp=timestamp,
+                                     transition_model=self.transition_model)

--- a/stonesoup/predictor/tests/test_kalman.py
+++ b/stonesoup/predictor/tests/test_kalman.py
@@ -67,6 +67,9 @@ def test_kalman(PredictorClass, transition_model,
     prediction = predictor.predict(prior=prior,
                                    timestamp=new_timestamp)
 
+    # Assert presence of transition model
+    assert hasattr(prediction, 'transition_model')
+
     assert np.allclose(prediction.mean,
                        eval_prediction.mean, 0, atol=1.e-14)
     assert np.allclose(prediction.covar,
@@ -124,6 +127,9 @@ def test_sqrt_kalman():
     prediction = predictor.predict(prior=prior, timestamp=new_timestamp)
     sqrt_prediction = sqrt_predictor.predict(prior=sqrt_prior,
                                              timestamp=new_timestamp)
+
+    # Assert presence of transition model
+    assert hasattr(prediction, 'transition_model')
 
     assert np.allclose(prediction.mean, sqrt_prediction.mean, 0, atol=1.e-14)
     assert np.allclose(prediction.covar,

--- a/stonesoup/types/prediction.py
+++ b/stonesoup/types/prediction.py
@@ -6,6 +6,7 @@ from .array import CovarianceMatrix
 from .base import Type
 from .state import (State, GaussianState, ParticleState, SqrtGaussianState,
                     TaggedWeightedGaussianState, StateMutableSequence)
+from ..models.transition.base import TransitionModel
 
 
 def _from_state(
@@ -58,6 +59,8 @@ class Prediction(Type):
     This is the base prediction class. """
     class_mapping = {}
     from_state = classmethod(_from_state)
+    transition_model: TransitionModel = Property(
+        default=None, doc='The transition model used to make the prediction')
 
     def __init_subclass__(cls, **kwargs):
         state_type = cls.__bases__[-1]


### PR DESCRIPTION
This would be useful for analysis (e.g. in post-processing, like deriving metrics) and in smoothing. A smoother requires knowledge the transition model used to make predictions. This could be defined externally, but it seems more efficient to reach into the prediction to find it, particularly as the transition model may change as the track is created.

I've made it optional (`default=None`) in `Prediction` but modified the current set of predictors to include the link to the transition model (via the `predict()` method). Should this latter instead be optional?

