### PR TITLE
Add mapping to Combined Measurement Model

### DIFF
--- a/stonesoup/models/measurement/nonlinear.py
+++ b/stonesoup/models/measurement/nonlinear.py
@@ -31,7 +31,6 @@ class CombinedReversibleGaussianMeasurementModel(ReversibleModel, GaussianModel,
     :exc:`NotImplementedError` if any model isn't either a
     :class:`~.LinearModel` or :class:`~.ReversibleModel`.
     """
-    mapping = None
     model_list: Sequence[GaussianModel] = Property(doc="List of Measurement Models.")
 
     def __init__(self, *args, **kwargs):
@@ -49,6 +48,10 @@ class CombinedReversibleGaussianMeasurementModel(ReversibleModel, GaussianModel,
     @property
     def ndim_meas(self) -> int:
         return sum(model.ndim_meas for model in self.model_list)
+
+    @property
+    def mapping(self):
+        return [x for model in self.model_list for x in model.mapping]
 
     def function(self, state, **kwargs) -> StateVector:
         return np.vstack([model.function(state, **kwargs)

--- a/stonesoup/models/measurement/tests/test_combined.py
+++ b/stonesoup/models/measurement/tests/test_combined.py
@@ -36,6 +36,8 @@ def test_non_linear(model):
     assert np.array_equal(meas_vector,
                           np.array([[np.pi/2], [10], [-np.pi/2], [10]]))
 
+    assert model.mapping == [0, 1, 3, 4]
+
 
 def test_jacobian(model):
     state = State(StateVector([[10.0], [10.0], [0.0], [10.0], [0.0]]))


### PR DESCRIPTION
This is required to ensure that when using measurement based initiators, that the mapping is applied properly.