### PR TITLE
Correct bug when dealing with duplicate tags

### DIFF
--- a/stonesoup/mixturereducer/gaussianmixture.py
+++ b/stonesoup/mixturereducer/gaussianmixture.py
@@ -182,7 +182,8 @@ class GaussianMixtureReducer(MixtureReducer):
                     shared_components = sorted(
                         (component for component in merged_components
                             if component.tag == shared_tag),
-                        key=attrgetter('weight'))
+                        key=attrgetter('weight'),
+                        reverse=True)
                     final_merged_components.append(shared_components[0])
                     for component in shared_components[1:]:
                         # Assign a new uuid


### PR DESCRIPTION
In the GMPHD mixture reducer, sometimes there are multiple components (states) with the same tag. But in order to create tracks properly, the tags must be unique. When multiple states have the same tag, we want to assign the tag to the state that has the highest weight (as it is the most likely state to be part of the track). The rest of the states will get new tags. Previously, it accidently assigned the tag to the state with the lowest weight. To fix this, we just have to sort the components from highest to lowest weight instead of the default lowest to highest. Then we can keep the first one in the list and assign new tags to the rest of them.