### PR TITLE
Various test fixes for print statements, floating point errors and divide by zero warnings

### DIFF
--- a/stonesoup/metricgenerator/tests/test_tracktotruthmetrics.py
+++ b/stonesoup/metricgenerator/tests/test_tracktotruthmetrics.py
@@ -918,8 +918,6 @@ def test_no_truth_divide_by_zero(generator):
 
     assert len(metrics) == 20
 
-    print([metric.title for metric in metrics])
-
 
 @pytest.mark.parametrize("generator", metric_generators(), ids=["SIAP"])
 def test_no_track_divide_by_zero(generator):

--- a/stonesoup/models/measurement/tests/test_models.py
+++ b/stonesoup/models/measurement/tests/test_models.py
@@ -1147,8 +1147,7 @@ def test_models_with_particles(h, ModelClass, state_vec, R,
     ndim_meas = np.shape(meas_pred_wo_noise)[0]
     for particle in range(nparticles):
         for dimension in range(ndim_meas):
-            assert np.array_equal(meas_pred_wo_noise[dimension][particle],
-                                  np.atleast_1d(eval_m)[dimension])
+            assert approx(meas_pred_wo_noise[dimension][particle]) == eval_m[dimension]
 
     # Ensure inverse function returns original
     # TODO Would be nice if this worked
@@ -1174,8 +1173,7 @@ def test_models_with_particles(h, ModelClass, state_vec, R,
     test_meas = h(single_state_vec, mapping, model.translation_offset, model.rotation_offset)
     for particle in range(nparticles):
         for dimension in range(ndim_meas):
-            assert np.array_equal(meas_pred_wo_noise[dimension][particle],
-                                  np.atleast_1d(test_meas)[dimension])
+            assert approx(meas_pred_wo_noise[dimension][particle]) == test_meas[dimension]
 
     # Evaluate the likelihood of the predicted measurement, given the state
     # (without noise)
@@ -1202,8 +1200,7 @@ def test_models_with_particles(h, ModelClass, state_vec, R,
 
     for particle in range(nparticles):
         for dimension in range(ndim_meas):
-            assert not np.array_equal(meas_pred_w_inoise[dimension][particle],
-                                      np.atleast_1d(test_meas)[dimension])
+            assert not approx(meas_pred_w_inoise[dimension][particle]) == test_meas[dimension]
 
     # Evaluate the likelihood of the predicted state, given the prior
     # (with noise)
@@ -1231,8 +1228,7 @@ def test_models_with_particles(h, ModelClass, state_vec, R,
 
     for particle in range(nparticles):
         for dimension in range(ndim_meas):
-            assert np.array_equal(meas_pred_w_enoise[dimension][particle],
-                                  np.atleast_1d(test_meas)[dimension])
+            assert approx(meas_pred_w_enoise[dimension][particle]) == test_meas[dimension]
 
     # Evaluate the likelihood of the predicted state, given the prior
     # (with noise)

--- a/stonesoup/resampler/particle.py
+++ b/stonesoup/resampler/particle.py
@@ -26,9 +26,13 @@ class SystematicResampler(Resampler):
             particles = Particles(particle_list=particles)
         n_particles = len(particles)
         weight = Probability(1/n_particles)
+
         log_weights = np.array([weight.log_value for weight in particles.weight])
         weight_order = np.argsort(log_weights, kind='stable')
-        cdf = np.log(np.cumsum(np.exp(log_weights[weight_order])))
+        max_log_value = log_weights[weight_order[-1]]
+        with np.errstate(divide='ignore'):
+            cdf = np.log(np.cumsum(np.exp(log_weights[weight_order] - max_log_value)))
+        cdf += max_log_value
 
         # Pick random starting point
         u_i = np.random.uniform(0, 1 / n_particles)

--- a/stonesoup/updater/tests/test_pointprocess.py
+++ b/stonesoup/updater/tests/test_pointprocess.py
@@ -71,7 +71,7 @@ def test_phd_single_component_update(UpdaterClass, measurement_model,
                   MultipleHypothesis([SingleHypothesis(
                                     prediction=prediction,
                                     measurement=None)])]
-    # print(hypotheses)
+
     updated_mixture = phd_updater.update(hypotheses)
     # One for updated component, one for missed detection
     assert len(updated_mixture) == 2
@@ -143,7 +143,7 @@ def test_lcc_single_component_update(UpdaterClass, measurement_model,
                   MultipleHypothesis([SingleHypothesis(
                                     prediction=prediction,
                                     measurement=None)])]
-    # print(hypotheses)
+
     updated_mixture = phd_updater.update(hypotheses)
     # One for updated component, one for missed detection
     assert len(updated_mixture) == 2


### PR DESCRIPTION
- Remove print statements in tests
- Use `approx` comparison in measurement model tests with particles
- Ignore divide by zero warnings in `SystematicResampler`, and avoid underflow