### PR TITLE
Update StateMutableSequence error handling

### DIFF
--- a/stonesoup/types/state.py
+++ b/stonesoup/types/state.py
@@ -111,7 +111,15 @@ class StateMutableSequence(Type, abc.MutableSequence):
                 "{!r} object has no attribute {!r}".format(
                     type(self).__name__, item))
         else:
-            return getattr(self.state, item)
+            try:
+                return getattr(self.state, item)
+            except AttributeError as err:
+                if str(err).startswith("'State' object has no attribute"):
+                    raise AttributeError(
+                        "{!r} object has no attribute {!r}".format(
+                            type(self).__name__, item))
+                else:
+                    raise err
 
     def insert(self, index, value):
         return self.states.insert(index, value)


### PR DESCRIPTION
This PR tweaks error handling in `StateMutableSequence`

Before this change, any class that inherited from `StateMutableSequence` (e.g. `Platform` would give the following behaviour:

```python
platform = Platform(some_parameters)
platform.missing_attribute
```
```
AttributeError: 'State' object has no attribute 'missing_attribute'
```

This is odd behaviour, as `Platform` is not a `State` and caused me to spend an annoying amount of time debugging the problem.

After the PR, the error message would be:
```
AttributeError: 'Platform' object has no attribute 'missing_attribute'
```
This is much more helpful and seems like a sensible change at the expense of only a little more code.