### PR TITLE
Add GitHub related files for reviewers and actions

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default, reviewer team auto assignment
+*   @dstl/stone-soup-reviewers

--- a/.github/workflows/docs-link.yml
+++ b/.github/workflows/docs-link.yml
@@ -1,0 +1,13 @@
+name: Documentation link
+on: status
+jobs:
+  circleci_artifacts_redirector_job:
+    runs-on: ubuntu-latest
+    name: Run CircleCI artifacts redirector
+    steps:
+      - name: GitHub Action step
+        uses: larsoner/circleci-artifacts-redirector-action@0.2.0
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          artifact-path: 0/docs/index.html
+          circleci-jobs: docs


### PR DESCRIPTION
This adds a [`CODEOWNERS` file](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners) to enable auto assignment of reviewers.

This also adds a GitHub action to automatically add a link to docs built on CircleCI for pull request status checks (not sure this will work on this PR, as needs to be merged into _master_ first).