### PR TITLE
Fixing timestamps for the video reader

### DIFF
--- a/stonesoup/reader/video.py
+++ b/stonesoup/reader/video.py
@@ -111,6 +111,9 @@ class VideoClipReader(FileReader, FrameReader):
     end_time: datetime.timedelta = Property(
         doc="End time expressed as duration from the start of the clip",
         default=None)
+    timestamp: datetime.datetime = Property(
+        doc="Timestamp given to the first frame",
+        default=None)
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -120,7 +123,9 @@ class VideoClipReader(FileReader, FrameReader):
 
     @BufferedGenerator.generator_method
     def frames_gen(self):
-        start_time = datetime.datetime.now()
+        if self.timestamp is None:
+            self.timestamp = datetime.datetime.now()
+        start_time = self.timestamp
         for timestamp_sec, pixels in self.clip.iter_frames(with_times=True):
             timestamp = start_time + datetime.timedelta(seconds=timestamp_sec)
             frame = ImageFrame(pixels, timestamp)


### PR DESCRIPTION
Video reader now has a timestamp attribute which is a DateTime object specifying the time of the first frame of the video. If it is None, then when the frame generator is called, it will be set to the current datetime. This prevents the timestamps of detections in the same detector object being changed by repeated calling of the iterator.