### PR TITLE
Fixed an error in the angle calculations in smooth transition model maker

### DIFF
--- a/stonesoup/simulator/transition.py
+++ b/stonesoup/simulator/transition.py
@@ -105,10 +105,10 @@ def create_smooth_transition_models(initial_state, x_coords, y_coords, times, tu
         alpha = np.arctan2(p, q)
         beta = np.arccos(r / np.sqrt(p**2 + q**2))
 
-        angle = (alpha + beta) % (2*np.pi) - 2*np.pi  # actual angle turned
+        angle = (alpha + beta + np.pi) % (2*np.pi) - np.pi  # actual angle turned
 
         if w > 0:
-            angle = (alpha - beta + 2*np.pi) % (2*np.pi)  # quadrant adjustment
+            angle = (alpha - beta + np.pi) % (2*np.pi) - np.pi  # quadrant adjustment
 
         t1 = angle / w  # turn time
 


### PR DESCRIPTION
It doesn't seem to make any difference to current use cases (though I really don't know why, it seems like it should) but it was causing me some problems while implementing a new feature