### PR TITLE
Add optional caches to SIAP metric generators

### DIFF
--- a/stonesoup/metricgenerator/_utils.py
+++ b/stonesoup/metricgenerator/_utils.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+from functools import lru_cache, wraps
+
+
+def clearable_lru_cache():
+    """Cache decorator that allows keeping track of which methods are decorated.
+    A new cache is created for each instance of :class:`SIAPMetrics`
+    """
+
+    def cache_decorator(func):
+        @wraps(func)
+        def cache_factory(self, *args, **kwargs):
+            if self.cache:
+                instance_cache = lru_cache(*self.cache_args, **self.cache_kwargs)(func)
+                instance_cache = instance_cache.__get__(self, self.__class__)
+                setattr(self, func.__name__, instance_cache)
+
+                self.cached_functions.append(instance_cache)
+
+                return instance_cache(*args, **kwargs)
+            else:
+                return func(self, *args, **kwargs)
+
+        return cache_factory
+
+    return cache_decorator

--- a/stonesoup/metricgenerator/_utils.py
+++ b/stonesoup/metricgenerator/_utils.py
@@ -4,7 +4,8 @@ from functools import lru_cache, wraps
 
 def clearable_lru_cache():
     """Cache decorator that allows keeping track of which methods are decorated.
-    A new cache is created for each instance of :class:`SIAPMetrics`
+    Requires a class utilising this to have a `cache` boolean property, determining whether the
+    decorated method is cached or not.
     """
 
     def cache_decorator(func):

--- a/stonesoup/metricgenerator/manager.py
+++ b/stonesoup/metricgenerator/manager.py
@@ -27,6 +27,8 @@ class SimpleManager(MetricManager):
         self._groundtruth_paths = set()
         self._detections = set()
         self.association_set = None
+        if self.generators is None:
+            self.generators = set()
 
     @property
     def tracks(self):
@@ -58,6 +60,7 @@ class SimpleManager(MetricManager):
             overwriting one field (e.g. tracks) does not affect the others
         """
 
+        # Clear all generator caches
         for generator in self.generators:
             try:
                 generator.clear_caches()

--- a/stonesoup/metricgenerator/manager.py
+++ b/stonesoup/metricgenerator/manager.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import copy
 from itertools import chain
 from typing import Sequence, Iterable, Union
 
@@ -67,11 +68,16 @@ class SimpleManager(MetricManager):
             except AttributeError:
                 pass
 
-        self._add(overwrite, _groundtruth_paths=groundtruth_paths,
-                  _tracks=tracks, _detections=detections)
+        if overwrite:
+            self._add(overwrite, _groundtruth_paths=copy.copy(groundtruth_paths),
+                      _tracks=copy.copy(tracks), _detections=copy.copy(detections))
+        else:
+            self._add(overwrite, _groundtruth_paths=groundtruth_paths,
+                      _tracks=tracks, _detections=detections)
 
     def _add(self, overwrite, **kwargs):
         for key, value in kwargs.items():
+            print(key)
             if value is not None:
                 if overwrite:
                     setattr(self, key, set(value))

--- a/stonesoup/metricgenerator/tests/test_manager.py
+++ b/stonesoup/metricgenerator/tests/test_manager.py
@@ -85,7 +85,7 @@ def test_listtimestamps():
         states=[State(np.array([[2]]), timestamp=timestamp2)])]
     manager.add_data(truths, tracks)
 
-    assert manager.list_timestamps() == [timestamp1, timestamp2]
+    assert manager.list_timestamps() == (timestamp1, timestamp2)
 
 
 def test_generate_metrics():

--- a/stonesoup/metricgenerator/tracktotruthmetrics.py
+++ b/stonesoup/metricgenerator/tracktotruthmetrics.py
@@ -1008,7 +1008,7 @@ class SIAPMetrics(MetricGenerator):
             Sum of Euclidean distances (of position or velocity) of each truth to its associated
             tracks in manager at timestamp
         """
-        measure = EuclideanWeighted(mapping=list(mapping), weighting=weighting)
+        measure = EuclideanWeighted(mapping=mapping, weighting=weighting)
         distance_sum = 0
         for assoc in manager.association_set.associations_at_timestamp(timestamp):
             track, truth = assoc.objects


### PR DESCRIPTION
This PR introduces functools' 'lru cache' decorators to the SIAP metric generators, with the 'simple metric manager' clearing these caches when new data is added or old data overwritten.
Other metric generators have not had their methods decorated (open to discussion).
A new decorator has been created allowing for the user to choose whether the SIAP components are cached or not (either all or none), and provide additional cache arguments ('maxsize', 'typed').
A user may want to cache metrics in an alternate way, however this PR could be considered an intermediate step to creating a more versatile method of allowing user-defined caching methods.