### PR TITLE
Fix UAV demonstration sensor parameters

### DIFF
--- a/docs/demos/UAV_tutorial.py
+++ b/docs/demos/UAV_tutorial.py
@@ -110,13 +110,13 @@ from stonesoup.simulator.platform import PlatformDetectionSimulator
 from stonesoup.types.state import State
 
 sensor = RadarElevationBearingRange(
-    [0, 2, 4],
-    meas_covar,
-    6,
+    position_mapping=[0, 2, 4],
+    noise_covar=meas_covar,
+    ndim_state=6,
 )
 platform = FixedPlatform(
     State([0, 0, 0, 0, 0, 0]),  # Sensor at reference point, zero velocity
-    [0, 2, 4],
+    position_mapping=[0, 2, 4],
     sensors=[sensor]
 )
 


### PR DESCRIPTION
Added keywords, as argument order changed in #427, causing this to add number of dimensions to rotation offset.