### PR TITLE
Change time-based SIAP titles

### DIFF
--- a/docs/examples/Metrics.py
+++ b/docs/examples/Metrics.py
@@ -190,12 +190,12 @@ fig2, axes = plt.subplots(5)
 
 fig2.subplots_adjust(hspace=1)
 
-t_siaps = {metric for metric in metrics if metric.title.startswith('T ')}
+t_siaps = {metric for metric in metrics if metric.title.startswith('time-based SIAP')}
 
 times = metric_manager.list_timestamps()
 
 for siap, axis in zip(t_siaps, axes):
-    name = siap.title[2:]
+    name = siap.title[16:]
     if name == 'C':
         title = 'Completeness'
     elif name == 'A':

--- a/stonesoup/metricgenerator/tests/test_tracktotruthmetrics.py
+++ b/stonesoup/metricgenerator/tests/test_tracktotruthmetrics.py
@@ -693,7 +693,7 @@ def test_compute_metric(generator):
     assert pa.generator == generator
 
     tpa = metrics[8]
-    assert tpa.title == "T PA"
+    assert tpa.title == "time-based SIAP PA"
     for i in range(len(manager.list_timestamps())):
         t_metric = tpa.value[i]
         timestamp = manager.list_timestamps()[i]
@@ -725,7 +725,7 @@ def test_compute_metric(generator):
     assert va.generator == generator
 
     tva = metrics[10]
-    assert tva.title == "T VA"
+    assert tva.title == "time-based SIAP VA"
     for i in range(len(manager.list_timestamps())):
         t_metric = tva.value[i]
         timestamp = manager.list_timestamps()[i]
@@ -745,7 +745,7 @@ def test_compute_metric(generator):
     assert tva.generator == generator
 
     tc = metrics[11]
-    assert tc.title == "T C"
+    assert tc.title == "time-based SIAP C"
     for i in range(len(manager.list_timestamps())):
         t_metric = tc.value[i]
         timestamp = manager.list_timestamps()[i]
@@ -762,7 +762,7 @@ def test_compute_metric(generator):
     assert tc.generator == generator
 
     ta = metrics[12]
-    assert ta.title == "T A"
+    assert ta.title == "time-based SIAP A"
     for i in range(len(manager.list_timestamps())):
         t_metric = ta.value[i]
         timestamp = manager.list_timestamps()[i]
@@ -779,7 +779,7 @@ def test_compute_metric(generator):
     assert ta.generator == generator
 
     ts = metrics[13]
-    assert ts.title == "T S"
+    assert ts.title == "time-based SIAP S"
     for i in range(len(manager.list_timestamps())):
         t_metric = ts.value[i]
         timestamp = manager.list_timestamps()[i]
@@ -806,7 +806,7 @@ def test_compute_metric(generator):
     assert cid.generator == generator
 
     tcid = metrics[15]
-    assert tcid.title == "T CID"
+    assert tcid.title == "time-based SIAP CID"
     for i in range(len(manager.list_timestamps())):
         t_metric = tcid.value[i]
         timestamp = manager.list_timestamps()[i]
@@ -839,7 +839,7 @@ def test_compute_metric(generator):
     assert ida.generator == generator
 
     tidc = metrics[18]
-    assert tidc.title == "T IDC"
+    assert tidc.title == "time-based SIAP IDC"
     for i in range(len(manager.list_timestamps())):
         t_metric = tidc.value[i]
         timestamp = manager.list_timestamps()[i]
@@ -856,7 +856,7 @@ def test_compute_metric(generator):
     assert tidc.generator == generator
 
     tida = metrics[19]
-    assert tida.title == "T IDA"
+    assert tida.title == "time-based SIAP IDA"
     for i in range(len(manager.list_timestamps())):
         t_metric = tida.value[i]
         timestamp = manager.list_timestamps()[i]
@@ -975,11 +975,14 @@ def test_absent_params():
     metrics = generator.compute_metric(manager)
 
     metric_names = {'SIAP C', 'SIAP A', 'SIAP S', 'SIAP LT', 'SIAP LS', 'SIAP nt', 'SIAP nj',
-                    'SIAP PA', 'T PA', 'SIAP VA', 'T VA', 'T C', 'T A', 'T S', 'SIAP CID',
-                    'T CID', 'SIAP IDC', 'SIAP IDA', 'T IDC', 'T IDA'}
+                    'SIAP PA', 'time-based SIAP PA', 'SIAP VA', 'time-based SIAP VA',
+                    'time-based SIAP C', 'time-based SIAP A', 'time-based SIAP S', 'SIAP CID',
+                    'time-based SIAP CID', 'SIAP IDC', 'SIAP IDA', 'time-based SIAP IDC',
+                    'time-based SIAP IDA'}
 
-    absent_names = {'SIAP PA', 'T PA', 'SIAP VA', 'T VA', 'SIAP CID', 'T CID', 'SIAP IDC',
-                    'SIAP IDA', 'T IDC', 'T IDA'}
+    absent_names = {'SIAP PA', 'time-based SIAP PA', 'SIAP VA', 'time-based SIAP VA', 'SIAP CID',
+                    'time-based SIAP CID', 'SIAP IDC', 'SIAP IDA', 'time-based SIAP IDC',
+                    'time-based SIAP IDA'}
 
     assert all(metric.title in (metric_names - absent_names) for metric in metrics)
 
@@ -987,6 +990,7 @@ def test_absent_params():
 
     metrics = generator.compute_metric(manager)
 
-    absent_names = {'SIAP PA', 'T PA', 'SIAP VA', 'T VA', 'SIAP IDC', 'T IDC', 'SIAP IDA', 'T IDA'}
+    absent_names = {'SIAP PA', 'time-based SIAP PA', 'SIAP VA', 'time-based SIAP VA', 'SIAP IDC',
+                    'time-based SIAP IDC', 'SIAP IDA', 'time-based SIAP IDA'}
 
     assert all(metric.title in (metric_names - absent_names) for metric in metrics)

--- a/stonesoup/metricgenerator/tracktotruthmetrics.py
+++ b/stonesoup/metricgenerator/tracktotruthmetrics.py
@@ -89,12 +89,14 @@ class SIAPMetrics(MetricGenerator):
 
         metrics = [C, A, S, LT, LS, nt, nj]
 
-        timestamped_metrics = {'T C': [], 'T A': [], 'T S': []}
+        timestamped_metrics = {'time-based SIAP C': [],
+                               'time-based SIAP A': [],
+                               'time-based SIAP S': []}
         timestamps = manager.list_timestamps()
         for timestamp in timestamps:
-            timestamped_metrics['T C'].append(self.C_single_time(manager, timestamp))
-            timestamped_metrics['T A'].append(self.A_single_time(manager, timestamp))
-            timestamped_metrics['T S'].append(self.S_single_time(manager, timestamp))
+            timestamped_metrics['time-based SIAP C'].append(self.C_single_time(manager, timestamp))
+            timestamped_metrics['time-based SIAP A'].append(self.A_single_time(manager, timestamp))
+            timestamped_metrics['time-based SIAP S'].append(self.S_single_time(manager, timestamp))
         t_metrics = [TimeRangeMetric(title=key,
                                      value=value,
                                      time_range=TimeRange(min(timestamps), max(timestamps)),
@@ -107,7 +109,7 @@ class SIAPMetrics(MetricGenerator):
             t_PA = []
             for timestamp in timestamps:
                 t_PA.append(self.PA_single_time(manager, timestamp))
-            metrics.append(TimeRangeMetric(title='T PA',
+            metrics.append(TimeRangeMetric(title='time-based SIAP PA',
                                            value=t_PA,
                                            time_range=TimeRange(min(timestamps), max(timestamps)),
                                            generator=self))
@@ -118,7 +120,7 @@ class SIAPMetrics(MetricGenerator):
             t_VA = []
             for timestamp in timestamps:
                 t_VA.append(self.VA_single_time(manager, timestamp))
-            metrics.append(TimeRangeMetric(title='T VA',
+            metrics.append(TimeRangeMetric(title='time-based SIAP VA',
                                            value=t_VA,
                                            time_range=TimeRange(min(timestamps), max(timestamps)),
                                            generator=self))
@@ -132,7 +134,7 @@ class SIAPMetrics(MetricGenerator):
             t_CID = []
             for timestamp in timestamps:
                 t_CID.append(self.CID_single_time(manager, timestamp))
-            metrics.append(TimeRangeMetric(title='T CID',
+            metrics.append(TimeRangeMetric(title='time-based SIAP CID',
                                            value=t_CID,
                                            time_range=TimeRange(min(timestamps),
                                                                 max(timestamps)),
@@ -148,12 +150,12 @@ class SIAPMetrics(MetricGenerator):
                 for timestamp in timestamps:
                     t_IDC.append(self.IDC_single_time(manager, timestamp))
                     t_IDA.append(self.IDA_single_time(manager, timestamp))
-                metrics.append(TimeRangeMetric(title='T IDC',
+                metrics.append(TimeRangeMetric(title='time-based SIAP IDC',
                                                value=t_IDC,
                                                time_range=TimeRange(min(timestamps),
                                                                     max(timestamps)),
                                                generator=self))
-                metrics.append(TimeRangeMetric(title='T IDA',
+                metrics.append(TimeRangeMetric(title='time-based SIAP IDA',
                                                value=t_IDA,
                                                time_range=TimeRange(min(timestamps),
                                                                     max(timestamps)),


### PR DESCRIPTION
Time-based SIAP titles were previously not descriptive.
This change also prevents the time-based metrics from being picked-up in a print statement in the Examples doc, where previously long strings were output.
Tests altered accordingly.