### PR TITLE
Trackers are Iterables instead of Generators 

### DIFF
--- a/docs/demos/AIS_Solent_Tracker.py
+++ b/docs/demos/AIS_Solent_Tracker.py
@@ -161,7 +161,7 @@ tracker = MultiTargetTracker(
 # :class:`set` we can simply update this with `current_tracks` at each timestep, not worrying about
 # duplicates.
 tracks = set()
-for step, (time, current_tracks) in enumerate(tracker.tracks_gen(), 1):
+for step, (time, current_tracks) in enumerate(tracker, 1):
     tracks.update(current_tracks)
     if not step % 10:
         print("Step: {} Time: {}".format(step, time))

--- a/docs/demos/OpenSky_Demo.py
+++ b/docs/demos/OpenSky_Demo.py
@@ -238,7 +238,7 @@ kalman_tracker = MultiTargetTracker(
 )
 
 tracks = set()
-for step, (time, current_tracks) in enumerate(kalman_tracker.tracks_gen(), 1):
+for step, (time, current_tracks) in enumerate(kalman_tracker, 1):
     tracks.update(current_tracks)
 
 # %%

--- a/docs/examples/Metrics.py
+++ b/docs/examples/Metrics.py
@@ -146,7 +146,7 @@ metric_manager = SimpleManager([basic_generator, ospa_generator, siap_generator,
 # With this basic tracker built and metrics ready, we'll now run the tracker, adding the sets of
 # :class:`~.GroundTruthPath`, :class:`~.Detection` and :class:`~.Track` objects: to the metric
 # manager.
-for time, tracks in tracker.tracks_gen():
+for time, tracks in tracker:
     metric_manager.add_data(
         groundtruth_sim.groundtruth_paths, tracks, detection_sim.detections,
         overwrite=False,  # Don't overwrite, instead add above as additional data

--- a/docs/examples/Sensor_Platform_Simulation.py
+++ b/docs/examples/Sensor_Platform_Simulation.py
@@ -346,7 +346,7 @@ kalman_tracks = {}  # Store for plotting later
 groundtruth_paths = {}  # Store for plotting later
 detections = []  # Store for plotting later
 
-for time, ctracks in kalman_tracker.tracks_gen():
+for time, ctracks in kalman_tracker:
     for track in ctracks:
         loc = (track.state_vector[0], track.state_vector[2])
         if track not in kalman_tracks:

--- a/stonesoup/reader/yaml.py
+++ b/stonesoup/reader/yaml.py
@@ -74,16 +74,23 @@ class YAMLTrackReader(YAMLReader, Tracker):
     def data_gen(self):
         yield from super().data_gen()
 
-    @BufferedGenerator.generator_method
-    def tracks_gen(self):
-        tracks = dict()
-        for time, document in self.data_gen():
-            updated_tracks = set()
-            for track in document.get('tracks', set()):
-                if track.id in tracks:
-                    tracks[track.id].states = track.states
-                else:
-                    tracks[track.id] = track
-                updated_tracks.add(tracks[track.id])
+    def __iter__(self):
+        self.data_iter = iter(self.data_gen())
+        self._tracks = dict()
+        return super().__iter__()
 
-            yield time, updated_tracks
+    @property
+    def tracks(self):
+        return self._tracks
+
+    def __next__(self):
+        time, document = next(self.data_iter)
+        updated_tracks = set()
+        for track in document.get('tracks', set()):
+            if track.id in self.tracks:
+                self._tracks[track.id].states = track.states
+            else:
+                self._tracks[track.id] = track
+            updated_tracks.add(self.tracks[track.id])
+
+        return time, updated_tracks

--- a/stonesoup/tracker/base.py
+++ b/stonesoup/tracker/base.py
@@ -2,23 +2,24 @@
 from abc import abstractmethod
 
 from ..base import Base
-from ..buffered_generator import BufferedGenerator
 
 
-class Tracker(Base, BufferedGenerator):
+class Tracker(Base):
     """Tracker base class"""
 
     @property
+    @abstractmethod
     def tracks(self):
-        return self.current[1]
+        raise NotImplementedError
+
+    def __iter__(self):
+        return self
 
     @abstractmethod
-    @BufferedGenerator.generator_method
-    def tracks_gen(self):
-        """Returns a generator of tracks for each time step.
-
-        Yields
-        ------
+    def __next__(self):
+        """
+        Returns
+        -------
         : :class:`datetime.datetime`
             Datetime of current time step
         : set of :class:`~.Track`

--- a/stonesoup/tracker/pointprocess.py
+++ b/stonesoup/tracker/pointprocess.py
@@ -9,7 +9,6 @@ from ..types.track import Track
 from ..updater import Updater
 from ..hypothesiser.gaussianmixture import GaussianMixtureHypothesiser
 from ..mixturereducer.gaussianmixture import GaussianMixtureReducer
-from ..buffered_generator import BufferedGenerator
 
 
 class PointProcessMultiTargetTracker(Tracker):
@@ -46,6 +45,10 @@ class PointProcessMultiTargetTracker(Tracker):
             tracks.add(track)
         return tracks
 
+    def __iter__(self):
+        self.detector_iter = iter(self.detector)
+        return super().__iter__()
+
     def update_tracks(self):
         """
         Updates the tracks (:class:`Track`) associated with the filter.
@@ -74,27 +77,26 @@ class PointProcessMultiTargetTracker(Tracker):
                             self.extraction_threshold:
                         self.target_tracks[tag] = Track([component], id=tag)
 
-    @BufferedGenerator.generator_method
-    def tracks_gen(self):
-        for time, detections in self.detector:
-            # Add birth component
-            self.birth_component.timestamp = time
-            self.gaussian_mixture.append(self.birth_component)
-            # Perform GM Prediction and generate hypotheses
-            hypotheses = self.hypothesiser.hypothesise(
-                        self.gaussian_mixture.components,
-                        detections,
-                        time
-                        )
-            # Perform GM Update
-            self.gaussian_mixture = self.updater.update(hypotheses)
-            # Reduce mixture - Pruning and Merging
-            self.gaussian_mixture.components = \
-                self.reducer.reduce(self.gaussian_mixture.components)
-            # Update the tracks
-            self.update_tracks()
-            self.end_tracks()
-            yield time, self.tracks
+    def __next__(self):
+        time, detections = next(self.detector_iter)
+        # Add birth component
+        self.birth_component.timestamp = time
+        self.gaussian_mixture.append(self.birth_component)
+        # Perform GM Prediction and generate hypotheses
+        hypotheses = self.hypothesiser.hypothesise(
+                    self.gaussian_mixture.components,
+                    detections,
+                    time
+                    )
+        # Perform GM Update
+        self.gaussian_mixture = self.updater.update(hypotheses)
+        # Reduce mixture - Pruning and Merging
+        self.gaussian_mixture.components = \
+            self.reducer.reduce(self.gaussian_mixture.components)
+        # Update the tracks
+        self.update_tracks()
+        self.end_tracks()
+        return time, self.tracks
 
     def end_tracks(self):
         """

--- a/stonesoup/tracker/simple.py
+++ b/stonesoup/tracker/simple.py
@@ -12,7 +12,6 @@ from ..types.array import StateVectors
 from ..types.prediction import GaussianStatePrediction
 from ..types.update import GaussianStateUpdate
 from ..functions import gm_reduce_single
-from stonesoup.buffered_generator import BufferedGenerator
 
 
 class SingleTargetTracker(Tracker):
@@ -45,29 +44,36 @@ class SingleTargetTracker(Tracker):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        self._track = None
 
-    @BufferedGenerator.generator_method
-    def tracks_gen(self):
-        track = None
-        for time, detections in self.detector:
-            if track is not None:
-                associations = self.data_associator.associate(
-                    {track}, detections, time)
-                if associations[track]:
-                    state_post = self.updater.update(associations[track])
-                    track.append(state_post)
-                else:
-                    track.append(
-                        associations[track].prediction)
+    @property
+    def tracks(self):
+        return {self._track} if self._track else set()
 
-            if track is None or self.deleter.delete_tracks({track}):
-                new_tracks = self.initiator.initiate(detections, time)
-                if new_tracks:
-                    track = new_tracks.pop()
-                else:
-                    track = None
+    def __iter__(self):
+        self.detector_iter = iter(self.detector)
+        return super().__iter__()
 
-            yield (time, {track}) if track is not None else (time, set())
+    def __next__(self):
+        time, detections = next(self.detector_iter)
+        if self._track is not None:
+            associations = self.data_associator.associate(
+                self.tracks, detections, time)
+            if associations[self._track]:
+                state_post = self.updater.update(associations[self._track])
+                self._track.append(state_post)
+            else:
+                self._track.append(
+                    associations[self._track].prediction)
+
+        if self._track is None or self.deleter.delete_tracks(self.tracks):
+            new_tracks = self.initiator.initiate(detections, time)
+            if new_tracks:
+                self._track = new_tracks.pop()
+            else:
+                self._track = None
+
+        return time, self.tracks
 
 
 class MultiTargetTracker(Tracker):
@@ -93,28 +99,35 @@ class MultiTargetTracker(Tracker):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        self._tracks = set()
 
-    @BufferedGenerator.generator_method
-    def tracks_gen(self):
-        tracks = set()
+    @property
+    def tracks(self):
+        return self._tracks
 
-        for time, detections in self.detector:
+    def __iter__(self):
+        self.detector_iter = iter(self.detector)
+        return super().__iter__()
 
-            associations = self.data_associator.associate(
-                tracks, detections, time)
-            associated_detections = set()
-            for track, hypothesis in associations.items():
-                if hypothesis:
-                    state_post = self.updater.update(hypothesis)
-                    track.append(state_post)
-                    associated_detections.add(hypothesis.measurement)
-                else:
-                    track.append(hypothesis.prediction)
+    def __next__(self):
+        time, detections = next(self.detector_iter)
 
-            tracks -= self.deleter.delete_tracks(tracks)
-            tracks |= self.initiator.initiate(detections - associated_detections, time)
+        associations = self.data_associator.associate(
+            self.tracks, detections, time)
+        associated_detections = set()
+        for track, hypothesis in associations.items():
+            if hypothesis:
+                state_post = self.updater.update(hypothesis)
+                track.append(state_post)
+                associated_detections.add(hypothesis.measurement)
+            else:
+                track.append(hypothesis.prediction)
 
-            yield time, tracks
+        self._tracks -= self.deleter.delete_tracks(self.tracks)
+        self._tracks |= self.initiator.initiate(
+            detections - associated_detections, time)
+
+        return time, self.tracks
 
 
 class MultiTargetMixtureTracker(Tracker):
@@ -142,64 +155,71 @@ class MultiTargetMixtureTracker(Tracker):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        self._tracks = set()
 
-    @BufferedGenerator.generator_method
-    def tracks_gen(self):
-        tracks = set()
+    @property
+    def tracks(self):
+        return self._tracks
 
-        for time, detections in self.detector:
+    def __iter__(self):
+        self.detector_iter = iter(self.detector)
+        return super().__iter__()
 
-            associations = self.data_associator.associate(
-                tracks, detections, time)
-            unassociated_detections = set(detections)
-            for track, multihypothesis in associations.items():
+    def __next__(self):
+        time, detections = next(self.detector_iter)
 
-                # calculate each Track's state as a Gaussian Mixture of
-                # its possible associations with each detection, then
-                # reduce the Mixture to a single Gaussian State
-                posterior_states = []
-                posterior_state_weights = []
-                for hypothesis in multihypothesis:
-                    if not hypothesis:
-                        posterior_states.append(hypothesis.prediction)
-                    else:
-                        posterior_states.append(
-                            self.updater.update(hypothesis))
-                    posterior_state_weights.append(
-                        hypothesis.probability)
+        associations = self.data_associator.associate(
+            self.tracks, detections, time)
+        unassociated_detections = set(detections)
+        for track, multihypothesis in associations.items():
 
-                means = StateVectors([state.state_vector for state in posterior_states])
-                covars = np.stack([state.covar for state in posterior_states], axis=2)
-                weights = np.asarray(posterior_state_weights)
-
-                post_mean, post_covar = gm_reduce_single(means, covars, weights)
-
-                missed_detection_weight = next(hyp.weight for hyp in multihypothesis if not hyp)
-
-                # Check if at least one reasonable measurement...
-                if any(hypothesis.weight > missed_detection_weight
-                       for hypothesis in multihypothesis):
-                    # ...and if so use update type
-                    track.append(GaussianStateUpdate(
-                        post_mean, post_covar,
-                        multihypothesis,
-                        multihypothesis[0].measurement.timestamp))
+            # calculate each Track's state as a Gaussian Mixture of
+            # its possible associations with each detection, then
+            # reduce the Mixture to a single Gaussian State
+            posterior_states = []
+            posterior_state_weights = []
+            for hypothesis in multihypothesis:
+                if not hypothesis:
+                    posterior_states.append(hypothesis.prediction)
                 else:
-                    # ...and if not, treat as a prediction
-                    track.append(GaussianStatePrediction(
-                        post_mean, post_covar,
-                        multihypothesis[0].prediction.timestamp))
+                    posterior_states.append(
+                        self.updater.update(hypothesis))
+                posterior_state_weights.append(
+                    hypothesis.probability)
 
-                # any detections in multihypothesis that had an
-                # association score (weight) lower than or equal to the
-                # association score of "MissedDetection" is considered
-                # unassociated - candidate for initiating a new Track
-                for hyp in multihypothesis:
-                    if hyp.weight > missed_detection_weight:
-                        if hyp.measurement in unassociated_detections:
-                            unassociated_detections.remove(hyp.measurement)
+            means = StateVectors([state.state_vector for state in posterior_states])
+            covars = np.stack([state.covar for state in posterior_states], axis=2)
+            weights = np.asarray(posterior_state_weights)
 
-            tracks -= self.deleter.delete_tracks(tracks)
-            tracks |= self.initiator.initiate(unassociated_detections, time)
+            post_mean, post_covar = gm_reduce_single(means, covars, weights)
 
-            yield time, tracks
+            missed_detection_weight = next(hyp.weight for hyp in multihypothesis if not hyp)
+
+            # Check if at least one reasonable measurement...
+            if any(hypothesis.weight > missed_detection_weight
+                   for hypothesis in multihypothesis):
+                # ...and if so use update type
+                track.append(GaussianStateUpdate(
+                    post_mean, post_covar,
+                    multihypothesis,
+                    multihypothesis[0].measurement.timestamp))
+            else:
+                # ...and if not, treat as a prediction
+                track.append(GaussianStatePrediction(
+                    post_mean, post_covar,
+                    multihypothesis[0].prediction.timestamp))
+
+            # any detections in multihypothesis that had an
+            # association score (weight) lower than or equal to the
+            # association score of "MissedDetection" is considered
+            # unassociated - candidate for initiating a new Track
+            for hyp in multihypothesis:
+                if hyp.weight > missed_detection_weight:
+                    if hyp.measurement in unassociated_detections:
+                        unassociated_detections.remove(hyp.measurement)
+
+        self._tracks -= self.deleter.delete_tracks(self.tracks)
+        self._tracks |= self.initiator.initiate(
+            unassociated_detections, time)
+
+        return time, self.tracks

--- a/stonesoup/writer/tests/conftest.py
+++ b/stonesoup/writer/tests/conftest.py
@@ -52,18 +52,25 @@ def groundtruth_reader():
 @pytest.fixture()
 def tracker():
     class TestTracker(Tracker):
-        @BufferedGenerator.generator_method
-        def tracks_gen(self):
-            time = datetime.datetime(2018, 1, 1, 14)
+        @property
+        def tracks(self):
+            return self._tracks
+
+        def __iter__(self):
+            self.iter = iter(range(2))
+            self.time = datetime.datetime(2018, 1, 1, 13, 59)
+            return super().__iter__()
+
+        def __next__(self):
+            i = next(self.iter)
             state_vector = StateVector([[0]])
-            for i in range(2):
-                tracks = {
-                    Track(
-                        [State(
-                            state_vector + i + 10*j, timestamp=time)
-                            for j in range(i)],
-                        str(k))
-                    for k in range(i)}
-                yield time, tracks
-                time += datetime.timedelta(minutes=1)
+            self.time += datetime.timedelta(minutes=1)
+            self._tracks = {
+                Track(
+                    [State(
+                        state_vector + i + 10*j, timestamp=self.time)
+                        for j in range(i)],
+                    str(k))
+                for k in range(i)}
+            return self.time, self.tracks
     return TestTracker()


### PR DESCRIPTION
The trackers have been turned into iterables instead of generators. This allows trackers to be copied/ manipulated while producing tracks if needed.

Instead of `for time, tracks in tracker.tracks_gen():`
you now write
`for time, tracks in tracker:`

There _should_ be no other changes to how the trackers function 