### PR TITLE
Fix gm_reduce_single.

### DIFF
--- a/stonesoup/functions/__init__.py
+++ b/stonesoup/functions/__init__.py
@@ -537,6 +537,9 @@ def gm_reduce_single(means, covars, weights):
     # Normalise weights such that they sum to 1
     weights = weights/Probability.sum(weights)
 
+    # Cast means as a StateVectors, so this works with ndarray types
+    means = means.view(StateVectors)
+
     # Calculate mean
     mean = np.average(means, axis=1, weights=weights)
 

--- a/stonesoup/functions/tests/test_functions.py
+++ b/stonesoup/functions/tests/test_functions.py
@@ -115,6 +115,13 @@ def test_gm_reduce_single():
     assert np.allclose(covar, np.array([[3.675, 3.35],
                                         [3.2, 3.3375]]))
 
+    # Test handling of means as array instead of StateVectors
+    mean, covar = gm_reduce_single(means.view(np.ndarray), covars, weights)
+
+    assert np.allclose(mean, np.array([[4], [5]]))
+    assert np.allclose(covar, np.array([[3.675, 3.35],
+                                        [3.2, 3.3375]]))
+
 
 def test_bearing():
     bearing_in = [10., 170., 190., 260., 280., 350., 705]


### PR DESCRIPTION
Updated gm_reduce_single to handle `means` passed in as `np.array` type. The `StateVectors` class overrides the average() routine to work properly. This causes an issue when a np.array type is passed into `gm_reduce_single`. Rather than force the user to pass in a StateVectors type, the easiest fix is to cast `means` as a StateVectors type.