### PR TITLE
Add support for plugins

### DIFF
--- a/docs/source/stonesoup.plugins.rst
+++ b/docs/source/stonesoup.plugins.rst
@@ -1,0 +1,5 @@
+Plugins
+=======
+
+.. automodule:: stonesoup.plugins
+

--- a/docs/source/stonesoup.rst
+++ b/docs/source/stonesoup.rst
@@ -11,6 +11,7 @@ Stone Soup Framework
     stonesoup.functions
     stonesoup.measures
     stonesoup.plotter
+    stonesoup.plugins
     stonesoup.serialise
 
 Components

--- a/stonesoup/plugins.py
+++ b/stonesoup/plugins.py
@@ -35,16 +35,8 @@ import importlib.util
 for entry_point in pkg_resources.iter_entry_points('stonesoup.plugins'):
     try:
         name = entry_point.name
-        module_name = entry_point.module_name
-
-        module = importlib.util.find_spec(module_name)
-        module_spec = importlib.util.spec_from_loader(name=module.name,
-                                                      loader=module.loader,
-                                                      origin=module.origin)
-
         plugin_module = f'{__name__}.{name}'
-
-        sys.modules[plugin_module] = importlib.util.module_from_spec(module_spec)
+        sys.modules[plugin_module] = entry_point.load()
 
     except (ImportError, ModuleNotFoundError) as e:
         warnings.warn(f'Failed to load module. {e}')

--- a/stonesoup/plugins.py
+++ b/stonesoup/plugins.py
@@ -1,0 +1,50 @@
+"""
+Plugin system for Stone Soup.
+
+Stone Soup is able to import plugins using package metadata. Packages can
+register themselves for discovery by providing the :attr:`entry_points` argument
+to setup() in :attr:`setup.py`.
+
+For example if you have a package named :attr:`my_package` and its :attr:`setup.py` file includes:
+
+.. code-block:: python
+
+    setup(
+        ...
+        entry_points={'stonesoup.plugins': 'my_plugin = my_package'}
+        ...
+    )
+
+Then Stone Soup will discover your plugin and load all of the registered entry points. It is
+possible to name your plugin the same name as your package name in :attr:`setup()`. Your plugin
+can be loaded using:
+
+.. code-block:: python
+
+    from stonesoup.plugins.my_plugin import MyClass
+
+.. note::
+    When developing plugins for Stone Soup, :attr:`entry_points` must be associated with
+    the :attr:`stonesoup.plugins` key in the :attr:`entry_points` dictionary.
+"""
+import sys
+import pkg_resources
+import warnings
+import importlib.util
+
+for entry_point in pkg_resources.iter_entry_points('stonesoup.plugins'):
+    try:
+        name = entry_point.name
+        module_name = entry_point.module_name
+
+        module = importlib.util.find_spec(module_name)
+        module_spec = importlib.util.spec_from_loader(name=module.name,
+                                                      loader=module.loader,
+                                                      origin=module.origin)
+
+        plugin_module = f'{__name__}.{name}'
+
+        sys.modules[plugin_module] = importlib.util.module_from_spec(module_spec)
+
+    except (ImportError, ModuleNotFoundError) as e:
+        warnings.warn(f'Failed to load module. {e}')

--- a/stonesoup/plugins.py
+++ b/stonesoup/plugins.py
@@ -30,7 +30,6 @@ can be loaded using:
 import sys
 import pkg_resources
 import warnings
-import importlib.util
 
 for entry_point in pkg_resources.iter_entry_points('stonesoup.plugins'):
     try:


### PR DESCRIPTION
Add ability to load plugins using package metadata in package's setup.py [entry_points](https://packaging.python.org/guides/creating-and-discovering-plugins/#using-package-metadata). This will enable third party Stone Soup components to be easily discoverable.