### PR TITLE
Speed up track to truth associator by avoiding searching of all times

### DIFF
--- a/stonesoup/dataassociator/tracktotrack.py
+++ b/stonesoup/dataassociator/tracktotrack.py
@@ -202,16 +202,24 @@ class TrackToTruth(TrackToTrackAssociator):
             start_timestamp = None
             end_timestamp = None
 
+            truth_state_iters = {truth: iter(truth) for truth in truth_set}
+            truth_states = {truth: next(truth_state_iter)
+                            for truth, truth_state_iter in truth_state_iters.items()}
+
             for track_state in track:
 
                 min_dist = None
                 min_truth = None
 
                 for truth in truth_set:
+                    if truth[0].timestamp > track_state.timestamp \
+                            or truth[-1].timestamp < track_state.timestamp:
+                        continue
 
-                    try:
-                        truth_state = truth[track_state.timestamp]
-                    except IndexError:
+                    while truth_states[truth].timestamp < track_state.timestamp:
+                        truth_states[truth] = next(truth_state_iters[truth])
+                    truth_state = truth_states[truth]
+                    if truth_state.timestamp != track_state.timestamp:
                         continue
 
                     distance = self.measure(track_state, truth_state)

--- a/stonesoup/dataassociator/tracktotrack.py
+++ b/stonesoup/dataassociator/tracktotrack.py
@@ -1,10 +1,13 @@
 # -*- coding: utf-8 -*-
 from operator import attrgetter
+from typing import Set
 
 from .base import TrackToTrackAssociator
 from ..base import Property
 from ..measures import Measure, Euclidean
 from ..types.association import AssociationSet, TimeRangeAssociation, Association
+from ..types.groundtruth import GroundTruthPath
+from ..types.track import Track
 from ..types.time import TimeRange
 
 
@@ -48,14 +51,14 @@ class TrackToTrack(TrackToTrackAssociator):
         default=Euclidean(),
         doc="Distance measure to use. Default :class:`~.measures.Euclidean()`")
 
-    def associate_tracks(self, tracks_set_1, tracks_set_2):
+    def associate_tracks(self, tracks_set_1: Set[Track], tracks_set_2: Set[Track]):
         """Associate two sets of tracks together.
 
         Parameters
         ----------
-        tracks_set_1 : list of :class:`~.Track` objects
+        tracks_set_1 : set of :class:`~.Track` objects
             Tracks to associate to track set 2
-        tracks_set_2 : list of :class:`~.Track` objects
+        tracks_set_2 : set of :class:`~.Track` objects
             Tracks to associate to track set 1
 
         Returns
@@ -132,9 +135,9 @@ class TrackToTrack(TrackToTrackAssociator):
 class TrackToTruth(TrackToTrackAssociator):
     """Track to truth associator
 
-    Compares two sets of :class:`~.tracks`, each formed of a sequence of
+    Compares two sets of :class:`~.Track`, each formed of a sequence of
     :class:`~.State` objects and returns an :class:`~.Association` object for
-    each time at which a the two :class:`~.State` within the :class:`~.tracks`
+    each time at which a the two :class:`~.State` within the :class:`~.Track`
     are assessed to be associated. Tracks are considered to be associated with
     the Truth if the true :class:`~.State` is the closest to the track and
     within the specified distance for a specified number of time steps.
@@ -171,7 +174,7 @@ class TrackToTruth(TrackToTrackAssociator):
         default=Euclidean(),
         doc="Distance measure to use. Default :class:`~.measures.Euclidean()`")
 
-    def associate_tracks(self, tracks_set, truth_set):
+    def associate_tracks(self, tracks_set: Set[Track], truth_set: Set[GroundTruthPath]):
         """Associate Tracks
 
         Method compares to sets of :class:`~.Track` objects and will determine
@@ -179,9 +182,9 @@ class TrackToTruth(TrackToTrackAssociator):
 
         Parameters
         ----------
-        tracks_set : list of :class:`~.Track` objects
+        tracks_set : set of :class:`~.Track` objects
             Tracks to associate to truth
-        truth_set : list of :class:`~.Track` objects
+        truth_set : set of :class:`~.GroundTruthPath` objects
             Truth to associate to tracks
 
         Returns
@@ -202,11 +205,12 @@ class TrackToTruth(TrackToTrackAssociator):
             start_timestamp = None
             end_timestamp = None
 
-            truth_state_iters = {truth: iter(truth) for truth in truth_set}
+            truth_state_iters = {truth: GroundTruthPath.last_timestamp_generator(truth)
+                                 for truth in truth_set}
             truth_states = {truth: next(truth_state_iter)
                             for truth, truth_state_iter in truth_state_iters.items()}
 
-            for track_state in track:
+            for track_state in Track.last_timestamp_generator(track):
 
                 min_dist = None
                 min_truth = None

--- a/stonesoup/types/state.py
+++ b/stonesoup/types/state.py
@@ -137,6 +137,28 @@ class StateMutableSequence(Type, abc.MutableSequence):
     def state(self):
         return self.states[-1]
 
+    def last_timestamp_generator(self):
+        """Generator yielding the last state for each timestamp
+
+        This provides a method of iterating over a sequence of states,
+        such that when multiple states for the same timestamp exist,
+        only the last state is yielded. This is particularly useful in
+        cases where you may have multiple :class:`~.Update` states for
+        a single timestamp e.g. multi-sensor tracking example.
+
+        Yields
+        ------
+        State
+            A state for each timestamp present in the sequence.
+        """
+        state_iter = iter(self)
+        current_state = next(state_iter)
+        for next_state in state_iter:
+            if next_state.timestamp > current_state.timestamp:
+                yield current_state
+            current_state = next_state
+        yield current_state
+
 
 class GaussianState(State):
     """Gaussian State type

--- a/stonesoup/types/tests/test_state.py
+++ b/stonesoup/types/tests/test_state.py
@@ -255,6 +255,18 @@ def test_state_mutable_sequence_slice():
 
     assert sequence[timestamp] == sequence.states[0]
 
+    end_timestamp = sequence.timestamp
+    assert sequence[end_timestamp] == sequence.states[-1]
+    assert sequence[end_timestamp].state_vector == StateVector([[0]])
+
+    # Add state at same time
+    sequence.append(State(state_vector + 1, timestamp=end_timestamp))
+    assert sequence[end_timestamp]
+    assert sequence[end_timestamp].state_vector == StateVector([[1]])
+
+    assert len(sequence) == 11
+    assert len(list(sequence.last_timestamp_generator())) == 10
+
     with pytest.raises(TypeError):
         sequence[timestamp:1]
 


### PR DESCRIPTION
This speeds up track to truth association by:
 - avoiding looking at truths which start/end are after/before the
   current timestep
 - and maintaining an iterator for each truth to pick up from the
   last timestep and search forward for a matching timestamp.