### PR TITLE
Add jacobian() to Linear model and add kwarg handling to jacobian().

### DIFF
--- a/stonesoup/functions/__init__.py
+++ b/stonesoup/functions/__init__.py
@@ -70,7 +70,7 @@ def cholesky_eps(A, lower=False):
         return L.T
 
 
-def jacobian(fun, x):
+def jacobian(fun, x,  **kwargs):
     """Compute Jacobian through finite difference calculation
 
     Parameters
@@ -101,7 +101,7 @@ def jacobian(fun, x):
     x2.state_vector = np.tile(x.state_vector, ndim+1) + np.eye(ndim, ndim+1)*delta[:, np.newaxis]
     x2.state_vector = x2.state_vector.view(StateVectors)
 
-    F = fun(x2)
+    F = fun(x2, **kwargs)
 
     jac = np.divide(F[:, :ndim] - F[:, -1:], delta)
     return jac.astype(np.float_)

--- a/stonesoup/functions/tests/test_functions.py
+++ b/stonesoup/functions/tests/test_functions.py
@@ -90,6 +90,20 @@ def test_jacobian2():
     assert len(FOM[0]) == 0
 
 
+def test_jacobian_param():
+    """ jacobian function test """
+
+    # Sample functions to compute Jacobian on
+    def fun(x, value=0.0):
+        """ function for jabcobian parameter passing"""
+        return value*x.state_vector
+
+    x = 4
+    value = 2.0
+    jac = jacobian(fun, State(StateVector([[x]])), value=value)
+    assert np.allclose(value, jac)
+
+
 def test_jacobian_large_values():
     # State related variables
     state = State(StateVector([[1E10], [1.0]]))

--- a/stonesoup/models/base.py
+++ b/stonesoup/models/base.py
@@ -123,6 +123,22 @@ class LinearModel(Model):
 
         return self.matrix(**kwargs) @ state.state_vector + noise
 
+    def jacobian(self, state: State, **kwargs) -> np.ndarray:
+        """Model jacobian matrix :math:`H_{jac}`
+
+        Parameters
+        ----------
+        state : :class:`~.State`
+            An input state
+
+        Returns
+        -------
+        :class:`numpy.ndarray` of shape (:py:attr:`~ndim_meas`, \
+        :py:attr:`~ndim_state`)
+            The model jacobian matrix evaluated around the given state vector.
+        """
+        return self.matrix(**kwargs)
+
 
 class NonLinearModel(Model):
     """NonLinearModel class

--- a/stonesoup/models/measurement/tests/test_lg.py
+++ b/stonesoup/models/measurement/tests/test_lg.py
@@ -47,6 +47,9 @@ def test_lgmodel(H, R, ndim_state, mapping):
     # Ensure ```lg.transfer_function()``` returns H
     assert np.array_equal(H, lg.matrix())
 
+    # Ensure lg.jacobian() returns H
+    assert np.array_equal(H, lg.jacobian(state=state))
+
     # Ensure ```lg.covar()``` returns R
     assert np.array_equal(R, lg.covar())
 


### PR DESCRIPTION
The jacobian() function needs to pass the **kwargs - this is needed for the nonlinear models which have a time component passed in. Also added the jacobian() to the Linear model - This simplifies handling when mixing Linear & Non-Linear models. One example is a coordinated turn with unknown turn rate (model is coming soon) in x,y plane and CV model in z-dimension.

This should also eliminate the need for a Linear Kalman model since the EKF with a Linear model will produce the same calculations.