### PR TITLE
Multimap measures

### DIFF
--- a/stonesoup/measures.py
+++ b/stonesoup/measures.py
@@ -18,6 +18,21 @@ class Measure(Base):
         doc="Mapping array which specifies which elements within the"
             " state vectors are to be assessed as part of the measure"
     )
+    mapping2: np.ndarray = Property(
+        default=None,
+        doc="A second mapping for when the states being compared exist "
+            "in different parameter spaces. Defaults to the same as the"
+            " first mapping"
+    )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if self.mapping2 is not None and self.mapping is None:
+            raise ValueError("Cannot set mapping2 if mapping is None. "
+                             "If this is really what you meant to do, then"
+                             " set mapping to include all dimensions.")
+        if self.mapping2 is None and self.mapping is not None:
+            self.mapping2 = self.mapping
 
     @abstractmethod
     def __call__(self, state1, state2):
@@ -68,7 +83,7 @@ class Euclidean(Measure):
         # Calculate Euclidean distance between two state
         if self.mapping is not None:
             return distance.euclidean(state1.state_vector[self.mapping, :],
-                                      state2.state_vector[self.mapping, :])
+                                      state2.state_vector[self.mapping2, :])
         else:
             return distance.euclidean(state1.state_vector, state2.state_vector)
 
@@ -113,7 +128,7 @@ class EuclideanWeighted(Measure):
         """
         if self.mapping is not None:
             return distance.euclidean(state1.state_vector[self.mapping, :],
-                                      state2.state_vector[self.mapping, :],
+                                      state2.state_vector[self.mapping2, :],
                                       self.weighting)
         else:
             return distance.euclidean(state1.state_vector,
@@ -153,7 +168,7 @@ class Mahalanobis(Measure):
         """
         if self.mapping is not None:
             u = state1.state_vector[self.mapping, :]
-            v = state2.state_vector[self.mapping, :]
+            v = state2.state_vector[self.mapping2, :]
             # extract the mapped covariance data
             rows = np.array(self.mapping, dtype=np.intp)
             columns = np.array(self.mapping, dtype=np.intp)
@@ -212,7 +227,7 @@ class SquaredGaussianHellinger(Measure):
         """
         if self.mapping is not None:
             mu1 = state1.state_vector[self.mapping, :]
-            mu2 = state2.state_vector[self.mapping, :]
+            mu2 = state2.state_vector[self.mapping2, :]
 
             # extract the mapped covariance data
             rows = np.array(self.mapping, dtype=np.intp)

--- a/stonesoup/metricgenerator/tests/test_tracktotruthmetrics.py
+++ b/stonesoup/metricgenerator/tests/test_tracktotruthmetrics.py
@@ -33,6 +33,24 @@ def metric_generators_2_maps():
                         track_id='ident')]
 
 
+def test_SIAP_raise_error():
+    with pytest.raises(ValueError) as excinfo:
+        SIAPMetrics(velocity_mapping=[1, 3],
+                    position_mapping2=[0, 1],
+                    velocity_mapping2=[2, 3],
+                    truth_id='identify',
+                    track_id='ident')
+    assert "Cannot set position_mapping2 if position_mapping is None." in str(excinfo.value)
+
+    with pytest.raises(ValueError) as excinfo:
+        SIAPMetrics(position_mapping=[0, 2],
+                    position_mapping2=[0, 1],
+                    velocity_mapping2=[2, 3],
+                    truth_id='identify',
+                    track_id='ident')
+    assert "Cannot set velocity_mapping2 if velocity_mapping is None." in str(excinfo.value)
+
+
 @pytest.mark.parametrize("generator", metric_generators(), ids=["SIAP"])
 def test_num_tracks_tracks(generator):
     manager = SimpleManager()

--- a/stonesoup/metricgenerator/tests/test_tracktotruthmetrics.py
+++ b/stonesoup/metricgenerator/tests/test_tracktotruthmetrics.py
@@ -23,6 +23,16 @@ def metric_generators():
                         track_id='ident')]
 
 
+def metric_generators_2_maps():
+    """A list of metric generators to be used in tests"""
+    return [SIAPMetrics(position_mapping=[0, 2],
+                        velocity_mapping=[1, 3],
+                        position_mapping2=[0, 1],
+                        velocity_mapping2=[2, 3],
+                        truth_id='identify',
+                        track_id='ident')]
+
+
 @pytest.mark.parametrize("generator", metric_generators(), ids=["SIAP"])
 def test_num_tracks_tracks(generator):
     manager = SimpleManager()
@@ -123,6 +133,65 @@ def test_assoc_distances_sum_t(generator, mapping):
                                                         tstart + datetime.timedelta(seconds=i),
                                                         getattr(generator, mapping),
                                                         1)
+        assert distance_sum == 2
+
+
+@pytest.mark.parametrize("generator", metric_generators_2_maps(), ids=["SIAP"])
+@pytest.mark.parametrize("mapping, mapping2", [('position_mapping', 'position_mapping2'),
+                                               ('velocity_mapping', 'velocity_mapping2')]
+                         )
+def test_assoc_distances_sum_t_2maps(generator, mapping, mapping2):
+    manager = SimpleManager()
+    tstart = datetime.datetime.now()
+    truth = GroundTruthPath(
+        states=[GroundTruthState([[i], [0], [i], [0]],
+                                 timestamp=tstart + datetime.timedelta(seconds=i))
+                for i in range(5)]
+    )
+    track1 = Track(
+        states=[State([[i], [i], [1], [1]], timestamp=tstart + datetime.timedelta(seconds=i))
+                for i in range(5)]
+    )
+    track2 = Track(
+        states=[State([[i], [i], [-1], [-1]], timestamp=tstart + datetime.timedelta(seconds=i))
+                for i in range(5)]
+    )
+    assoc1 = TimeRangeAssociation(
+        {truth, track1},
+        time_range=TimeRange(
+            start_timestamp=tstart,
+            end_timestamp=tstart + datetime.timedelta(seconds=5))
+    )
+
+    assoc2 = TimeRangeAssociation(
+        {truth, track2},
+        time_range=TimeRange(
+            start_timestamp=tstart,
+            end_timestamp=tstart + datetime.timedelta(seconds=5))
+    )
+    associations = {assoc1}
+
+    manager.groundtruth_paths = {truth}
+    manager.tracks = {track1, track2}
+    manager.association_set = AssociationSet(associations)
+
+    for i in range(5):
+        distance_sum = generator._assoc_distances_sum_t(manager,
+                                                        tstart + datetime.timedelta(seconds=i),
+                                                        getattr(generator, mapping),
+                                                        1,
+                                                        getattr(generator, mapping2))
+        assert distance_sum == 1
+
+    associations = {assoc1, assoc2}
+    manager.association_set = AssociationSet(associations)
+
+    for i in range(5):
+        distance_sum = generator._assoc_distances_sum_t(manager,
+                                                        tstart + datetime.timedelta(seconds=i),
+                                                        getattr(generator, mapping),
+                                                        1,
+                                                        getattr(generator, mapping2))
         assert distance_sum == 2
 
 
@@ -564,7 +633,8 @@ def test_variable_id(generator):
     assert generator._ja_sum(manager, manager.list_timestamps()) == 2
 
 
-@pytest.mark.parametrize("generator", metric_generators(), ids=["SIAP"])
+@pytest.mark.parametrize("generator", metric_generators() + metric_generators_2_maps(),
+                         ids=["SIAP", "SIAP2Map"])
 def test_compute_metric(generator):
     manager = SimpleManager()
     # Create truth, tracks and associations, same as test_nu_j
@@ -685,7 +755,8 @@ def test_compute_metric(generator):
            sum(generator._assoc_distances_sum_t(manager,
                                                 timestamp,
                                                 generator.position_mapping,
-                                                1)
+                                                1,
+                                                generator.position_mapping2)
                for timestamp in manager.list_timestamps()) \
            / generator._na_sum(manager, manager.list_timestamps())
     assert pa.time_range.start_timestamp == tstart
@@ -701,7 +772,8 @@ def test_compute_metric(generator):
         numerator = generator._assoc_distances_sum_t(manager,
                                                      timestamp,
                                                      generator.position_mapping,
-                                                     1)
+                                                     1,
+                                                     generator.position_mapping2)
         if generator._na_t(manager, timestamp) != 0:
             assert t_metric.value == numerator / generator._na_t(manager, timestamp)
         else:
@@ -717,7 +789,8 @@ def test_compute_metric(generator):
     numerator = sum(generator._assoc_distances_sum_t(manager,
                                                      timestamp,
                                                      generator.velocity_mapping,
-                                                     1)
+                                                     1,
+                                                     generator.velocity_mapping2)
                     for timestamp in manager.list_timestamps())
     assert va.value == numerator / generator._na_sum(manager, manager.list_timestamps())
     assert va.time_range.start_timestamp == tstart
@@ -733,7 +806,8 @@ def test_compute_metric(generator):
         numerator = generator._assoc_distances_sum_t(manager,
                                                      timestamp,
                                                      generator.velocity_mapping,
-                                                     1)
+                                                     1,
+                                                     generator.velocity_mapping2)
         if generator._na_t(manager, timestamp) != 0:
             assert t_metric.value == numerator / generator._na_t(manager, timestamp)
         else:

--- a/stonesoup/metricgenerator/tracktotruthmetrics.py
+++ b/stonesoup/metricgenerator/tracktotruthmetrics.py
@@ -10,6 +10,7 @@ from ..base import Property
 from ..measures import EuclideanWeighted
 from ..types.metric import SingleTimeMetric, TimeRangeMetric
 from ..types.time import TimeRange
+from ..types.track import Track
 
 
 class SIAPMetrics(MetricGenerator):
@@ -1019,6 +1020,9 @@ class SIAPMetrics(MetricGenerator):
         distance_sum = 0
         for assoc in manager.association_set.associations_at_timestamp(timestamp):
             track, truth = assoc.objects
+            # Sets aren't ordered, so need to ensure correct path is truth/track
+            if isinstance(truth, Track):
+                track, truth = truth, track
             distance_sum += measure(track[timestamp], truth[timestamp])
         return distance_sum
 

--- a/stonesoup/metricgenerator/tracktotruthmetrics.py
+++ b/stonesoup/metricgenerator/tracktotruthmetrics.py
@@ -60,11 +60,39 @@ class SIAPMetrics(MetricGenerator):
                                             doc="Mapping array which specifies which elements "
                                                 "within state space state vectors correspond to "
                                                 "velocity")
+    position_mapping2: np.ndarray = Property(default=None,
+                                             doc="Mapping array which specifies which elements "
+                                                 "within the ground truth state space state "
+                                                 "vectors correspond to position. Default is "
+                                                 "same as position_mapping")
+    velocity_mapping2: np.ndarray = Property(default=None,
+                                             doc="Mapping array which specifies which elements "
+                                                 "within the ground truth state space state "
+                                                 "vectors correspond to velocity. Default is "
+                                                 "same as velocity_mapping")
 
     truth_id: str = Property(default=None,
                              doc="Metadata key for ID of each ground truth path in dataset")
     track_id: str = Property(default=None,
                              doc="Metadata key for ID of each track in dataset")
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if self.position_mapping2 is not None and self.position_mapping is None:
+            raise ValueError("Cannot set position_mapping2 if position_mapping is None. "
+                             "If this is really what you meant to do, then"
+                             " set position_mapping to include all dimensions.")
+
+        if self.velocity_mapping2 is not None and self.velocity_mapping is None:
+            raise ValueError("Cannot set velocity_mapping2 if velocity_mapping is None. "
+                             "If this is really what you meant to do, then"
+                             " set velocity_mapping to include all dimensions.")
+
+        if self.position_mapping2 is None and self.position_mapping is not None:
+            self.position_mapping2 = self.position_mapping
+
+        if self.velocity_mapping2 is None and self.velocity_mapping is not None:
+            self.velocity_mapping2 = self.velocity_mapping
 
     def compute_metric(self, manager, *args, **kwargs):
         """Compute metric
@@ -524,7 +552,8 @@ class SIAPMetrics(MetricGenerator):
         numerator = self._assoc_distances_sum_t(manager,
                                                 timestamp,
                                                 self.position_mapping,
-                                                self.position_weighting)
+                                                self.position_weighting,
+                                                self.position_mapping2)
         try:
             PA = numerator / self._na_t(manager, timestamp)
         except ZeroDivisionError:
@@ -566,7 +595,8 @@ class SIAPMetrics(MetricGenerator):
         numerator = sum(self._assoc_distances_sum_t(manager,
                                                     timestamp,
                                                     self.position_mapping,
-                                                    self.position_weighting)
+                                                    self.position_weighting,
+                                                    self.position_mapping2)
                         for timestamp in timestamps)
         try:
             PA = numerator / self._na_sum(manager, timestamps)
@@ -612,7 +642,8 @@ class SIAPMetrics(MetricGenerator):
         numerator = self._assoc_distances_sum_t(manager,
                                                 timestamp,
                                                 self.velocity_mapping,
-                                                self.velocity_weighting)
+                                                self.velocity_weighting,
+                                                self.velocity_mapping2)
         try:
             VA = numerator / self._na_t(manager, timestamp)
         except ZeroDivisionError:
@@ -655,7 +686,8 @@ class SIAPMetrics(MetricGenerator):
         numerator = sum(self._assoc_distances_sum_t(manager,
                                                     timestamp,
                                                     self.velocity_mapping,
-                                                    self.velocity_weighting)
+                                                    self.velocity_weighting,
+                                                    self.velocity_mapping2)
                         for timestamp in timestamps)
         try:
             VA = numerator / self._na_sum(manager, timestamps)
@@ -961,7 +993,7 @@ class SIAPMetrics(MetricGenerator):
             time_range=TimeRange(min(timestamps), max(timestamps)),
             generator=self)
 
-    def _assoc_distances_sum_t(self, manager, timestamp, mapping, weighting):
+    def _assoc_distances_sum_t(self, manager, timestamp, mapping, weighting, mapping2=None):
         """Sum of spatial (positon or velocity) distance between each truth and its associations
         Parameters
         ----------
@@ -973,6 +1005,9 @@ class SIAPMetrics(MetricGenerator):
             Indices of the required positon/velocity components of the state space
         weighting: np.ndarray
             The weighting to be used by the Euclidean measure
+        mapping2: np.ndarray
+            Indices of the required positon/velocity components of the state space
+            when the two states require different mapping
 
         Returns
         -------
@@ -980,7 +1015,7 @@ class SIAPMetrics(MetricGenerator):
             Sum of Euclidean distances (of position or velocity) of each truth to its associated
             tracks in manager at timestamp
         """
-        measure = EuclideanWeighted(mapping=mapping, weighting=weighting)
+        measure = EuclideanWeighted(mapping=mapping, mapping2=mapping2, weighting=weighting)
         distance_sum = 0
         for assoc in manager.association_set.associations_at_timestamp(timestamp):
             track, truth = assoc.objects

--- a/stonesoup/tests/test_measures.py
+++ b/stonesoup/tests/test_measures.py
@@ -25,6 +25,12 @@ vi = CovarianceMatrix(np.diag([20., 3., 7., 10.]))
 state_v = GaussianState(v, vi, timestamp=t)
 
 
+def test_measure_raise_error():
+    with pytest.raises(ValueError) as excinfo:
+        measures.Euclidean(mapping2=[0, 3])
+    assert "Cannot set mapping2 if mapping is None." in str(excinfo.value)
+
+
 def test_euclidean():
 
     measure = measures.Euclidean()

--- a/stonesoup/tests/test_measures.py
+++ b/stonesoup/tests/test_measures.py
@@ -83,6 +83,8 @@ def test_hellinger_full_mapping(mapping_type):
     state_v = GaussianState(v, vi, timestamp=t)
     measure = measures.GaussianHellinger(mapping=mapping)
     assert np.isclose(measure(state_u, state_v), 0.940, atol=1e-3)
+    measure = measures.GaussianHellinger(mapping=mapping, mapping2=mapping)
+    assert np.isclose(measure(state_u, state_v), 0.940, atol=1e-3)
 
 
 def test_hellinger_partial_mapping(mapping_type):
@@ -95,10 +97,28 @@ def test_hellinger_partial_mapping(mapping_type):
     measure = measures.GaussianHellinger(mapping=mapping)
     assert np.isclose(measure(state_u, state_v), 0.386, atol=1e-3)
 
+    mapping = mapping_type([0, 1])
+    measure = measures.GaussianHellinger(mapping=mapping, mapping2=mapping)
+    assert np.isclose(measure(state_u, state_v), 0.913, atol=1e-3)
+    mapping = np.array([0, 3])
+    measure = measures.GaussianHellinger(mapping=mapping, mapping2=mapping)
+    assert np.isclose(measure(state_u, state_v), 0.386, atol=1e-3)
+
+    v = StateVector([[11.], [2.], [10.], [10.]])
+    state_v = GaussianState(v, vi, timestamp=t)
+    mapping = mapping_type([0, 1])
+    mapping2 = np.array([0, 3])
+    measure = measures.GaussianHellinger(mapping=mapping, mapping2=mapping2)
+    assert np.isclose(measure(state_u, state_v), 0.913, atol=1e-3)
+
 
 def test_mahalanobis_full_mapping(mapping_type):
     mapping = mapping_type(np.arange(len(u)))
     measure = measures.Mahalanobis(mapping=mapping)
+    assert measure(state_u, state_v) == distance.mahalanobis(u,
+                                                             v,
+                                                             np.linalg.inv(ui))
+    measure = measures.Mahalanobis(mapping=mapping, mapping2=mapping)
     assert measure(state_u, state_v) == distance.mahalanobis(u,
                                                              v,
                                                              np.linalg.inv(ui))
@@ -118,10 +138,30 @@ def test_mahalanobis_partial_mapping(mapping_type):
         distance.mahalanobis([[10], [1]],
                              [[11], [2]], np.linalg.inv(reduced_ui))
 
+    mapping = mapping_type([0, 1])
+    measure = measures.Mahalanobis(mapping=mapping, mapping2=mapping)
+    assert measure(state_u, state_v) == \
+        distance.mahalanobis([[10], [1]],
+                             [[11], [10]], np.linalg.inv(reduced_ui))
+    mapping = np.array([0, 3])
+    measure = measures.Mahalanobis(mapping=mapping, mapping2=mapping)
+    assert measure(state_u, state_v) == \
+        distance.mahalanobis([[10], [1]],
+                             [[11], [2]], np.linalg.inv(reduced_ui))
+
+    mapping = mapping_type([0, 1])
+    mapping2 = np.array([0, 3])
+    measure = measures.Mahalanobis(mapping=mapping, mapping2=mapping2)
+    assert measure(state_u, state_v) == \
+        distance.mahalanobis([[10], [1]],
+                             [[11], [2]], np.linalg.inv(reduced_ui))
+
 
 def test_euclidean_full_mapping(mapping_type):
     mapping = mapping_type(np.arange(len(u)))
     measure = measures.Euclidean(mapping=mapping)
+    assert measure(state_u, state_v) == distance.euclidean(u, v)
+    measure = measures.Euclidean(mapping=mapping, mapping2=mapping)
     assert measure(state_u, state_v) == distance.euclidean(u, v)
 
 
@@ -135,11 +175,28 @@ def test_euclidean_partial_mapping(mapping_type):
     assert measure(state_u, state_v) == \
         distance.euclidean([[10], [1]], [[11], [2]])
 
+    mapping = mapping_type([0, 1])
+    measure = measures.Euclidean(mapping=mapping, mapping2=mapping)
+    assert measure(state_u, state_v) == \
+        distance.euclidean([[10], [1]], [[11], [10]])
+    mapping = np.array([0, 3])
+    measure = measures.Euclidean(mapping=mapping, mapping2=mapping)
+    assert measure(state_u, state_v) == \
+        distance.euclidean([[10], [1]], [[11], [2]])
+
+    mapping = mapping_type([0, 1])
+    mapping2 = np.array([0, 3])
+    measure = measures.Euclidean(mapping=mapping, mapping2=mapping2)
+    assert measure(state_u, state_v) == \
+        distance.euclidean([[10], [1]], [[11], [2]])
+
 
 def test_euclideanweighted_full_mapping(mapping_type):
     mapping = mapping_type(np.arange(len(u)))
     weight = np.array([[1], [2], [3], [1]])
     measure = measures.EuclideanWeighted(weight, mapping=mapping)
+    assert measure(state_u, state_v) == distance.euclidean(u, v, weight)
+    measure = measures.EuclideanWeighted(weight, mapping=mapping, mapping2=mapping)
     assert measure(state_u, state_v) == distance.euclidean(u, v, weight)
 
 
@@ -151,5 +208,20 @@ def test_euclideanweighted_partial_mapping(mapping_type):
         distance.euclidean([[10], [1]], [[11], [10]], weight)
     mapping = np.array([0, 3])
     measure = measures.EuclideanWeighted(weight, mapping=mapping)
+    assert measure(state_u, state_v) == \
+        distance.euclidean([[10], [1]], [[11], [2]], weight)
+
+    mapping = mapping_type([0, 1])
+    measure = measures.EuclideanWeighted(weight, mapping=mapping, mapping2=mapping)
+    assert measure(state_u, state_v) == \
+        distance.euclidean([[10], [1]], [[11], [10]], weight)
+    mapping = np.array([0, 3])
+    measure = measures.EuclideanWeighted(weight, mapping=mapping, mapping2=mapping)
+    assert measure(state_u, state_v) == \
+        distance.euclidean([[10], [1]], [[11], [2]], weight)
+
+    mapping = np.array([0, 1])
+    mapping2 = np.array([0, 3])
+    measure = measures.EuclideanWeighted(weight, mapping=mapping, mapping2=mapping2)
     assert measure(state_u, state_v) == \
         distance.euclidean([[10], [1]], [[11], [2]], weight)


### PR DESCRIPTION
Added the option to apply different maps to the groundtruth data and the state space in all the different measures. Also made changes to SIAPs metric generator to be able to use the new maps. 

If second map is not set, then it defaults to the same as the first map. This means all existing code still works. 

If you try to set the second map but not the first then it will raise an error. This is possibly something someone might want to do (i.e. not apply a map to the first space but apply a map to the groundtruth) so the error explains that this can be done by making the first map a list of all dimensions. The alternative would be to not make the second mapping default to the same as the first, which would make these changes not backwards compatible.  