### PR TITLE
Add mapping to CovarianceBasedDeleter

### DIFF
--- a/stonesoup/deleter/error.py
+++ b/stonesoup/deleter/error.py
@@ -17,9 +17,10 @@ class CovarianceBasedDeleter(Deleter):
 
     covar_trace_thresh: float = Property(doc="Covariance matrix trace threshold")
     mapping: Sequence[int] = Property(default=None,
-                                 doc="Track state vector indices whose corresponding covariances' "
-                                     "sum is to be considered. Defaults to None, whereby the "
-                                     "entire track covariance trace is considered.")
+                                      doc="Track state vector indices whose corresponding "
+                                          "covariances' sum is to be considered. Defaults to"
+                                          "None, whereby the entire track covariance trace is "
+                                          "considered.")
 
     def check_for_deletion(self, track, **kwargs):
         """Check if a given track should be deleted

--- a/stonesoup/deleter/error.py
+++ b/stonesoup/deleter/error.py
@@ -16,7 +16,7 @@ class CovarianceBasedDeleter(Deleter):
     """
 
     covar_trace_thresh: float = Property(doc="Covariance matrix trace threshold")
-    mapping: Sequence = Property(default=None,
+    mapping: Sequence[int] = Property(default=None,
                                  doc="Track state vector indices whose corresponding covariances' "
                                      "sum is to be considered. Defaults to None, whereby the "
                                      "entire track covariance trace is considered.")

--- a/stonesoup/deleter/error.py
+++ b/stonesoup/deleter/error.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 """Contains collection of error based deleters"""
+from typing import Sequence
+
 import numpy as np
 
 from ..base import Property
@@ -14,6 +16,10 @@ class CovarianceBasedDeleter(Deleter):
     """
 
     covar_trace_thresh: float = Property(doc="Covariance matrix trace threshold")
+    mapping: Sequence = Property(default=None,
+                                 doc="Track state vector indices whose corresponding covariances' "
+                                     "sum is to be considered. Defaults to None, whereby the "
+                                     "entire track covariance trace is considered.")
 
     def check_for_deletion(self, track, **kwargs):
         """Check if a given track should be deleted
@@ -32,7 +38,11 @@ class CovarianceBasedDeleter(Deleter):
             `True` if track should be deleted, `False` otherwise.
         """
 
-        track_covar_trace = np.trace(track.state.covar)
+        diagonals = np.diag(track.state.covar)
+        if self.mapping:
+            track_covar_trace = np.sum(diagonals[self.mapping])
+        else:
+            track_covar_trace = np.sum(diagonals)
 
         if track_covar_trace > self.covar_trace_thresh:
             return True

--- a/stonesoup/deleter/tests/test_error.py
+++ b/stonesoup/deleter/tests/test_error.py
@@ -3,9 +3,9 @@ import datetime
 
 import numpy as np
 
+from ..error import CovarianceBasedDeleter
 from ...types.state import GaussianState
 from ...types.track import Track
-from ..error import CovarianceBasedDeleter
 
 
 def test_cbd():
@@ -15,17 +15,14 @@ def test_cbd():
     state = GaussianState(
         np.array([[0], [0]]),
         np.array([[100, 0], [0, 1]]), timestamp)
-    track = Track()
-    track.append(state)
-    tracks = {track}
+    track1 = Track(state)
 
     state = GaussianState(
         np.array([[0], [0]]),
         np.array([[1, 0], [0, 1]]), timestamp)
-    track = Track()
-    track.append(state)
+    track2 = Track(state)
 
-    tracks.add(track)
+    tracks = {track1, track2}
 
     cover_deletion_thresh = 100
     deleter = CovarianceBasedDeleter(cover_deletion_thresh)
@@ -33,5 +30,15 @@ def test_cbd():
     deleted_tracks = deleter.delete_tracks(tracks)
     tracks -= deleted_tracks
 
-    assert(len(tracks) == 1)
-    assert(len(deleted_tracks) == 1)
+    assert len(tracks) == 1
+    assert len(deleted_tracks) == 1
+
+    deleter = CovarianceBasedDeleter(cover_deletion_thresh, mapping=[1])
+
+    tracks = {track1, track2}
+
+    deleted_tracks = deleter.delete_tracks(tracks)
+    tracks -= deleted_tracks
+
+    assert len(tracks) == 2
+    assert len(deleted_tracks) == 0


### PR DESCRIPTION
Sometimes it is useful to consider deleting a track only when particular components of its state vector become very uncertain. This change introduces a mapping to the `CovarianceBasedDeleter`, which allows the user to define which components of the track state should be taken in to consideration when evaluating a covariance trace.
For example, with a track state vector (x, vx, y, vy), the user might only want to delete a track if its positional uncertainties grow too large, in which case a mapping of [0, 2] could be passed in, in which case the deleter will sum the variance in x and y only.