### PR TITLE
Include timestamp with Initiator and allow predictions with multi measurement initiator

### DIFF
--- a/docs/demos/UAV_tutorial.py
+++ b/docs/demos/UAV_tutorial.py
@@ -145,8 +145,9 @@ from stonesoup.initiator.simple import SimpleMeasurementInitiator
 from stonesoup.types.track import Track
 from stonesoup.types.hypothesis import SingleHypothesis
 
+
 class Initiator(SimpleMeasurementInitiator):
-    def initiate(self, detections, **kwargs):
+    def initiate(self, detections, timestamp, **kwargs):
         MAX_DEV = 400.
         tracks = set()
         measurement_model = self.measurement_model

--- a/docs/examples/Sensor_Platform_Simulation.py
+++ b/docs/examples/Sensor_Platform_Simulation.py
@@ -274,7 +274,7 @@ from stonesoup.types.hypothesis import SingleHypothesis
 
 
 class Initiator(SimpleMeasurementInitiator):
-    def initiate(self, detections, **kwargs):
+    def initiate(self, detections, timestamp, **kwargs):
         MAX_DEV = 500.
         tracks = set()
         measurement_model = self.measurement_model

--- a/docs/tutorials/09_Initiators_&_Deleters.py
+++ b/docs/tutorials/09_Initiators_&_Deleters.py
@@ -196,7 +196,8 @@ for n, measurements in enumerate(all_measurements):
 
     # Carry out deletion and initiation
     tracks -= deleter.delete_tracks(tracks)
-    tracks |= initiator.initiate(measurements - associated_measurements)
+    tracks |= initiator.initiate(measurements - associated_measurements,
+                                 start_time + timedelta(seconds=n))
 
 # %%
 # Plot the resulting tracks.

--- a/stonesoup/initiator/base.py
+++ b/stonesoup/initiator/base.py
@@ -11,13 +11,15 @@ class Initiator(Base):
     """
 
     @abstractmethod
-    def initiate(self, detections, **kwargs):
+    def initiate(self, detections, timestamp, **kwargs):
         """Generate tracks from detections.
 
         Parameters
         ----------
         detections : set of :class:`~.Detection`
             Detections used to generate set of tracks
+        timestamp: datetime.datetime
+            Current timestamp
 
         Returns
         -------

--- a/stonesoup/initiator/simple.py
+++ b/stonesoup/initiator/simple.py
@@ -27,25 +27,26 @@ class SinglePointInitiator(GaussianInitiator):
     prior_state: GaussianState = Property(doc="Prior state information")
     measurement_model: MeasurementModel = Property(doc="Measurement model")
 
-    def initiate(self, unassociated_detections, **kwargs):
+    def initiate(self, detections, timestamp, **kwargs):
         """Initiates tracks given unassociated measurements
 
         Parameters
         ----------
-        unassociated_detections : list of \
-        :class:`stonesoup.types.detection.Detection`
+        detections : set of :class:`stonesoup.types.detection.Detection`
             A list of unassociated detections
+        timestamp: datetime.datetime
+            Current timestamp
 
         Returns
         -------
-        : :class:`sets.Set` of :class:`stonesoup.types.track.Track`
+        : set of :class:`stonesoup.types.track.Track`
             A list of new tracks with an initial :class:`~.GaussianState`
         """
 
         updater = ExtendedKalmanUpdater(self.measurement_model)
 
         tracks = set()
-        for detection in unassociated_detections:
+        for detection in detections:
             measurement_prediction = updater.predict_measurement(
                 self.prior_state, detection.measurement_model)
             track_state = updater.update(SingleHypothesis(
@@ -86,7 +87,7 @@ class SimpleMeasurementInitiator(GaussianInitiator):
             raise ValueError(
                 "diag_load value can't be less than 0.0")
 
-    def initiate(self, detections, **kwargs):
+    def initiate(self, detections, timestamp, **kwargs):
         tracks = set()
 
         for detection in detections:
@@ -174,18 +175,16 @@ class MultiMeasurementInitiator(GaussianInitiator):
         if self.initiator is None:
             self.initiator = SimpleMeasurementInitiator(self.prior_state, self.measurement_model)
 
-    def initiate(self, detections, **kwargs):
+    def initiate(self, detections, timestamp, **kwargs):
         sure_tracks = set()
         if len(detections) == 0:
             return sure_tracks
 
-        detections_list = list(detections)
-        detections_set = set(detections)
         associated_detections = set()
 
         if not len(self.holding_tracks) == 0:
             associations = self.data_associator.associate(
-                self.holding_tracks, detections, detections_list[0].timestamp)
+                self.holding_tracks, detections, timestamp)
 
             for track, hypothesis in associations.items():
                 if hypothesis:
@@ -199,9 +198,9 @@ class MultiMeasurementInitiator(GaussianInitiator):
                 else:
                     track.append(hypothesis.prediction)
 
-            self.holding_tracks -= \
-                self.deleter.delete_tracks(self.holding_tracks)
-        self.holding_tracks |= self.initiator.initiate(detections_set - associated_detections)
+            self.holding_tracks -= self.deleter.delete_tracks(self.holding_tracks)
+        self.holding_tracks |= self.initiator.initiate(
+            detections - associated_detections, timestamp)
 
         return sure_tracks
 
@@ -223,20 +222,22 @@ class GaussianParticleInitiator(ParticleInitiator):
         doc="If `True`, the Gaussian state covariance is used for the "
             ":class:`~.ParticleState` as a fixed covariance. Default `False`.")
 
-    def initiate(self, unassociated_detections, **kwargs):
+    def initiate(self, detections, timestamp, **kwargs):
         """Initiates tracks given unassociated measurements
 
         Parameters
         ----------
-        unassociated_detections : list of :class:`~.Detection`
+        detections : set of :class:`~.Detection`
             A list of unassociated detections
+        timestamp: datetime.datetime
+            Current timestamp
 
         Returns
         -------
         : set of :class:`~.Track`
             A list of new tracks with a initial :class:`~.ParticleState`
         """
-        tracks = self.initiator.initiate(unassociated_detections, **kwargs)
+        tracks = self.initiator.initiate(detections, timestamp, **kwargs)
         weight = Probability(1 / self.number_particles)
         for track in tracks:
             samples = multivariate_normal.rvs(track.state_vector.ravel(),

--- a/stonesoup/initiator/tests/test_simple.py
+++ b/stonesoup/initiator/tests/test_simple.py
@@ -56,7 +56,7 @@ def test_spi(measurement_model):
                   Detection(np.array([[-4.5], [2.0]]), timestamp)]
 
     # Run the initiator based on the available detections
-    tracks = initiator.initiate(detections)
+    tracks = initiator.initiate(detections, timestamp)
 
     # Ensure same number of tracks are initiated as number of measurements
     # (i.e. 2)
@@ -94,7 +94,7 @@ def test_linear_measurement():
     detections = [Detection(np.array([[5]]), timestamp),
                   Detection(np.array([[-5]]), timestamp)]
 
-    tracks = measurement_initiator.initiate(detections)
+    tracks = measurement_initiator.initiate(detections, timestamp)
 
     for track in tracks:
         if track.state_vector[0, 0] > 0:
@@ -140,15 +140,19 @@ def test_nonlinear_measurement(meas_model, skip_non_linear):
 
     if not (isinstance(measurement_model, ReversibleModel) or skip_non_linear):
         with pytest.raises(Exception):
-            measurement_initiator.initiate(detections)  # Non-reversible and not skipping
+            # Non-reversible and not skipping
+            measurement_initiator.initiate(detections, timestamp)
         with pytest.raises(NotImplementedError):
-            combined_measurement_initiator.initiate(detections)  # Reversible but not implemented
+            # Reversible but not implemented
+            combined_measurement_initiator.initiate(detections, timestamp)
     elif not isinstance(measurement_model, ReversibleModel) and skip_non_linear:
-        assert len(measurement_initiator.initiate(detections)) == 0  # Skipping for non-reversible
-        assert len(combined_measurement_initiator.initiate(detections)) == 0
+        # Skipping for non-reversible
+        assert len(measurement_initiator.initiate(detections, timestamp)) == 0
+        assert len(combined_measurement_initiator.initiate(detections, timestamp)) == 0
     else:
-        all_tracks = [measurement_initiator.initiate(detections),
-                      combined_measurement_initiator.initiate(detections)]  # Otherwise tracks made
+        # Otherwise tracks made
+        all_tracks = [measurement_initiator.initiate(detections, timestamp),
+                      combined_measurement_initiator.initiate(detections, timestamp)]
         for tracks in all_tracks:
             assert len(tracks) == 2
             for track in tracks:
@@ -182,7 +186,7 @@ def test_linear_measurement_non_direct():
     detections = [Detection(np.array([[5], [2]]), timestamp),
                   Detection(np.array([[-5], [8]]), timestamp)]
 
-    tracks = measurement_initiator.initiate(detections)
+    tracks = measurement_initiator.initiate(detections, timestamp)
 
     for track in tracks:
         if track.state_vector[1, 0] > 0:
@@ -230,7 +234,7 @@ def test_linear_measurement_extra_state_dim():
     detections = [Detection(np.array([[5], [2]]), timestamp),
                   Detection(np.array([[-5], [8]]), timestamp)]
 
-    tracks = measurement_initiator.initiate(detections)
+    tracks = measurement_initiator.initiate(detections, timestamp)
 
     for track in tracks:
         if track.state_vector[0, 0] > 0:
@@ -275,17 +279,17 @@ def test_multi_measurement():
         measurement_model, deleter, data_associator, updater)
 
     timestamp = datetime.datetime.now()
-    first_detections = [Detection(np.array([[5], [2]]), timestamp),
-                        Detection(np.array([[-5], [-2]]), timestamp)]
+    first_detections = {Detection(np.array([[5], [2]]), timestamp),
+                        Detection(np.array([[-5], [-2]]), timestamp)}
 
-    first_tracks = measurement_initiator.initiate(first_detections)
+    first_tracks = measurement_initiator.initiate(first_detections, timestamp)
     assert len(first_tracks) == 0
     assert len(measurement_initiator.holding_tracks) == 2
 
     timestamp = datetime.datetime.now() + datetime.timedelta(seconds=60)
-    second_detections = [Detection(np.array([[5], [3]]), timestamp)]
+    second_detections = {Detection(np.array([[5], [3]]), timestamp)}
 
-    second_tracks = measurement_initiator.initiate(second_detections)
+    second_tracks = measurement_initiator.initiate(second_detections, timestamp)
     assert len(second_tracks) == 1
     assert len(measurement_initiator.holding_tracks) == 0
 
@@ -307,7 +311,7 @@ def test_gaussian_particle(gaussian_initiator):
     detections = [Detection(np.array([[5]]), timestamp),
                   Detection(np.array([[-5]]), timestamp)]
 
-    tracks = particle_initiator.initiate(detections)
+    tracks = particle_initiator.initiate(detections, timestamp)
 
     for track in tracks:
         assert isinstance(track.state, ParticleStateUpdate)

--- a/stonesoup/initiator/tests/test_wrapper.py
+++ b/stonesoup/initiator/tests/test_wrapper.py
@@ -52,7 +52,7 @@ def test_states_length_limiter(max_len):
         hypothesis = SingleHypothesis(prediction, measurement)
         posterior = updater.update(hypothesis)
         if track is None:
-            track = initiator.initiate([measurement]).pop()
+            track = initiator.initiate([measurement], measurement.timestamp).pop()
         else:
             track.append(posterior)
         prior = track[-1]

--- a/stonesoup/tracker/simple.py
+++ b/stonesoup/tracker/simple.py
@@ -61,7 +61,7 @@ class SingleTargetTracker(Tracker):
                         associations[track].prediction)
 
             if track is None or self.deleter.delete_tracks({track}):
-                new_tracks = self.initiator.initiate(detections)
+                new_tracks = self.initiator.initiate(detections, time)
                 if new_tracks:
                     track = new_tracks.pop()
                 else:
@@ -112,8 +112,7 @@ class MultiTargetTracker(Tracker):
                     track.append(hypothesis.prediction)
 
             tracks -= self.deleter.delete_tracks(tracks)
-            tracks |= self.initiator.initiate(
-                detections - associated_detections)
+            tracks |= self.initiator.initiate(detections - associated_detections, time)
 
             yield time, tracks
 
@@ -201,7 +200,6 @@ class MultiTargetMixtureTracker(Tracker):
                             unassociated_detections.remove(hyp.measurement)
 
             tracks -= self.deleter.delete_tracks(tracks)
-            tracks |= self.initiator.initiate(
-                unassociated_detections)
+            tracks |= self.initiator.initiate(unassociated_detections, time)
 
             yield time, tracks

--- a/stonesoup/tracker/tests/conftest.py
+++ b/stonesoup/tracker/tests/conftest.py
@@ -20,9 +20,9 @@ from ...types.update import GaussianStateUpdate
 @pytest.fixture()
 def initiator():
     class TestInitiator:
-        def initiate(self, unassociated_detections):
+        def initiate(self, detections, timestamp):
             return {Track([detection])
-                    for detection in unassociated_detections}
+                    for detection in detections}
     return TestInitiator()
 
 


### PR DESCRIPTION
- Add timestamp to `Initiator.initiate()` method: This enables initiators to possibly take action when a timestamp occurs when no measurement is present.
- Allow `MultiMeasurementInitiator` to predict tracks: This allows cases where you may want to yield tracks that have survived
the deleter a number of time steps as well.