### PR TITLE
Added equal operator in Base

### DIFF
--- a/stonesoup/base.py
+++ b/stonesoup/base.py
@@ -341,3 +341,6 @@ class Base(metaclass=BaseMeta):
         params = ("{}={!r}".format(name, getattr(self, name))
                   for name in type(self).properties)
         return "{}({})".format(type(self).__name__, ", ".join(params))
+
+    def __eq__(self, other):
+        return self._properties.items() == other._properties.items()


### PR DESCRIPTION
If a Stone-Soup object is only defined by it's properties then this should be a way of comparing two objects? 

I haven't tested this yet, but wanted some thoughts before I continued