### PR TITLE
Fix missing thumbnails in sphinx gallery examples

### DIFF
--- a/docs/examples/Smooth_Platform_Coordinate_Transitions.py
+++ b/docs/examples/Smooth_Platform_Coordinate_Transitions.py
@@ -188,6 +188,9 @@ platform = MultiTransitionMovingPlatform(states=platform_state,
 
 
 # %%
+
+# sphinx_gallery_thumbnail_number = 4
+
 platform_coords = []
 sim_rate = 100  # 'sim_rate'-seconds each time-step.
 for i in range(int((times[-1] - times[0]).total_seconds()/sim_rate)):
@@ -200,5 +203,3 @@ ax.plot([coord[0] for coord in platform_coords],
         color='blue',
         linewidth=3)
 fig
-
-# sphinx_gallery_thumbnail_number = 4

--- a/docs/tutorials/01_KalmanFilterTutorial.py
+++ b/docs/tutorials/01_KalmanFilterTutorial.py
@@ -342,10 +342,10 @@ for measurement in measurements:
 # %%
 # Plot the resulting track, including uncertainty ellipses
 
+
 plotter.plot_tracks(track, [0, 2], uncertainty=True)
 plotter.fig
 
-# sphinx_gallery_thumbnail_number = 3
 
 # %%
 # Key points
@@ -368,3 +368,5 @@ plotter.fig
 #        (https://pdfs.semanticscholar.org/bb55/c1c619c30f939fc792b049172926a4a0c0f7.pdf?_ga=2.51363242.2056055521.1592932441-1812916183.1592932441)
 # .. [#] Anderson & Moore 1979, Optimal filtering,
 #        (http://users.cecs.anu.edu.au/~john/papers/BOOK/B02.PDF)
+
+# sphinx_gallery_thumbnail_number = 3

--- a/docs/tutorials/02_ExtendedKalmanFilterTutorial.py
+++ b/docs/tutorials/02_ExtendedKalmanFilterTutorial.py
@@ -192,8 +192,6 @@ for measurement in measurements:
 plotter.plot_tracks(track, [0, 2], uncertainty=True)
 plotter.fig
 
-# sphinx_gallery_thumbnail_number = 3
-
 # %%
 # Key points
 # ----------
@@ -217,3 +215,5 @@ plotter.fig
 # ----------
 # .. [#] Anderson & Moore 2012, Optimal filtering,
 #        (http://users.cecs.anu.edu.au/~john/papers/BOOK/B02.PDF)
+
+# sphinx_gallery_thumbnail_number = 3

--- a/docs/tutorials/03_UnscentedKalmanFilterTutorial.py
+++ b/docs/tutorials/03_UnscentedKalmanFilterTutorial.py
@@ -297,8 +297,6 @@ color_list = ['r', 'g']
 plotter.ellipse_legend(ax, label_list, color_list)
 fig
 
-# sphinx_gallery_thumbnail_number = 5
-
 # %%
 # You may have to spend some time fiddling with the parameters to see major differences between the
 # EKF and UKF. Indeed the point to make is not that there is any great magic about the UKF. Its
@@ -320,3 +318,5 @@ fig
 # .. [#] Julier S.J. 2002, The scaled unscented transformation, Proceedings of the 2002 American
 #        Control Conference (IEEE Cat. No.CH37301), Anchorage, AK, USA, 2002, pp. 4555-4559 vol.6,
 #        doi: 10.1109/ACC.2002.1025369.
+
+# sphinx_gallery_thumbnail_number = 5

--- a/docs/tutorials/04_ParticleFilter.py
+++ b/docs/tutorials/04_ParticleFilter.py
@@ -200,8 +200,6 @@ for measurement in measurements:
 plotter.plot_tracks(track, [0, 2], particle=True)
 plotter.fig
 
-# sphinx_gallery_thumbnail_number = 3
-
 # %%
 # Key points
 # ----------
@@ -220,3 +218,5 @@ plotter.fig
 #
 # .. [#] Carpenter J., Clifford P., Fearnhead P. 1999, An improved particle filter for non-linear
 #        problems, IEE Proc., Radar Sonar Navigation, 146:2–7
+
+# sphinx_gallery_thumbnail_number = 3

--- a/docs/tutorials/05_DataAssociation-Clutter.py
+++ b/docs/tutorials/05_DataAssociation-Clutter.py
@@ -225,10 +225,10 @@ for n, measurements in enumerate(all_measurements):
 plotter.plot_tracks(track, [0, 2], uncertainty=True)
 plotter.fig
 
-# sphinx_gallery_thumbnail_number = 2
-
 # %%
 # If you experiment with the clutter and detection parameters, you'll notice that there are often
 # instances where the estimate drifts away from the ground truth path. This is known as *track
 # seduction*, and is a common feature of 'greedy' methods of association such as the nearest
 # neighbour algorithm.
+
+# sphinx_gallery_thumbnail_number = 2

--- a/docs/tutorials/06_DataAssociation-MultiTargetTutorial.py
+++ b/docs/tutorials/06_DataAssociation-MultiTargetTutorial.py
@@ -198,7 +198,8 @@ for n, measurements in enumerate(all_measurements):
 # %%
 # Plot the resulting tracks
 
+# sphinx_gallery_thumbnail_number = 3
+
 plotter.plot_tracks(tracks, [0, 2], uncertainty=True)
 plotter.fig
 
-# sphinx_gallery_thumbnail_number = 3

--- a/docs/tutorials/07_PDATutorial.py
+++ b/docs/tutorials/07_PDATutorial.py
@@ -203,10 +203,10 @@ for n, measurements in enumerate(all_measurements):
 plotter.plot_tracks(track, [0, 2], uncertainty=True)
 plotter.fig
 
-# sphinx_gallery_thumbnail_number = 2
-
 # %%
 # References
 # ----------
 # 1. Bar-Shalom Y, Daum F, Huang F 2009, The Probabilistic Data Association Filter, IEEE Control
 # Systems Magazine
+
+# sphinx_gallery_thumbnail_number = 2

--- a/docs/tutorials/08_JPDATutorial.py
+++ b/docs/tutorials/08_JPDATutorial.py
@@ -191,10 +191,10 @@ for n, measurements in enumerate(all_measurements):
 plotter.plot_tracks(tracks, [0, 2], uncertainty=True)
 plotter.fig
 
-# sphinx_gallery_thumbnail_number = 2
-
 # %%
 # References
 # ----------
 # 1. Bar-Shalom Y, Daum F, Huang F 2009, The Probabilistic Data Association Filter, IEEE Control
 # Systems Magazine
+
+# sphinx_gallery_thumbnail_number = 2

--- a/docs/tutorials/09_Initiators_&_Deleters.py
+++ b/docs/tutorials/09_Initiators_&_Deleters.py
@@ -202,7 +202,7 @@ for n, measurements in enumerate(all_measurements):
 # %%
 # Plot the resulting tracks.
 
+# sphinx_gallery_thumbnail_number = 3
+
 plotter.plot_tracks(tracks, [0, 2], uncertainty=True)
 plotter.fig
-
-# sphinx_gallery_thumbnail_number = 3


### PR DESCRIPTION
Issue seems related to specifying the thumbnail number as comment after `fig` lines. Moved to specifying the thumbnail number to last cell (but above any code)

Issue can be seen on recent builds on Read The Docs.