### PR TITLE
Add option to delete posterior predictions from deleted tracks

### DIFF
--- a/docs/demos/AIS_Solent_Tracker.py
+++ b/docs/demos/AIS_Solent_Tracker.py
@@ -138,7 +138,7 @@ initiator = SimpleMeasurementInitiator(
 # As well as an initiator we must also have a deleter. This deleter removes tracks which haven't
 # been updated for a defined time period, in this case 10 minutes.
 from stonesoup.deleter.time import UpdateTimeDeleter
-deleter = UpdateTimeDeleter(datetime.timedelta(minutes=10))
+deleter = UpdateTimeDeleter(time_since_update=datetime.timedelta(minutes=10))
 
 # %%
 # Building and running the tracker

--- a/docs/tutorials/09_Initiators_&_Deleters.py
+++ b/docs/tutorials/09_Initiators_&_Deleters.py
@@ -139,7 +139,7 @@ data_associator = GNNWith2DAssignment(hypothesiser)
 # your state vector. So the higher the threshold value, the longer tracks that haven't been
 # updated will remain.
 from stonesoup.deleter.error import CovarianceBasedDeleter
-deleter = CovarianceBasedDeleter(4)
+deleter = CovarianceBasedDeleter(covar_trace_thresh=4)
 
 # %%
 # Creating an Initiator

--- a/docs/tutorials/10_Simulation_&_Tracking_Components.py
+++ b/docs/tutorials/10_Simulation_&_Tracking_Components.py
@@ -158,7 +158,7 @@ data_associator = GNNWith2DAssignment(hypothesiser)
 # Create deleter - get rid of anything with a covariance trace greater than 2
 from stonesoup.deleter.error import CovarianceBasedDeleter
 covariance_limit_for_delete = 2
-deleter = CovarianceBasedDeleter(covariance_limit_for_delete)
+deleter = CovarianceBasedDeleter(covar_trace_thresh=covariance_limit_for_delete)
 
 # %%
 # Set a standard prior state and the minimum number of detections required to qualify for

--- a/stonesoup/deleter/tests/test_base.py
+++ b/stonesoup/deleter/tests/test_base.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+import datetime
+
+import pytest
+
+from ...deleter import Deleter
+from ...types.detection import Detection
+from ...types.hypothesis import SingleHypothesis
+from ...types.prediction import StatePrediction
+from ...types.track import Track
+from ...types.update import StateUpdate
+
+
+class BasicDeleter(Deleter):
+    """Deletes tracks if they are longer than 3 states"""
+
+    def check_for_deletion(self, track):
+        return len(track) > 3
+
+
+@pytest.mark.parametrize("delete_last_pred", [True, False])
+def test_delete_tracks(delete_last_pred):
+    start = datetime.datetime.now()
+    times = [start + datetime.timedelta(seconds=5*i) for i in range(4)]
+
+    track1 = Track([
+        StateUpdate([[0]], SingleHypothesis(None, Detection([[0]])), timestamp=times[0]),
+        StatePrediction([[0]], timestamp=times[1]),
+        StatePrediction([[0]], timestamp=times[2]),
+        StatePrediction([[0]], timestamp=times[3])
+    ])
+    track2 = Track([
+        StateUpdate([[0]], SingleHypothesis(None, Detection([[0]])), timestamp=times[0]),
+        StatePrediction([[0]], timestamp=times[1]),
+        StatePrediction([[0]], timestamp=times[2]),
+        StateUpdate([[0]], SingleHypothesis(None, Detection([[0]])), timestamp=times[3])
+    ])
+    track3 = Track([
+        StateUpdate([[0]], SingleHypothesis(None, Detection([[0]])), timestamp=times[0]),
+        StatePrediction([[0]], timestamp=times[3])
+    ])
+    track4 = Track([
+        StateUpdate([[0]], SingleHypothesis(None, Detection([[0]])), timestamp=times[0]),
+        StateUpdate([[0]], SingleHypothesis(None, Detection([[0]])), timestamp=times[3])
+    ])
+
+    tracks = {track1, track2, track3, track4}
+
+    deleter = BasicDeleter(delete_last_pred)
+
+    tracks_to_delete = deleter.delete_tracks(tracks)
+
+    tracks -= tracks_to_delete
+
+    assert tracks == {track3, track4}
+    assert tracks_to_delete == {track1, track2}
+
+    if delete_last_pred:
+        assert len(track1) == 3  # last state is prediction, so delete
+    else:
+        assert len(track1) == 4
+    assert len(track2) == 4  # last state is update, so do not delete

--- a/stonesoup/deleter/tests/test_error.py
+++ b/stonesoup/deleter/tests/test_error.py
@@ -28,7 +28,7 @@ def test_cbd():
     tracks.add(track)
 
     cover_deletion_thresh = 100
-    deleter = CovarianceBasedDeleter(cover_deletion_thresh)
+    deleter = CovarianceBasedDeleter(covar_trace_thresh=cover_deletion_thresh)
 
     deleted_tracks = deleter.delete_tracks(tracks)
     tracks -= deleted_tracks

--- a/stonesoup/deleter/tests/test_multi.py
+++ b/stonesoup/deleter/tests/test_multi.py
@@ -36,11 +36,11 @@ def test_multi_deleter_single(intersect):
     track = Track()
     track.append(state)
     tracks.add(track)
-    cover_deletion_thresh = 100
-    deleter = CovarianceBasedDeleter(cover_deletion_thresh)
+    covar_deletion_thresh = 100
+    deleter = CovarianceBasedDeleter(covar_trace_thresh=covar_deletion_thresh)
 
     # Test intersect deleter
-    multi_deleter = CompositeDeleter([deleter], intersect)
+    multi_deleter = CompositeDeleter(deleters=[deleter], intersect=intersect)
     deleted_tracks = multi_deleter.delete_tracks(tracks)
     tracks -= deleted_tracks
 
@@ -51,10 +51,10 @@ def test_multi_deleter_single(intersect):
 def test_multi_deleter_multiple(intersect):
     """Test multi deleter classes with multiple deleters"""
 
-    cover_deletion_thresh = 99
-    deleter = CovarianceBasedDeleter(cover_deletion_thresh)
+    covar_deletion_thresh = 99
+    deleter = CovarianceBasedDeleter(covar_trace_thresh=covar_deletion_thresh)
     deleter2 = UpdateTimeDeleter(datetime.timedelta(minutes=10))
-    multi_deleter = CompositeDeleter([deleter, deleter2], intersect)
+    multi_deleter = CompositeDeleter(deleters=[deleter, deleter2], intersect=intersect)
 
     # Create track that is not deleted by either deleter
     track = Track([

--- a/stonesoup/deleter/tests/test_time.py
+++ b/stonesoup/deleter/tests/test_time.py
@@ -10,7 +10,7 @@ from ...types.update import StateUpdate
 
 
 def test_update_time_steps_deleter():
-    deleter = UpdateTimeStepsDeleter(3)
+    deleter = UpdateTimeStepsDeleter(time_steps_since_update=3)
 
     track = Track([
         StateUpdate(
@@ -45,7 +45,7 @@ def test_update_time_steps_deleter():
 
 
 def test_update_time_deleter():
-    deleter = UpdateTimeDeleter(datetime.timedelta(minutes=20))
+    deleter = UpdateTimeDeleter(time_since_update=datetime.timedelta(minutes=20))
 
     track = Track([
         StateUpdate(


### PR DESCRIPTION
Introduces option to deleters to remove the last state in a track that has caused it to be marked for deletion. State will only be removed if it is not an `update`. This is useful when there are large time steps between each incoming detection to a tracker.