### PR TITLE
User random seeds

### DIFF
--- a/docs/examples/Metrics.py
+++ b/docs/examples/Metrics.py
@@ -35,8 +35,9 @@ from stonesoup.updater.kalman import KalmanUpdater
 
 # Models
 transition_model = CombinedLinearGaussianTransitionModel(
-    [ConstantVelocity(1), ConstantVelocity(1)])
-measurement_model = LinearGaussian(4, [0, 2], np.diag([0.5, 0.5]))
+    [ConstantVelocity(1), ConstantVelocity(1)], seed=1)
+
+measurement_model = LinearGaussian(4, [0, 2], np.diag([0.5, 0.5]), seed=2)
 
 # Simulators
 groundtruth_sim = MultiTargetGroundTruthSimulator(
@@ -47,7 +48,8 @@ groundtruth_sim = MultiTargetGroundTruthSimulator(
     timestep=datetime.timedelta(seconds=5),
     number_steps=100,
     birth_rate=0.2,
-    death_probability=0.05
+    death_probability=0.05,
+    seed=3
 )
 detection_sim = SimpleDetectionSimulator(
     groundtruth=groundtruth_sim,
@@ -55,6 +57,7 @@ detection_sim = SimpleDetectionSimulator(
     meas_range=np.array([[-1, 1], [-1, 1]]) * 5000,  # Area to generate clutter
     detection_probability=0.9,
     clutter_rate=1,
+    seed=4
 )
 
 # Filter

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(name='stonesoup',
       setup_requires=['setuptools_scm', 'setuptools_scm_git_archive'],
       use_scm_version=True,
       install_requires=[
-          'ruamel.yaml>=0.15.45', 'numpy>=1.17', 'scipy', 'matplotlib', 'utm', 'pymap3d',
+          'ruamel.yaml>=0.15.45', 'numpy>=1.17', 'scipy', 'matplotlib', 'utm', 'pymap3d', 'ordered-set',
           'setuptools>=42',
       ],
       extras_require={

--- a/stonesoup/models/measurement/tests/test_lg.py
+++ b/stonesoup/models/measurement/tests/test_lg.py
@@ -90,3 +90,17 @@ def test_lgmodel(H, R, ndim_state, mapping):
         meas_pred_w_enoise.T,
         mean=np.array(H@state_vec).ravel(),
         cov=R)
+
+    # Test random seed give consistent results
+    lg1 = LinearGaussian(ndim_state=ndim_state,
+                         noise_covar=R,
+                         mapping=mapping,
+                         seed=1)
+    lg2 = LinearGaussian(ndim_state=ndim_state,
+                         noise_covar=R,
+                         mapping=mapping,
+                         seed=1)
+
+    # Check first values produced by seed match
+    for _ in range(3):
+        assert all(lg1.rvs() == lg2.rvs())

--- a/stonesoup/simulator/simple.py
+++ b/stonesoup/simulator/simple.py
@@ -62,15 +62,18 @@ class SwitchOneTargetGroundTruthSimulator(SingleTargetGroundTruthSimulator):
     The element in the ith row and the jth column is the probability of\
      switching from the ith transition model in :attr:`transition_models`\
      to the jth")
+    seed: Optional[int] = Property(default=None, doc="Seed for random number generation."
+                                                     " Default None")
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.index = 0
+        self.random_state = np.random.RandomState(self.seed)
 
     @property
     def transition_model(self):
-        self.index = np.random.choice(range(0, len(self.transition_models)),
-                                      p=self.model_probs[self.index])
+        self.index = self.random_state.choice(range(0, len(self.transition_models)),
+                                              p=self.model_probs[self.index])
         return self.transition_models[self.index]
 
 
@@ -87,7 +90,8 @@ class MultiTargetGroundTruthSimulator(SingleTargetGroundTruthSimulator):
                          "Poisson distribution. Default 1.0.")
     death_probability: Probability = Property(
         default=0.1, doc="Probability of track dying in each time step. Default 0.1.")
-    seed: Optional[int] = Property(default=None, doc="Seed for random number generation. Default None")
+    seed: Optional[int] = Property(default=None, doc="Seed for random number generation."
+                                                     " Default None")
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -167,7 +171,8 @@ class SimpleDetectionSimulator(DetectionSimulator):
     meas_range: np.ndarray = Property()
     detection_probability: Probability = Property(default=0.9)
     clutter_rate: float = Property(default=2.0)
-    seed: Optional[int] = Property(default=None, doc="Seed for random number generation. Default None")
+    seed: Optional[int] = Property(default=None, doc="Seed for random number generation."
+                                                     " Default None")
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/stonesoup/simulator/simple.py
+++ b/stonesoup/simulator/simple.py
@@ -4,6 +4,7 @@ import datetime
 from typing import Sequence
 
 import numpy as np
+from ordered_set import OrderedSet
 
 from ..base import Property
 from ..models.measurement import MeasurementModel
@@ -94,7 +95,7 @@ class MultiTargetGroundTruthSimulator(SingleTargetGroundTruthSimulator):
 
     @BufferedGenerator.generator_method
     def groundtruth_paths_gen(self, random_state=None):
-        groundtruth_paths = set()
+        groundtruth_paths = OrderedSet()
         time = self.initial_state.timestamp or datetime.datetime.now()
         random_state = random_state if random_state is not None else self.random_state
 

--- a/stonesoup/simulator/simple.py
+++ b/stonesoup/simulator/simple.py
@@ -144,15 +144,19 @@ class SwitchMultiTargetGroundTruthSimulator(MultiTargetGroundTruthSimulator):
         The element in the ith row and the jth column is the probability of\
          switching from the ith transition model in :attr:`transition_models`\
          to the jth")
+    seed: Optional[int] = Property(default=None, doc="Seed for random number generation."
+                                                     " Default None")
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.index = 0
+        self.random_state = np.random.RandomState(self.seed)
 
     @property
-    def transition_model(self):
-        self.index = np.random.choice(range(0, len(self.transition_models)),
-                                      p=self.model_probs[self.index])
+    def transition_model(self, random_state=None):
+        random_state = random_state if random_state is not None else self.random_state
+        self.index = random_state.choice(range(0, len(self.transition_models)),
+                                         p=self.model_probs[self.index])
         return self.transition_models[self.index]
 
 

--- a/stonesoup/simulator/tests/test_detections.py
+++ b/stonesoup/simulator/tests/test_detections.py
@@ -45,6 +45,18 @@ def test_simple_detection_simulator(
 
     assert simulate_detections.clutter_spatial_density == 3e-8
 
+    # Check random seed gives consistent results
+    simulate_detections1 = SimpleDetectionSimulator(
+        groundtruth, measurement_model, meas_range, clutter_rate=3, seed=1)
+    simulate_detections2 = SimpleDetectionSimulator(
+        groundtruth, measurement_model, meas_range, clutter_rate=3, seed=1)
+
+    for (_, detections1), (_, detections2) in zip(simulate_detections1, simulate_detections2):
+        state_vectors1 = tuple(tuple(det.state_vector) for det in detections1)
+        state_vectors2 = tuple(tuple(det.state_vector) for det in detections2)
+        for sv in state_vectors1:
+            assert sv in state_vectors2
+
 
 def test_switch_detection_simulator(
         transition_model1, transition_model2, measurement_model, timestep):

--- a/stonesoup/simulator/tests/test_groundtruth.py
+++ b/stonesoup/simulator/tests/test_groundtruth.py
@@ -67,6 +67,20 @@ def test_multitarget_ground_truth_simulator(transition_model1, timestep):
     # Check that ground truth paths vary in length
     assert len({len(path) for path in total_paths}) > 1
 
+    # Check random seed gives consistent results
+    simulator1 = MultiTargetGroundTruthSimulator(transition_model1,
+                                                 initial_state, timestep,
+                                                 seed=1)
+    simulator2 = MultiTargetGroundTruthSimulator(transition_model1,
+                                                 initial_state, timestep,
+                                                 seed=1)
+
+    for (_, truth1), (_, truth2) in zip(simulator1, simulator2):
+        state_vectors1 = tuple(tuple(gt.state_vector) for gt in truth1)
+        state_vectors2 = tuple(tuple(gt.state_vector) for gt in truth2)
+        for sv in state_vectors1:
+            assert sv in state_vectors2
+
 
 def test_one_target_ground_truth_simulator_switch(transition_model1,
                                                   transition_model2,

--- a/stonesoup/simulator/tests/test_groundtruth.py
+++ b/stonesoup/simulator/tests/test_groundtruth.py
@@ -103,6 +103,26 @@ def test_one_target_ground_truth_simulator_switch(transition_model1,
     # Check that the number of steps is equal to the simulation steps
     assert step + 1 == simulator.number_steps
 
+    # Check random seed gives consistent results
+    groundtruth1 = SwitchOneTargetGroundTruthSimulator(
+        transition_models=[transition_model1, transition_model2],
+        model_probs=model_probs,
+        initial_state=initial_state,
+        timestep=timestep,
+        seed=1)
+    groundtruth2 = SwitchOneTargetGroundTruthSimulator(
+        transition_models=[transition_model1, transition_model2],
+        model_probs=model_probs,
+        initial_state=initial_state,
+        timestep=timestep,
+        seed=1)
+
+    for (_, truth1), (_, truth2) in zip(groundtruth1, groundtruth2):
+        state_vectors1 = tuple(tuple(gt.state_vector) for gt in truth1)
+        state_vectors2 = tuple(tuple(gt.state_vector) for gt in truth2)
+        for sv in state_vectors1:
+            assert sv in state_vectors2
+
 
 def test_multitarget_ground_truth_simulator_witch(transition_model1,
                                                   transition_model2,

--- a/stonesoup/simulator/tests/test_groundtruth.py
+++ b/stonesoup/simulator/tests/test_groundtruth.py
@@ -104,20 +104,20 @@ def test_one_target_ground_truth_simulator_switch(transition_model1,
     assert step + 1 == simulator.number_steps
 
     # Check random seed gives consistent results
-    groundtruth1 = SwitchOneTargetGroundTruthSimulator(
+    simulator1 = SwitchOneTargetGroundTruthSimulator(
         transition_models=[transition_model1, transition_model2],
         model_probs=model_probs,
         initial_state=initial_state,
         timestep=timestep,
         seed=1)
-    groundtruth2 = SwitchOneTargetGroundTruthSimulator(
+    simulator2 = SwitchOneTargetGroundTruthSimulator(
         transition_models=[transition_model1, transition_model2],
         model_probs=model_probs,
         initial_state=initial_state,
         timestep=timestep,
         seed=1)
 
-    for (_, truth1), (_, truth2) in zip(groundtruth1, groundtruth2):
+    for (_, truth1), (_, truth2) in zip(simulator1, simulator2):
         state_vectors1 = tuple(tuple(gt.state_vector) for gt in truth1)
         state_vectors2 = tuple(tuple(gt.state_vector) for gt in truth2)
         for sv in state_vectors1:
@@ -161,3 +161,23 @@ def test_multitarget_ground_truth_simulator_witch(transition_model1,
             indices.append(state.metadata.get("index"))
         if len(path) > 9:
             assert indices.count(1) < len(path)
+
+    # Check random seed gives consistent results
+    simulator1 = SwitchMultiTargetGroundTruthSimulator(
+        transition_models=[transition_model1, transition_model2],
+        model_probs=model_probs,
+        initial_state=initial_state,
+        timestep=timestep,
+        seed=1)
+    simulator2 = SwitchMultiTargetGroundTruthSimulator(
+        transition_models=[transition_model1, transition_model2],
+        model_probs=model_probs,
+        initial_state=initial_state,
+        timestep=timestep,
+        seed=1)
+
+    for (_, truth1), (_, truth2) in zip(simulator1, simulator2):
+        state_vectors1 = tuple(tuple(gt.state_vector) for gt in truth1)
+        state_vectors2 = tuple(tuple(gt.state_vector) for gt in truth2)
+        for sv in state_vectors1:
+            assert sv in state_vectors2


### PR DESCRIPTION
Addresses the issue raised here
https://github.com/dstl/Stone-Soup/issues/396

Now all models that use random number generation have an optional seed that allows the user to, for example, always produce the same randomly generated truth data but allow other components to change between runs. 

Also needed to change the groundtruth paths to be an ordered set rather than a set in the groundtruth paths generator, otherwise the order that items were iterated through in the set would cause different results between runs. 

I added the seeds to the metrics example as well, as this was my test case and it makes sense that it should produce consistent results.

It would be useful if reviewers could make sure I haven't missed any models. I'd also appreciate a second opinion on the tests I wrote to check they don't miss anything important. 