### PR TITLE
Sensor and platform minor documentation changes

### DIFF
--- a/docs/source/stonesoup.rst
+++ b/docs/source/stonesoup.rst
@@ -26,12 +26,12 @@ Enabling Components
     stonesoup.detector
     stonesoup.feeder
     stonesoup.metricgenerator
+    stonesoup.platform
     stonesoup.reader
+    stonesoup.sensor
     stonesoup.simulator
     stonesoup.tracker
     stonesoup.writer
-    stonesoup.platform
-    stonesoup.sensor
 
 Algorithm Components
 ^^^^^^^^^^^^^^^^^^^^

--- a/stonesoup/platform/base.py
+++ b/stonesoup/platform/base.py
@@ -160,6 +160,7 @@ class Platform(StateMutableSequence, ABC):
         """
         raise NotImplementedError
 
+    @property
     @abstractmethod
     def is_moving(self) -> bool:
         """Return the ``True`` if the platform is moving, ``False`` otherwise.

--- a/stonesoup/sensor/base.py
+++ b/stonesoup/sensor/base.py
@@ -1,13 +1,16 @@
 # -*- coding: utf-8 -*-
 import weakref
 from abc import abstractmethod, ABC
-from typing import Optional
+from typing import Optional, Set, Union
 from warnings import warn
 
-from ..types.array import StateVector
-from ..platform import Platform
+import numpy as np
 
 from ..base import Base
+from ..platform import Platform
+from ..types.array import StateVector
+from ..types.detection import TrueDetection
+from ..types.groundtruth import GroundTruthState
 
 
 class BaseSensor(Base, ABC):
@@ -50,7 +53,26 @@ class BaseSensor(Base, ABC):
         self._platform_system = value
 
     @abstractmethod
-    def measure(self, **kwargs):
+    def measure(self, ground_truths: Set[GroundTruthState], noise: Union[np.ndarray, bool] = True,
+                **kwargs) -> Set[TrueDetection]:
+        """Generate a measurement for a given state
+
+        Parameters
+        ----------
+        ground_truths : Set[:class:`~.GroundTruthState`]
+            A set of :class:`~.GroundTruthState`
+        noise: :class:`numpy.ndarray` or bool
+            An externally generated random process noise sample (the default is `True`, in which
+            case :meth:`~.Model.rvs` is used; if `False`, no noise will be added)
+
+        Returns
+        -------
+        Set[:class:`~.TrueDetection`]
+            A set of measurements generated from the given states. The timestamps of the
+            measurements are set equal to that of the corresponding states that they were
+            calculated from. Each measurement stores the ground truth path that it was produced
+            from.
+        """
         raise NotImplementedError
 
     @property

--- a/stonesoup/sensor/passive.py
+++ b/stonesoup/sensor/passive.py
@@ -35,25 +35,6 @@ class PassiveElevationBearing(Sensor):
 
     def measure(self, ground_truths: Set[GroundTruthState], noise: Union[np.ndarray, bool] = True,
                 **kwargs) -> Set[TrueDetection]:
-        """Generate a measurement for a given state
-
-        Parameters
-        ----------
-        ground_truths : Set[:class:`~.GroundTruthState`]
-            A set of :class:`~.GroundTruthState`
-        noise: :class:`numpy.ndarray` or bool
-            An externally generated random process noise sample (the default is
-            `True`, in which case :meth:`~.Model.rvs` is used
-            if 'False', no noise will be added)
-
-        Returns
-        -------
-        Set[:class:`~.TrueDetection`]
-            A set of measurements generated from the given states. The timestamps of the
-            measurements are set equal to that of the corresponding states that they were
-            calculated from. Each measurement stores the ground truth path that it was produced
-            from.
-        """
 
         measurement_model = CartesianToElevationBearing(
             ndim_state=self.ndim_state,

--- a/stonesoup/sensor/radar/radar.py
+++ b/stonesoup/sensor/radar/radar.py
@@ -46,25 +46,7 @@ class RadarBearingRange(Sensor):
 
     def measure(self, ground_truths: Set[GroundTruthState], noise: Union[np.ndarray, bool] = True,
                 **kwargs) -> Set[TrueDetection]:
-        """Generate a measurement for a given state
 
-        Parameters
-        ----------
-        ground_truths : Set[:class:`~.GroundTruthState`]
-            A set of :class:`~.GroundTruthState`
-        noise: :class:`numpy.ndarray` or bool
-            An externally generated random process noise sample (the default is
-            `True`, in which case :meth:`~.Model.rvs` is used
-            if 'False', no noise will be added)
-
-        Returns
-        -------
-        Set[:class:`~.TrueDetection`]
-            A set of measurements generated from the given states. The timestamps of the
-            measurements are set equal to that of the corresponding states that they were
-            calculated from. Each measurement stores the ground truth path that it was produced
-            from.
-        """
         measurement_model = CartesianToBearingRange(
             ndim_state=self.ndim_state,
             mapping=self.position_mapping,
@@ -111,25 +93,6 @@ class RadarRotatingBearingRange(RadarBearingRange):
 
     def measure(self, ground_truths: Set[GroundTruthState], noise: Union[np.ndarray, bool] = True,
                 **kwargs) -> Set[TrueDetection]:
-        """Generate a measurement for a given state
-
-        Parameters
-        ----------
-        ground_truths : Set[:class:`~.GroundTruthState`]
-            A set of :class:`~.GroundTruthState`
-        noise: :class:`numpy.ndarray` or bool
-            An externally generated random process noise sample (the default is
-            `True`, in which case :meth:`~.Model.rvs` is used
-            if 'False', no noise will be added)
-
-        Returns
-        -------
-        Set[:class:`~.TrueDetection`]
-            A set of measurements generated from the given states. If a state falls in the sensor's
-            field of view, a measurement is added. The timestamps of the measurements are set equal
-            to that of the corresponding states that they were calculated from. Each measurement
-            stores the ground truth path that it was produced from.
-        """
 
         # Read timestamp from ground truth
         try:
@@ -230,25 +193,7 @@ class RadarElevationBearingRange(RadarBearingRange):
 
     def measure(self, ground_truths: Set[GroundTruthState], noise: Union[np.ndarray, bool] = True,
                 **kwargs) -> Set[TrueDetection]:
-        """Generate a measurement for a given state
 
-        Parameters
-        ----------
-        ground_truths : Set[:class:`~.GroundTruthState`]
-            A set of :class:`~.GroundTruthState`
-        noise: :class:`numpy.ndarray` or bool
-            An externally generated random process noise sample (the default is
-            `True`, in which case :meth:`~.Model.rvs` is used
-            if 'False', no noise will be added)
-
-        Returns
-        -------
-        Set[:class:`~.TrueDetection`]
-            A set of measurements generated from the given states. The timestamps of the
-            measurements are set equal to that of the corresponding states that they were
-            calculated from. Each measurement stores the ground truth path that it was produced
-            from.
-        """
         measurement_model = CartesianToElevationBearingRange(
             ndim_state=self.ndim_state,
             mapping=self.position_mapping,
@@ -294,25 +239,7 @@ class RadarBearingRangeRate(RadarBearingRange):
 
     def measure(self, ground_truths: Set[GroundTruthState], noise: Union[np.ndarray, bool] = True,
                 **kwargs) -> Set[TrueDetection]:
-        """Generate a measurement for a given state
 
-        Parameters
-        ----------
-        ground_truths : Set[:class:`~.GroundTruthState`]
-            A set of :class:`~.GroundTruthState` which include position and velocity information
-        noise: :class:`numpy.ndarray` or bool
-            An externally generated random process noise sample (the default is
-            `True`, in which case :meth:`~.Model.rvs` is used
-            if 'False', no noise will be added)
-
-        Returns
-        -------
-        Set[:class:`~.TrueDetection`]
-            A set of measurements generated from the given states. The timestamps of the
-            measurements are set equal to that of the corresponding states that they were
-            calculated from. Each measurement stores the ground truth path that it was produced
-            from.
-        """
         measurement_model = CartesianToBearingRangeRate(
             ndim_state=self.ndim_state,
             mapping=self.position_mapping,
@@ -359,25 +286,7 @@ class RadarElevationBearingRangeRate(RadarBearingRangeRate):
 
     def measure(self, ground_truths: Set[GroundTruthState], noise: Union[np.ndarray, bool] = True,
                 **kwargs) -> Set[TrueDetection]:
-        """Generate a measurement for a given state
 
-        Parameters
-        ----------
-        ground_truths : Set[:class:`~.GroundTruthState`]
-            A set of :class:`~.GroundTruthState` which include position and velocity information
-        noise: :class:`numpy.ndarray` or bool
-            An externally generated random process noise sample (the default is
-            `True`, in which case :meth:`~.Model.rvs` is used
-            if 'False', no noise will be added)
-
-        Returns
-        -------
-        Set[:class:`~.TrueDetection`]
-            A set of measurements generated from the given states. The timestamps of the
-            measurements are set equal to that of the corresponding states that they were
-            calculated from. Each measurement stores the ground truth path that it was produced
-            from.
-        """
         measurement_model = CartesianToElevationBearingRangeRate(
             ndim_state=self.ndim_state,
             mapping=self.position_mapping,
@@ -657,25 +566,6 @@ class AESARadar(Sensor):
 
     def measure(self, ground_truths: Set[GroundTruthState], noise: Union[np.ndarray, bool] = True,
                 **kwargs) -> Set[TrueDetection]:
-        """Generate a measurement for a given state
-
-        Parameters
-        ----------
-        ground_truths : Set[:class:`~.GroundTruthState`]
-            A set of :class:`~.GroundTruthState` in 3-D cartesian space
-        noise: :class:`numpy.ndarray` or bool
-            An externally generated random process noise sample (the default is
-            `True`, in which case :meth:`~.Model.rvs` is used
-            if 'False', no noise will be added)
-
-        Returns
-        -------
-        Set[:class:`~.TrueDetection`]
-            A set of measurements generated from the given states. If np.random.rand() is less than
-            the probability of detection a measurement is added. The timestamps of the measurements
-            are set equal to that of the corresponding states that they were calculated from. Each
-            measurement stores the ground truth path that it was produced from.
-        """
 
         detections = set()
 


### PR DESCRIPTION
 - Base `Platform` class `is_moving` should be a `property`.
 - Document `measure()` method on sensor base class. Subclasses all have very similar docstrings, so removed those so they'll inherit parent.