### PR TITLE
Fix deterministic use of random seed

### DIFF
--- a/stonesoup/models/base.py
+++ b/stonesoup/models/base.py
@@ -196,7 +196,7 @@ class GaussianModel(Model):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.random_state = np.random.RandomState(self.seed)
+        self.random_state = np.random.RandomState(self.seed) if self.seed is not None else None
 
     def rvs(self, num_samples: int = 1, random_state=None, **kwargs) ->\
             Union[StateVector, StateVectors]:


### PR DESCRIPTION
Deterministic use of random seeds was originally implemented in #444 in response to #396. However, when a model was not explicitly passed a random seed it would use a random value, which meant the run was not deterministic overall. This fixes that, using the change originally suggested in #396.

CC: @idorrington-dstl @sdhiscocks 