### PR TITLE
Add hidden Markov model implementation for classification

### DIFF
--- a/docs/examples/Classifying_Using_HMM.py
+++ b/docs/examples/Classifying_Using_HMM.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+"""
+Classification Using Hidden Markov Model
+========================================
+This is a demonstration using the implemented Hidden Markov model to classify multiple targets.
+
+We will attempt to classify 3 targets in an undefined region.
+Our sensor will be all-seeing, and provide us with indirect observations of the targets such that,
+using the implemented hidden Markov Model (HMM), we should hopefully successfully classify exactly
+3 targets correctly.
+"""
+
+# %%
+# All Stone Soup imports will be given in order of usage.
+
+from datetime import datetime, timedelta
+import numpy as np
+
+# %%
+# Ground Truth
+# ^^^^^^^^^^^^
+# The targets may take one of three discrete hidden classes: 'bike', 'car' and 'bus'.
+# It will be assumed that the targets cannot transition from one class to another, hence an
+# identity transition matrix is given to the :class:`~.CategoricalTransitionModel`.
+#
+# A :class:`~.CategoricalState` class is used to store information on the classification/category
+# of the targets. The state vector will define a categorical distribution over the 3 possible
+# classes, whereby each component defines the probability that a target is of the corresponding
+# class. For example, the state vector (0.2, 0.3, 0.5), with category names ('bike', 'car', 'bus')
+# indicates that a target has a 20% probability of being class 'bike', a 30% probability of being
+# class 'car' etc.
+# It does not make sense to have a true target being a distribution over the possible classes, and
+# therefore the true categorical states will have binary state vectors indicating a specific class
+# (i.e. a '1' at one state vector index, and '0's elsewhere).
+# The :class:`~.CategoricalGroundTruthState` class inherits directly from the base
+# :class:`~.CategoricalState` class.
+#
+# While the category will remain the same, a :class:`~.CategoricalTransitionModel` is used here
+# for the sake of demonstration.
+#
+# The category and timings for one of the ground truth paths will be printed.
+
+from stonesoup.models.transition.categorical import CategoricalTransitionModel
+from stonesoup.types.groundtruth import CategoricalGroundTruthState
+from stonesoup.types.groundtruth import GroundTruthPath
+
+category_transition = CategoricalTransitionModel(transition_matrix=np.eye(3),
+                                                 transition_covariance=0.1 * np.eye(3))
+
+start = datetime.now()
+
+hidden_classes = ['bike', 'car', 'bus']
+
+# Generating ground truth
+ground_truths = list()
+for i in range(1, 4):
+    state_vector = np.zeros(3)  # create a vector with 3 zeroes
+    state_vector[np.random.choice(3, 1, p=[1/3, 1/3, 1/3])] = 1  # pick a random class out of the 3
+    ground_truth_state = CategoricalGroundTruthState(state_vector,
+                                                     timestamp=start,
+                                                     category_names=hidden_classes)
+
+    ground_truth = GroundTruthPath([ground_truth_state], id=f"GT{i}")
+
+    for _ in range(10):
+        new_vector = category_transition.function(ground_truth[-1],
+                                                  noise=True,
+                                                  time_interval=timedelta(seconds=1))
+        new_state = CategoricalGroundTruthState(
+            new_vector,
+            timestamp=ground_truth[-1].timestamp + timedelta(seconds=1),
+            category_names=hidden_classes
+        )
+
+        ground_truth.append(new_state)
+    ground_truths.append(ground_truth)
+
+for states in np.vstack(ground_truths).T:
+    print(f"{new_state.timestamp:%H:%M:%S}", end="")
+    for state in states:
+        print(f" -- {new_state.category}", end="")
+    print()
+
+# %%
+# Measurement
+# ^^^^^^^^^^^
+# Using a hidden markov model, it is assumed the hidden class of a target cannot be directly
+# observed, and instead indirect observations are taken. In this instance, observations of the
+# targets' sizes are taken ('small' or 'large'), which have direct implications as to the targets'
+# hidden classes, and this relationship is modelled by the `emission matrix` of the
+# :class:`~.CategoricalMeasurementModel`, which is used by the :class:`~.CategoricalSensor` to
+# provide :class:`~.CategoricalDetection` types.
+# We will model this such that a 'bike' has a very small chance of being observed as a 'big'
+# target. Similarly, a 'bus' will tend to appear as 'large'. Whereas, a 'car' has equal chance of
+# being observed as either.
+
+from stonesoup.models.measurement.categorical import CategoricalMeasurementModel
+from stonesoup.sensor.categorical import CategoricalSensor
+
+E = np.array([[0.99, 0.01],  # P(small | bike)  P(large | bike)
+              [0.5, 0.5],
+              [0.01, 0.99]])
+model = CategoricalMeasurementModel(ndim_state=3,
+                                    emission_matrix=E,
+                                    emission_covariance=0.1 * np.eye(2),
+                                    mapping=[0, 1, 2])
+
+eo = CategoricalSensor(measurement_model=model,
+                       category_names=['small', 'large'])
+
+# Generating measurements
+measurements = list()
+for states in np.vstack(ground_truths).T:
+    measurements_at_time = eo.measure(states)
+    timestamp = next(iter(states)).timestamp
+    measurements.append((timestamp, measurements_at_time))
+
+    print(f"{timestamp:%H:%M:%S} -- {[meas.category for meas in measurements_at_time]}")
+
+# %%
+# Tracking Components
+# ^^^^^^^^^^^^^^^^^^^
+
+# %%
+# Predictor
+# ---------
+# A :class:`~.HMMPredictor` specifically uses :class:`~.CategoricalTransitionModel` types to
+# predict.
+from stonesoup.predictor.categorical import HMMPredictor
+
+predictor = HMMPredictor(category_transition)
+
+# %%
+# Updater
+# -------
+from stonesoup.updater.categorical import HMMUpdater
+
+updater = HMMUpdater()
+
+# %%
+# Hypothesiser
+# ------------
+# %%
+# A :class:`~.CategoricalHypothesiser` is used for calculating categorical hypotheses.
+# It utilises the :class:`~.ObservationAccuracy` measure: a multi-dimensional extension of an
+# 'accuracy' score, essentially providing a measure of the similarity between two categorical
+# distributions.
+from stonesoup.hypothesiser.categorical import CategoricalHypothesiser
+
+hypothesiser = CategoricalHypothesiser(predictor=predictor, updater=updater)
+
+# %%
+# Data Associator
+# ---------------
+# We will use a standard :class:`~.GNNWith2DAssignment` data associator.
+from stonesoup.dataassociator.neighbour import GNNWith2DAssignment
+
+data_associator = GNNWith2DAssignment(hypothesiser)
+
+# %%
+# Prior
+# -----
+# As we are tracking in a categorical state space, we should initiate with a categorical state for
+# the prior. Equal probability is given to all 3 of the possible hidden classes that a target
+# might take (the category names are also provided here).
+from stonesoup.types.state import CategoricalState
+
+prior = CategoricalState([1 / 3, 1 / 3, 1 / 3], category_names=hidden_classes)
+
+# %%
+# Initiator
+# ---------
+# For each unassociated detection, a new track will be initiated. In this instance we use a
+# :class:`~.SimpleCategoricalInitiator`, which specifically handles categorical state priors.
+from stonesoup.initiator.categorical import SimpleCategoricalInitiator
+
+initiator = SimpleCategoricalInitiator(prior_state=prior, measurement_model=None)
+
+# %%
+# Deleter
+# -------
+# We can use a standard :class:`~.UpdateTimeStepsDeleter`.
+from stonesoup.deleter.time import UpdateTimeStepsDeleter
+
+deleter = UpdateTimeStepsDeleter(2)
+
+# %%
+# Tracker
+# -------
+# We can use a standard :class:`~.MultiTargetTracker`.
+from stonesoup.tracker.simple import MultiTargetTracker
+
+tracker = MultiTargetTracker(initiator, deleter, measurements, data_associator, updater)
+
+# %%
+# Tracking
+# ^^^^^^^^
+
+tracks = set()
+for time, ctracks in tracker:
+    tracks.update(ctracks)
+
+print(f"Number of tracks: {len(tracks)}")
+for track in tracks:
+    certainty = track.state_vector[np.argmax(track.state_vector)][0] * 100
+    print(f"id: {track.id} -- category: {track.category} -- certainty: {certainty}%")
+    for state in track:
+        meas_string = f"associated measurement: {state.hypothesis.measurement.category}"
+        print(f"{state.timestamp} -- {state.category} -- {meas_string}")
+    print()
+
+# %%
+# Metric
+# ^^^^^^
+# Determining tracking accuracy.
+# In calculating how many targets were classified correctly, only tracks with the highest
+# classification certainty are considered.
+
+excess_tracks = len(tracks) - len(ground_truths)  # target value = 0
+sorted_tracks = sorted(tracks,
+                       key=lambda track: track.state_vector[np.argmax(track.state_vector)][0],
+                       reverse=True)
+best_tracks = sorted_tracks[:3]
+true_classifications = {ground_truth.category for ground_truth in ground_truths}
+track_classifications = {track.category for track in best_tracks}
+
+num_correct_classifications = len(true_classifications & track_classifications)
+
+print(f"Excess tracks: {excess_tracks}")
+print(f"No. correct classifications: {num_correct_classifications}")

--- a/docs/examples/Classifying_Using_HMM.py
+++ b/docs/examples/Classifying_Using_HMM.py
@@ -78,9 +78,9 @@ for i in range(1, 4):
     ground_truths.append(ground_truth)
 
 for states in np.vstack(ground_truths).T:
-    print(f"{new_state.timestamp:%H:%M:%S}", end="")
+    print(f"{states[0].timestamp:%H:%M:%S}", end="")
     for state in states:
-        print(f" -- {new_state.category}", end="")
+        print(f" -- {state.category}", end="")
     print()
 
 # %%

--- a/docs/source/stonesoup.hypothesiser.rst
+++ b/docs/source/stonesoup.hypothesiser.rst
@@ -25,3 +25,9 @@ Gaussian Mixture
 .. automodule:: stonesoup.hypothesiser.gaussianmixture
     :show-inheritance:
 
+Categorical
+-----------
+
+.. automodule:: stonesoup.hypothesiser.categorical
+    :show-inheritance:
+

--- a/docs/source/stonesoup.initiator.rst
+++ b/docs/source/stonesoup.initiator.rst
@@ -15,3 +15,8 @@ Wrappers
 .. automodule:: stonesoup.initiator.wrapper
     :show-inheritance:
 
+Categorical
+-----------
+.. automodule:: stonesoup.initiator.categorical
+    :show-inheritance:
+

--- a/docs/source/stonesoup.models.measurement.rst
+++ b/docs/source/stonesoup.models.measurement.rst
@@ -18,3 +18,9 @@ NonLinear
 .. automodule:: stonesoup.models.measurement.nonlinear
     :show-inheritance:
     :inherited-members:
+
+Categorical
+-----------
+.. automodule:: stonesoup.models.measurement.categorical
+    :show-inheritance:
+    :inherited-members:

--- a/docs/source/stonesoup.models.transition.rst
+++ b/docs/source/stonesoup.models.transition.rst
@@ -18,3 +18,9 @@ NonLinear
 .. automodule:: stonesoup.models.transition.nonlinear
     :show-inheritance:
     :inherited-members:
+
+Categorical
+-----------
+.. automodule:: stonesoup.models.transition.categorical
+    :show-inheritance:
+    :inherited-members:

--- a/docs/source/stonesoup.predictor.rst
+++ b/docs/source/stonesoup.predictor.rst
@@ -19,6 +19,12 @@ Particle
 .. automodule:: stonesoup.predictor.particle
     :show-inheritance:
 
+Categorical
+-----------
+
+.. automodule:: stonesoup.predictor.categorical
+    :show-inheritance:
+
 Information
 -----------
 

--- a/docs/source/stonesoup.sensor.rst
+++ b/docs/source/stonesoup.sensor.rst
@@ -18,3 +18,8 @@ Passive
 -------
 .. automodule:: stonesoup.sensor.passive
     :show-inheritance:
+
+Categorical
+-----------
+.. automodule:: stonesoup.sensor.categorical
+    :show-inheritance:

--- a/docs/source/stonesoup.updater.rst
+++ b/docs/source/stonesoup.updater.rst
@@ -36,3 +36,9 @@ AlphaBeta
 
 .. automodule:: stonesoup.updater.alphabeta
     :show-inheritance:
+
+Categorical
+-----------
+
+.. automodule:: stonesoup.updater.categorical
+    :show-inheritance:

--- a/stonesoup/dataassociator/neighbour.py
+++ b/stonesoup/dataassociator/neighbour.py
@@ -3,11 +3,12 @@ import itertools
 
 import numpy as np
 
-from .base import DataAssociator
 from ._assignment import assign2D
+from .base import DataAssociator
 from ..base import Property
 from ..hypothesiser import Hypothesiser
-from ..types.hypothesis import SingleHypothesis, SingleProbabilityHypothesis, JointHypothesis
+from ..types.hypothesis import SingleHypothesis, JointHypothesis, \
+    ProbabilityHypothesis
 
 
 class NearestNeighbour(DataAssociator):
@@ -206,7 +207,7 @@ class GNNWith2DAssignment(DataAssociator):
         # Probability is maximise problem, distance is minimise problem
         # Mixed hypotheses cannot be computed at this time
         hypothesis_types = {
-            isinstance(hypothesis, SingleProbabilityHypothesis)
+            isinstance(hypothesis, ProbabilityHypothesis)
             for row in hypothesis_matrix for hypothesis in row
             if hypothesis is not None}
         if len(hypothesis_types) > 1:

--- a/stonesoup/hypothesiser/categorical.py
+++ b/stonesoup/hypothesiser/categorical.py
@@ -40,7 +40,7 @@ class CategoricalHypothesiser(Hypothesiser):
         track: :class:`~.Track`
             The track object to hypothesise on. Composed of :class:`~.CategoricalState` types.
         detections: :class:`set`
-            A set of :class:`~CategoricalDetection` objects, representing the available
+            A set of :class:`~.CategoricalDetection` objects, representing the available
             detections.
         timestamp: :class:`datetime.datetime`
             A timestamp used when evaluating the state and measurement predictions. Note that if a
@@ -50,7 +50,7 @@ class CategoricalHypothesiser(Hypothesiser):
         Returns
         -------
         : :class:`~.MultipleHypothesis`
-            A container of :class:`~SingleProbabilityHypothesis` objects
+            A container of :class:`~.SingleProbabilityHypothesis` objects
         """
 
         hypotheses = list()

--- a/stonesoup/hypothesiser/categorical.py
+++ b/stonesoup/hypothesiser/categorical.py
@@ -1,0 +1,89 @@
+# -*- coding: utf-8 -*-
+from .base import Hypothesiser
+from ..base import Property
+from ..measures import ObservationAccuracy
+from ..predictor.categorical import HMMPredictor
+from ..types.detection import MissedDetection
+from ..types.hypothesis import SingleProbabilityHypothesis
+from ..types.multihypothesis import MultipleHypothesis
+from ..types.numeric import Probability
+from ..updater.categorical import HMMUpdater
+
+
+class CategoricalHypothesiser(Hypothesiser):
+    r"""Hypothesiser based on categorical distribution accuracy.
+
+    This hypothesiser generates track predictions at detection times and scores each hypothesised
+    prediction-detection pair according to the accuracy of the corresponding measurement
+    prediction compared to the detection.
+    """
+
+    predictor: HMMPredictor = Property(doc="Predictor used to predict tracks to detection times")
+    updater: HMMUpdater = Property(doc="Updater used to get measurement prediction")
+    prob_detect: Probability = Property(
+        default=Probability(0.85),
+        doc="Target Detection Probability")
+    prob_gate: Probability = Property(
+        default=Probability(0.95),
+        doc="Gate Probability - prob. gate contains true measurement if detected")
+
+    def hypothesise(self, track, detections, timestamp):
+        """ Evaluate and return all track association hypotheses.
+
+        For a given track and a set of N available detections, return a MultipleHypothesis object
+        with N+1 detections (first detection is a 'MissedDetection'), each with an associated
+        accuracy (of prediction emission to measurement), considered the probability of the
+        hypothesis being true.
+
+        Parameters
+        ----------
+        track: :class:`~.Track`
+            The track object to hypothesise on. Composed of :class:`~.CategoricalState` types.
+        detections: :class:`set`
+            A set of :class:`~CategoricalDetection` objects, representing the available
+            detections.
+        timestamp: :class:`datetime.datetime`
+            A timestamp used when evaluating the state and measurement predictions. Note that if a
+            given detection has a non empty timestamp, then prediction will be performed according
+            to the timestamp of the detection.
+
+        Returns
+        -------
+        : :class:`~.MultipleHypothesis`
+            A container of :class:`~SingleProbabilityHypothesis` objects
+        """
+
+        hypotheses = list()
+
+        prediction = self.predictor.predict(track, timestamp=timestamp)
+        probability = Probability(1 - self.prob_detect * self.prob_gate)
+        hypotheses.append(
+            SingleProbabilityHypothesis(
+                prediction,
+                MissedDetection(timestamp=timestamp),
+                probability
+            ))
+
+        for detection in detections:
+            prediction = self.predictor.predict(
+                track, timestamp=detection.timestamp)
+
+            measurement_prediction = self.updater.predict_measurement(
+                prediction, detection.measurement_model, noise=False)
+
+            probability = self.measure(measurement_prediction, detection)
+            probability = probability * self.prob_detect
+            probability = Probability(probability, log_value=False)
+
+            # True detection hypothesis
+            hypotheses.append(
+                SingleProbabilityHypothesis(
+                    prediction,
+                    detection,
+                    probability,
+                    measurement_prediction))
+        return MultipleHypothesis(hypotheses, normalise=False, total_weight=1)
+
+    @property
+    def measure(self):
+        return ObservationAccuracy()

--- a/stonesoup/hypothesiser/tests/conftest.py
+++ b/stonesoup/hypothesiser/tests/conftest.py
@@ -1,8 +1,12 @@
 # -*- coding: utf-8 -*-
+import numpy as np
 import pytest
 
+from ...predictor.categorical import HMMPredictor
 from ...types.prediction import (
-    GaussianMeasurementPrediction, GaussianStatePrediction)
+    GaussianMeasurementPrediction, GaussianStatePrediction, CategoricalStatePrediction,
+    CategoricalMeasurementPrediction)
+from ...updater.categorical import HMMUpdater
 
 
 @pytest.fixture()
@@ -23,3 +27,36 @@ def updater():
                                                  state_prediction.covar,
                                                  state_prediction.timestamp)
     return TestGaussianUpdater()
+
+
+@pytest.fixture()
+def dummy_category_predictor():
+    class DummyCategoricalPredictor(HMMPredictor):
+
+        @property
+        def transition_model(self):
+            pass
+
+        def predict(self, prior, timestamp=None, **kwargs):
+            """Return the same state vector."""
+            return CategoricalStatePrediction(prior.state_vector, timestamp=timestamp)
+
+    return DummyCategoricalPredictor()
+
+
+@pytest.fixture()
+def dummy_category_updater():
+    class DummyCategoricalUpdater(HMMUpdater):
+
+        @property
+        def measurement_model(self):
+            pass
+
+        def predict_measurement(self, state_prediction, measurement_model=None, **kwargs):
+            """Return the first two state vector elements, normalised."""
+            vector = state_prediction.state_vector[:2]
+            vector = vector / np.sum(vector)
+            return CategoricalMeasurementPrediction(vector,
+                                                    timestamp=state_prediction.timestamp)
+
+    return DummyCategoricalUpdater()

--- a/stonesoup/hypothesiser/tests/test_categorical.py
+++ b/stonesoup/hypothesiser/tests/test_categorical.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+from datetime import datetime
+
+from ..categorical import CategoricalHypothesiser
+from ...types.detection import CategoricalDetection
+from ...types.state import CategoricalState
+from ...types.track import Track
+
+
+def test_categorical(dummy_category_predictor, dummy_category_updater):
+    timestamp = datetime.now()
+
+    track = Track([CategoricalState(state_vector=[0.5, 0.3, 0.2], timestamp=timestamp)])
+
+    detection1 = CategoricalDetection(state_vector=[0.6, 0.4], timestamp=timestamp)
+    detection2 = CategoricalDetection(state_vector=[0.5, 0.5], timestamp=timestamp)
+    detection3 = CategoricalDetection(state_vector=[0.1, 0.9], timestamp=timestamp)
+    detections = {detection1, detection2, detection3}
+
+    hypothesiser = CategoricalHypothesiser(dummy_category_predictor, dummy_category_updater)
+
+    hypotheses = hypothesiser.hypothesise(track, detections, timestamp)
+
+    # 4 hypotheses: detections 1, 2 and 3, and missed detection
+    assert len(hypotheses) == 4
+
+    hypothesis_detections = {hypothesis.measurement for hypothesis in hypotheses}
+
+    # All detections have a hypothesis
+    assert all(detection in hypothesis_detections for detection in detections)
+
+    # There is a missed detection hypothesis
+    assert any(not hypothesis.measurement for hypothesis in hypotheses)
+
+    # Each hypothesis has a probability attribute
+    assert all(hypothesis.probability >= 0 for hypothesis in hypotheses)

--- a/stonesoup/initiator/categorical.py
+++ b/stonesoup/initiator/categorical.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+import numpy as np
+
+from .base import Initiator
+from ..base import Property
+from ..models.measurement.categorical import CategoricalMeasurementModel
+from ..types.hypothesis import SingleHypothesis
+from ..types.state import CategoricalState
+from ..types.track import Track
+from ..types.update import CategoricalStateUpdate
+
+
+class SimpleCategoricalInitiator(Initiator):
+    """Initiator that creates tracks in a categorical state space.
+
+    The defined :attr:`measurement_model` or all detections' measurement models must be a
+    :class:`CategoricalMeasurementModel` type as this class utilises the models' emission matrices
+    to determine detections' state space equivalents.
+    For state space indices where a detection provides no information, the :attr:`prior_state`
+    value is used instead."""
+    prior_state: CategoricalState = Property(doc="Prior state information")
+    measurement_model: CategoricalMeasurementModel = Property(
+        default=None, doc="Measurement model (should be categorical model)")
+
+    def initiate(self, detections, timestamp, **kwargs):
+        tracks = set()
+
+        for detection in detections:
+            if detection.measurement_model is not None:
+                measurement_model = detection.measurement_model
+            else:
+                measurement_model = self.measurement_model
+
+            state_vector = measurement_model.emission_matrix @ detection.state_vector
+
+            # Replace the default prior with the measurement's state-space components were possible
+            prior_state_vector = self.prior_state.state_vector.copy()
+            for index, element in zip(measurement_model.mapping, state_vector):
+                prior_state_vector[index] = element
+
+            # Normalise the prior
+            prior_state_vector = prior_state_vector / np.sum(prior_state_vector)
+
+            state = CategoricalStateUpdate(state_vector=prior_state_vector,
+                                           hypothesis=SingleHypothesis(None, detection),
+                                           timestamp=detection.timestamp,
+                                           category_names=self.prior_state.category_names)
+
+            tracks.add(Track([state]))
+        return tracks

--- a/stonesoup/initiator/tests/test_categorical.py
+++ b/stonesoup/initiator/tests/test_categorical.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+from datetime import datetime
+
+import numpy as np
+import pytest
+
+from ..categorical import SimpleCategoricalInitiator
+from ...models.measurement.categorical import CategoricalMeasurementModel
+from ...models.transition.tests.test_categorical import create_categorical, \
+    create_categorical_matrix
+from ...types.detection import CategoricalDetection
+from ...types.state import CategoricalState
+from ...types.update import CategoricalStateUpdate
+
+
+@pytest.mark.parametrize(
+    'measurement_model',
+    [CategoricalMeasurementModel(ndim_state=3,
+                                 emission_matrix=create_categorical_matrix(3, 3),
+                                 emission_covariance=0.1 * np.eye(3),
+                                 mapping=[0, 1, 2]),
+     CategoricalMeasurementModel(ndim_state=3,
+                                 emission_matrix=create_categorical_matrix(2, 2),
+                                 emission_covariance=0.1 * np.eye(3),
+                                 mapping=[0, 1]),
+     CategoricalMeasurementModel(ndim_state=3,
+                                 emission_matrix=create_categorical_matrix(2, 2),
+                                 emission_covariance=0.1 * np.eye(3),
+                                 mapping=[0, 2]),
+     CategoricalMeasurementModel(ndim_state=3,
+                                 emission_matrix=create_categorical_matrix(2, 2),
+                                 emission_covariance=0.1 * np.eye(3),
+                                 mapping=[2, 0])
+     ],
+    ids=['[0, 1, 2]', '[0, 1]', '[0, 2]', '[2, 0]'])
+def test_categorical_initiator(measurement_model):
+    now = datetime.now()
+
+    # Prior state information
+    prior_state = CategoricalState([1 / 3, 1 / 3, 1 / 3], category_names=['red', 'green', 'blue'])
+
+    ndim_meas = measurement_model.ndim_meas
+
+    measurements = [CategoricalDetection(create_categorical(ndim_meas), timestamp=now,
+                                         measurement_model=measurement_model),
+                    CategoricalDetection(create_categorical(ndim_meas), timestamp=now)]
+
+    initiator = SimpleCategoricalInitiator(prior_state, measurement_model=measurement_model)
+
+    tracks = initiator.initiate(measurements, now)
+
+    assert len(tracks) == 2
+    for track in tracks:
+        assert len(track) == 1
+        assert isinstance(track.state, CategoricalStateUpdate)
+
+    assert set(measurements) == set(track.state.hypothesis.measurement for track in tracks)

--- a/stonesoup/measures.py
+++ b/stonesoup/measures.py
@@ -5,6 +5,7 @@ import numpy as np
 from scipy.spatial import distance
 
 from .base import Base, Property
+from .types.state import State
 
 
 class Measure(Base):
@@ -287,3 +288,25 @@ class GaussianHellinger(SquaredGaussianHellinger):
 
         """
         return np.sqrt(super().__call__(state1, state2))
+
+
+class ObservationAccuracy(Measure):
+    r"""Accuracy measure
+
+    This measure evaluates the accuracy of a categorical distribution with respect to another."""
+
+    def __call__(self, state1, state2):
+
+        if isinstance(state1, State):
+            s1 = state1.state_vector
+        else:
+            s1 = state1
+
+        if isinstance(state2, State):
+            s2 = state2.state_vector
+        else:
+            s2 = state2
+
+        mins = [min(s1, s2) for s1, s2 in zip(s1, s2)]
+        maxs = [max(s1, s2) for s1, s2 in zip(s1, s2)]
+        return np.sum(mins)/np.sum(maxs)

--- a/stonesoup/models/measurement/categorical.py
+++ b/stonesoup/models/measurement/categorical.py
@@ -1,0 +1,118 @@
+# -*- coding: utf-8 -*-
+from typing import Union, Sequence
+
+import numpy as np
+from scipy.stats import multinomial
+
+from .base import MeasurementModel
+from ...base import Property
+from ...types.array import Matrix, StateVector, StateVectors, CovarianceMatrix
+
+
+class CategoricalMeasurementModel(MeasurementModel):
+    r"""Measurement model which returns a category.
+    This is a time invariant model for simple observations of a state.
+    A measurement can take one of a finite number of observation categories
+    :math:`Y = \{y_k|k\in\Z_{\gt0}\}` and a measurement vector :math:`(z_k)_i = P(y_i, k)` will
+    define a categorical distribution over these categories. Measurements are generated via random
+    sampling.
+
+    Intended to be used in conjunction with the :class:`~.CategoricalState` type.
+    """
+    emission_matrix: Matrix = Property(
+        doc=r"The emission matrix defining emission probability "
+            r":math:`(E_k)_{ij} = P(z_{j}, k | \phi_{i}, k)` (the probability of receiving an "
+            r"observation :math:`z` from state :math:`x_{k_j} = P(\phi_j, k)`. "
+            r"Rows of the matrix must sum to 1.")
+    emission_covariance: CovarianceMatrix = Property(doc="Emission covariance.")
+    mapping: Sequence[int] = Property(default=None,
+                                      doc="Mapping between measurement and state dims.")
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        for i, row in enumerate(self.emission_matrix):
+            if not np.isclose(np.sum(row), 1):
+                raise ValueError(f"Row {i} of emission matrix does not sum to 1")
+
+        if self.mapping is None:
+            self.mapping = np.arange(self.ndim_state)
+        elif len(self.mapping) != np.shape(self.emission_matrix)[0]:
+            raise ValueError(f"Emission matrix maps from {np.shape(self.emission_matrix)[0]} "
+                             f"elements of the state space, but the mapping is length "
+                             f"{len(self.mapping)}")
+
+    @property
+    def ndim_meas(self):
+        """Number of observation dimensions/categories."""
+        return self.emission_matrix.shape[1]
+
+    def _cond_prob_emission(self, state, noise=False, **kwargs):
+        """This function returns the probability of each observation category conditioned on the
+        input state, :math:`(p(z_j|x_i) p(x_i)` (this should come out normalised).
+        Noise is additive, and used by transforming resultant vectors using a logit function."""
+
+        if type(noise) is bool and noise:
+            noise = self.rvs()
+        elif not noise:
+            noise = 0
+        else:
+            raise ValueError("Noise is generated via random sampling, and defined noise is not "
+                             "implemented")
+
+        hp = self.emission_matrix.T @ state.state_vector[self.mapping]
+
+        with np.errstate(divide='ignore', over='ignore', under='ignore'):
+            if any(hp == 1):
+                y = hp.astype(float)
+                y[hp == 1] = np.finfo(np.float64).max
+                y[hp == 0] = np.finfo(np.float64).min
+            else:
+                y = np.log(hp / (1 - hp))
+
+            y += noise
+
+            p = 1 / (1 + np.exp(-y))
+            return p / np.sum(p)
+
+    def function(self, state, noise=False, **kwargs):
+        r"""Observation function
+
+        Parameters
+        ----------
+        state: :class:`~.CategoricalState`
+            An input (hidden class) state, where the state vector defines a categorical
+            distribution over the set of possible hidden states
+            :math:`\Phi = \{\phi_m|m\in\Z_{\gt0}\}`.
+        noise: bool
+            If 'True', additive noise (generated via random sampling) will be included. Noise
+            vectors cannot be defined beforehand. Only a boolean value is valid.
+
+        Returns
+        -------
+        state_vector: :class:`stonesoup.types.array.StateVector`
+            of shape (:py:attr:`~ndim_meas, 1`). The resultant measurement vector.
+            The resultant vector represents a categorical distribution over the set of possible
+            measurement categories. A definitive measurement category is chosen, hence the vector
+            will be binary.
+        """
+        cond_prob_emission = self._cond_prob_emission(state, noise=noise, **kwargs)
+        rv = multinomial(n=1, p=cond_prob_emission.flatten())
+        if noise:
+            return StateVector(rv.rvs(size=1, random_state=None))
+        else:
+            return StateVector(cond_prob_emission)
+
+    def rvs(self, num_samples=1, **kwargs) -> Union[StateVector, StateVectors]:
+        """Additive noise."""
+        omega = np.random.multivariate_normal(np.zeros(self.ndim),
+                                              self.emission_covariance,
+                                              size=num_samples)
+        return StateVectors(omega).T
+
+    def pdf(self, state1, state2, **kwargs):
+        """Assumes that state 1 is a binary measurement state (i.e. one vector element is 1 and
+        the rest are zeroes).
+        Returns the probability that the emission of state 2 is state 1."""
+        Hx = self._cond_prob_emission(state2)
+        return Hx.T @ state1.state_vector

--- a/stonesoup/models/measurement/categorical.py
+++ b/stonesoup/models/measurement/categorical.py
@@ -13,7 +13,7 @@ class CategoricalMeasurementModel(MeasurementModel):
     r"""Measurement model which returns a category.
     This is a time invariant model for simple observations of a state.
     A measurement can take one of a finite number of observation categories
-    :math:`Y = \{y_k|k\in\Z_{\gt0}\}` and a measurement vector :math:`(z_k)_i = P(y_i, k)` will
+    :math:`Y = \{y_k|k\in Z_{\gt0}\}` and a measurement vector :math:`(z_k)_i = P(y_i, k)` will
     define a categorical distribution over these categories. Measurements are generated via random
     sampling.
 
@@ -83,7 +83,7 @@ class CategoricalMeasurementModel(MeasurementModel):
         state: :class:`~.CategoricalState`
             An input (hidden class) state, where the state vector defines a categorical
             distribution over the set of possible hidden states
-            :math:`\Phi = \{\phi_m|m\in\Z_{\gt0}\}`.
+            :math:`\Phi = \{\phi_m|m\in Z_{\gt0}\}`.
         noise: bool
             If 'True', additive noise (generated via random sampling) will be included. Noise
             vectors cannot be defined beforehand. Only a boolean value is valid.

--- a/stonesoup/models/measurement/tests/test_categorical.py
+++ b/stonesoup/models/measurement/tests/test_categorical.py
@@ -1,0 +1,99 @@
+# -*- coding: utf-8 -*-
+
+import numpy as np
+import pytest
+
+from ...transition.tests.test_categorical import create_categorical, create_categorical_matrix
+from ....models.measurement.categorical import CategoricalMeasurementModel
+from ....types.array import Matrix, CovarianceMatrix, StateVectors
+from ....types.state import CategoricalState
+
+
+def test_categorical_measurement_model():
+    # test emission matrix error
+    with pytest.raises(ValueError, match="Row 0 of emission matrix does not sum to 1"):
+        CategoricalMeasurementModel(ndim_state=2,
+                                    emission_matrix=Matrix([[1, 1],
+                                                            [0, 0]]),
+                                    emission_covariance=np.eye(2))
+
+    # test mapping error
+    with pytest.raises(ValueError, match="Emission matrix maps from 2 elements of the state "
+                                         "space, but the mapping is length 3"):
+        CategoricalMeasurementModel(ndim_state=2,
+                                    emission_matrix=np.eye(2),
+                                    emission_covariance=np.eye(2),
+                                    mapping=[0, 2, 4])
+
+    # 3 measurement categories, 2 hidden categories
+    E = create_categorical_matrix(2, 3)
+    Ecov = CovarianceMatrix(np.diag([0.1, 0.1, 0.1]))
+    mapping = [0, 2]
+
+    model = CategoricalMeasurementModel(ndim_state=2,
+                                        emission_matrix=E,
+                                        emission_covariance=Ecov,
+                                        mapping=mapping)
+
+    # test ndim meas
+    assert model.ndim_meas == 3
+
+    # test conditional probability emission
+    for _ in range(3):
+        state = CategoricalState(create_categorical(4))
+        # testing noiseless as noise generation uses random sampling
+        exp_hp = E.T @ state.state_vector[mapping]
+        exp_y = np.log(exp_hp / (1 - exp_hp))
+        exp_p = 1 / (1 + np.exp(-exp_y))
+        exp_p = exp_p / np.sum(exp_p)
+        actual_p = model._cond_prob_emission(state)
+        assert np.array_equal(exp_p, actual_p)
+        assert np.isclose(np.sum(actual_p), 1)
+
+    with pytest.raises(ValueError, match="Noise is generated via random sampling, and defined "
+                                         "noise is not implemented"):
+        model._cond_prob_emission(CategoricalState(create_categorical(4)), noise=[1, 2, 3])
+
+    states = [CategoricalState(create_categorical(4)) for _ in range(5)]
+
+    for state in states:
+        # test function with noise (random sampling at end)
+        measurement = model.function(state, noise=True)
+        assert len(np.where(measurement == 0)[0]) == 2
+        assert len(np.where(measurement == 1)[1]) == 1
+        assert len(measurement) == 3
+        assert np.isclose(np.sum(measurement), 1)
+
+        # test function without noise (no random sampling at end)
+        measurement = model.function(state, noise=False)
+        assert len(measurement) == 3
+        assert np.isclose(np.sum(measurement), 1)
+
+        # test pdf
+        meas = CategoricalState(create_categorical(3))  # measurement vector
+        exp_Hx = E.T @ state.state_vector[mapping]
+        exp_Hx = exp_Hx / np.sum(exp_Hx)
+        exp_value = exp_Hx.T @ meas.state_vector
+        actual_value = model.pdf(meas, state)
+        assert np.allclose(actual_value, exp_value)
+
+    # test rvs
+    for i in range(1, 4):
+        rvs = model.rvs(num_samples=i)
+        assert isinstance(rvs, StateVectors)
+        assert len(rvs.T) == i
+        for elem in rvs.T:
+            assert len(elem) == 3  # same as model ndim meas
+
+    # Test edge case
+    state = CategoricalState([1, 0])
+    E = np.eye(2)
+    Ecov = 0.1 * np.eye(2)
+    model = CategoricalMeasurementModel(ndim_state=2,
+                                        emission_matrix=E,
+                                        emission_covariance=Ecov)
+    measurement = model.function(state, noise=True)
+    assert len(np.where(measurement == 0)[0]) == 1
+    assert len(np.where(measurement == 1)[1]) == 1
+    assert len(measurement) == 2
+    assert np.isclose(np.sum(measurement), 1)

--- a/stonesoup/models/transition/categorical.py
+++ b/stonesoup/models/transition/categorical.py
@@ -12,7 +12,7 @@ from ...types.state import CategoricalState
 class CategoricalTransitionModel(TransitionModel):
     r"""The transition model for categorical data
     This is a time invariant model for the transition of a state that can take one of a finite
-    number of categories :math:`\{\phi_m|m\in\Z_{\gt0}\}`, where a state space vector takes the
+    number of categories :math:`\{\phi_m|m\in Z_{\gt0}\}`, where a state space vector takes the
     form :math:`x_{k_i} = P(\phi_i, k)`, i.e. the :math:`i`-th state vector component is the
     probability that the state is of category :math:`\phi_i` at 'time' :math:`k`.
 

--- a/stonesoup/models/transition/categorical.py
+++ b/stonesoup/models/transition/categorical.py
@@ -1,0 +1,116 @@
+# -*- coding: utf-8 -*-
+from typing import Union
+
+import numpy as np
+
+from .base import Property
+from ...models.transition import TransitionModel
+from ...types.array import Matrix, StateVector, StateVectors, CovarianceMatrix
+from ...types.state import CategoricalState
+
+
+class CategoricalTransitionModel(TransitionModel):
+    r"""The transition model for categorical data
+    This is a time invariant model for the transition of a state that can take one of a finite
+    number of categories :math:`\{\phi_m|m\in\Z_{\gt0}\}`, where a state space vector takes the
+    form :math:`x_{k_i} = P(\phi_i, k)`, i.e. the :math:`i`-th state vector component is the
+    probability that the state is of category :math:`\phi_i` at 'time' :math:`k`.
+
+    Intended to be used in conjunction with the :class:`~.CategoricalState` type.
+    """
+    transition_matrix: Matrix = Property(
+        doc=r"Stochastic matrix :math:`(F_{k+1})_{ij} = P(\phi_i, k+1 | \phi_j, k)` determining "
+            r"the conditional probability that an object is category :math:`\phi_i` at 'time' "
+            r":math:`k + 1` given that it was category :math:`\phi_j` at 'time' :math:`k`. "
+            r"Columns must sum to 1.")
+    transition_covariance: CovarianceMatrix = Property(
+        default=None,
+        doc="Transition covariance, used in noise generation.")
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        for i, col in enumerate(self.transition_matrix.T):
+            if not np.isclose(np.sum(col), 1):
+                raise ValueError(f"Column {i} of transition matrix does not sum to 1")
+
+    @property
+    def ndim_state(self):
+        """Number of model state dimensions/categories."""
+        return self.transition_matrix.shape[0]
+
+    def function(self, state: CategoricalState, noise: bool = False, **kwargs) -> StateVector:
+        r"""Applies the linear transformation:
+
+        .. math::
+            (F_{k+1}\mathbf{x}_k)_{i} = P(\phi_i, k+1 | \phi_j, k)P(\phi_j, k)
+
+        The resultant vector is transformed to the interval :math:`[-\infty, \infty]` via a logit
+        function, in order to add noise.
+        This is then transformed back to the interval :math:`[0, 1]` and normalised.
+
+        Parameters
+        ----------
+        state : :class:`~.CategoricalState`
+            The state to be transitioned according to the models in :py:attr:`~model_list`.
+        noise: bool
+            If 'True', additive log noise (generated via random sampling) will be included prior
+            to transformation back to the interval :math:`[0, 1]`. Noise vectors cannot be defined
+            beforehand. Only a boolean value is valid.
+
+        Returns
+        -------
+        state_vector: :class:`stonesoup.types.array.StateVector`
+            of shape (:py:attr:`~ndim_state, 1`). The resultant state vector of the transition.
+
+        Notes
+        -----
+        For p=0 or p=1 infinities will be generated. We manage that by using the `numpy.finfo()`
+        function.
+        """
+        if isinstance(noise, bool) and noise:
+            noise = self.rvs()
+        elif not noise:
+            noise = 0
+        else:
+            raise ValueError("Noise is generated via random sampling, and defined noise is not "
+                             "implemented")
+
+        # what to do if p=1
+        fp = self.transition_matrix @ state.state_vector
+
+        with np.errstate(divide='ignore', over='ignore', under='ignore'):
+            if any(fp == 1):
+                y = fp.astype(float)
+                y[fp == 1] = np.finfo(np.float64).max
+                y[fp == 0] = np.finfo(np.float64).min
+            else:
+                y = np.log(fp / (1 - fp))
+
+            y += noise
+
+            p = 1 / (1 + np.exp(-y))
+            return p / np.sum(p)
+
+    def rvs(self, num_samples=1, **kwargs) -> Union[StateVector, StateVectors]:
+        r"""Create noise samples. This samples from a multivariate normal distribution with
+        :math:`mean=0` and covariance defined by the transition covariance matrix.
+
+        Note:
+            * This is additive log noise, so multiplicative but with its effect largest at
+              :math:`p=0.5` (:math:`logit(p)=0`) and :math:`nil` when :math:`p=0`
+              (:math:`logit(p)=-\infty`, or :math:`p=1` (:math:`logit(p)=+\infty`).
+            * One could 'normalise' this such that the effect is more constant across :math:`p`
+              but it's impossible to escape the points that map to infinity in the logit function,
+              so :math:`p = 1 + noise` will still be :math:`p = 1 (+etc)`, unless a different form
+              is used.
+        """
+        omega = np.random.multivariate_normal(np.zeros(self.ndim_state),
+                                              self.transition_covariance,
+                                              size=num_samples)
+        return StateVectors(omega).T
+
+    def pdf(self, state1, state2, **kwargs):
+        """Assumes that state 1 is binary and this returns the probability that the transited
+        state2 is state1"""
+        Fx = self.transition_matrix @ state2.state_vector
+        return Fx.T @ state1.state_vector

--- a/stonesoup/models/transition/tests/test_categorical.py
+++ b/stonesoup/models/transition/tests/test_categorical.py
@@ -1,0 +1,116 @@
+# coding: utf-8
+
+import numpy as np
+import pytest
+
+from ..categorical import CategoricalTransitionModel
+from ....types.array import StateVectors, CovarianceMatrix
+from ....types.state import State, CategoricalState
+
+
+def create_categorical(ndim):
+    """Create a state with random state vector representing a categorical distribution across
+    `ndim` possible categories."""
+    total = 0
+    sv = list()
+    for i in range(ndim - 1):
+        x = np.random.uniform(0, 1 - total)
+        sv.append(x)
+        total += x
+    sv.append(1 - total)  # add probability that is left
+    sv = np.array(sv)
+    np.random.shuffle(sv)  # shuffle state vector
+    return sv
+
+
+def create_categorical_matrix(num_rows, num_cols):
+    """Create a matrix with normalised rows"""
+    matrix = list()
+    for i in range(num_rows):
+        matrix.append(create_categorical(num_cols))
+    return np.array(matrix)
+
+
+@pytest.mark.parametrize('ndim', (2, 3, 4))
+def test_categorical_transition_model(ndim):
+    # test invalid matrix
+    with pytest.raises(ValueError, match="Column 0 of transition matrix does not sum to 1"):
+        CategoricalTransitionModel(2 * np.eye(2))
+
+    # ndim possible categories
+    F = create_categorical_matrix(ndim, ndim).T  # normalised columns
+    Q = CovarianceMatrix(np.eye(ndim))
+
+    model = CategoricalTransitionModel(F, Q)
+
+    # test ndim state
+    assert model.ndim == F.shape[0]
+    assert model.ndim_state == F.shape[0]
+
+    # test function noise error
+    with pytest.raises(ValueError, match="Noise is generated via random sampling, and defined "
+                                         "noise is not implemented"):
+        prior = CategoricalState(create_categorical(2))
+        model.function(prior, noise=ndim * [0.5])
+
+    states = [CategoricalState(create_categorical(ndim)) for _ in range(5)]
+
+    # Test function
+    for state in states:
+
+        fp = F @ state.state_vector
+
+        # Test noiseless
+
+        if any(fp == 1):
+            exp_noiseless = fp * 1.0
+            exp_noiseless[fp == 1] = np.finfo(np.float64).max
+            exp_noiseless[fp == 0] = np.finfo(np.float64).min
+        else:
+            exp_noiseless = np.log(fp / (1 - fp)) + 0
+
+        exp_noiseless = 1 / (1 + np.exp(-exp_noiseless))
+        exp_noiseless = exp_noiseless / np.sum(exp_noiseless)
+
+        actual_noiseless = model.function(state, noise=False)
+
+        assert len(actual_noiseless) == ndim
+        assert np.isclose(sum(actual_noiseless), 1)  # test normalised
+        assert np.array_equal(exp_noiseless, actual_noiseless)  # test is expected
+
+        # Test noisy
+        noisy = model.function(state, noise=True)
+        assert len(noisy) == ndim
+        assert np.isclose(sum(noisy), 1)  # test normalised
+
+        # Test pdf
+        other_state = CategoricalState(create_categorical(ndim))
+        exp_value = (F @ other_state.state_vector).T @ state.state_vector
+        actual_value = model.pdf(state, other_state)
+        assert np.array_equal(actual_value, exp_value)
+
+    # Test edge case
+    id_model = CategoricalTransitionModel(np.eye(ndim), Q)
+    state = State(np.eye(ndim)[0])  # vector looks like (1, 0, ..., 0) - ndim elements
+    fp = np.eye(ndim) @ state.state_vector
+
+    exp_noiseless = fp * 1.0
+    exp_noiseless[fp == 1] = np.finfo(np.float64).max
+    exp_noiseless[fp == 0] = np.finfo(np.float64).min
+
+    exp_noiseless = 1 / (1 + np.exp(-exp_noiseless))
+    exp_noiseless = exp_noiseless / np.sum(exp_noiseless)
+
+    actual_noiseless = id_model.function(state, noise=False)
+
+    assert len(actual_noiseless) == ndim
+    assert np.isclose(sum(actual_noiseless), 1)  # test normalised
+    assert np.array_equal(exp_noiseless, actual_noiseless)  # test is expected
+
+    # test rvs
+    for i in range(1, 4):
+        rvs = model.rvs(num_samples=i)
+        assert isinstance(rvs, StateVectors)
+        assert len(rvs.T) == i
+        for elem in rvs.T:
+            assert len(elem) == ndim

--- a/stonesoup/predictor/categorical.py
+++ b/stonesoup/predictor/categorical.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 from ..base import Property
-from ..models.transition import TransitionModel
+from ..models.transition.categorical import CategoricalTransitionModel
 from ..predictor import Predictor
 from ..predictor._utils import predict_lru_cache
 from ..types.prediction import Prediction
@@ -10,9 +10,7 @@ from ..types.state import CategoricalState
 class HMMPredictor(Predictor):
     r"""Models the prediction step of a hidden Markov model"""
 
-    transition_model: TransitionModel = Property(
-        doc="The transition model to be used. This should be a "
-            ":class:`~.CategoricalTransitionModel`.")
+    transition_model: CategoricalTransitionModel = Property(doc="The transition model to be used.")
 
     def _transition_function(self, prior, **kwargs):
         return self.transition_model.function(prior, **kwargs)

--- a/stonesoup/predictor/categorical.py
+++ b/stonesoup/predictor/categorical.py
@@ -1,0 +1,86 @@
+# -*- coding: utf-8 -*-
+from ..base import Property
+from ..models.transition import TransitionModel
+from ..predictor import Predictor
+from ..predictor._utils import predict_lru_cache
+from ..types.prediction import Prediction
+from ..types.state import CategoricalState
+
+
+class HMMPredictor(Predictor):
+    r"""Models the prediction step of a hidden Markov model"""
+
+    transition_model: TransitionModel = Property(
+        doc="The transition model to be used. This should be a "
+            ":class:`~.CategoricalTransitionModel`.")
+
+    def _transition_function(self, prior, **kwargs):
+        return self.transition_model.function(prior, **kwargs)
+
+    def _predict_over_interval(self, prior, timestamp):
+        """Private function to get the prediction interval (or None)
+
+        Parameters
+        ----------
+        prior : :class:`~.State`
+            The prior state
+
+        timestamp : :class:`datetime.datetime`, optional
+            The (current) timestamp
+
+        Returns
+        -------
+        : :class:`datetime.timedelta`
+            time interval to predict over
+
+        """
+
+        # Deal with undefined timestamps
+        if timestamp is None or prior.timestamp is None:
+            predict_over_interval = None
+        else:
+            predict_over_interval = timestamp - prior.timestamp
+
+        return predict_over_interval
+
+    @predict_lru_cache()
+    def predict(self, prior, timestamp=None, **kwargs):
+        r"""A simple matrix multiplication. The Chapman-Kolmogorov equation is:
+
+        .. math::
+            p(x_k|z_{1:k-1}) &= \Sigma_{x_{k-1}} p(x_k|x_{k-1}) p(x_{k-1}|z_{1:k-1})\\
+                             &= F_k p(x_{k-1}|z_{1:k-1})
+
+        where :math:`F_k` is the category-transition matrix and :math:`p(x)` is encoded in the
+        state vector
+
+        Parameters
+        ----------
+        prior : :class:`~.CategoricalState`
+            :math:`\mathbf{x}_{k-1}`
+        timestamp : :class:`datetime.datetime`, optional
+            :math:`k + 1`
+        **kwargs :
+            These are passed to the :meth:`transition_model.function` method.
+
+        Returns
+        -------
+        : :class:`~.CategoricalStatePrediction`
+            :math:`\mathbf{x}_{t + \Delta t|t}`, the predicted state.
+
+        Notes
+        -----
+        The categorical transition model is time-invariant and the evaluated `time_interval` can be
+        `None`.
+        """
+
+        if not isinstance(prior, CategoricalState):
+            raise ValueError("Prior must be a categorical state type")
+
+        predict_over_interval = self._predict_over_interval(prior, timestamp)
+
+        prediction = self._transition_function(prior, time_interval=predict_over_interval,
+                                               **kwargs)
+
+        return Prediction.from_state(prior, prediction, timestamp=timestamp,
+                                     transition_model=self.transition_model)

--- a/stonesoup/predictor/categorical.py
+++ b/stonesoup/predictor/categorical.py
@@ -8,7 +8,7 @@ from ..types.state import CategoricalState
 
 
 class HMMPredictor(Predictor):
-    r"""Models the prediction step of a hidden Markov model"""
+    r"""Models the prediction step of a Hidden Markov Model"""
 
     transition_model: CategoricalTransitionModel = Property(doc="The transition model to be used.")
 

--- a/stonesoup/predictor/tests/test_categorical.py
+++ b/stonesoup/predictor/tests/test_categorical.py
@@ -1,0 +1,56 @@
+# coding: utf-8
+import datetime
+
+import numpy as np
+import pytest
+
+from ...models.transition.categorical import CategoricalTransitionModel
+from ...models.transition.tests.test_categorical import create_categorical, \
+    create_categorical_matrix
+from ...predictor.categorical import HMMPredictor
+from ...types.prediction import StatePrediction, CategoricalStatePrediction
+from ...types.state import State, CategoricalState
+
+
+@pytest.mark.parametrize('ndim_state', (2, 3, 4))
+def test_hmm_predictor(ndim_state):
+    timestamp = datetime.datetime.now()
+    timediff = 2  # 2sec
+    new_timestamp = timestamp + datetime.timedelta(seconds=timediff)
+
+    F = create_categorical_matrix(ndim_state, ndim_state).T  # normalised columns
+    Q = np.eye(ndim_state)
+    transition_model = CategoricalTransitionModel(F, Q)
+
+    # Test state prediction
+    predictor = HMMPredictor(transition_model)
+
+    # Test wrong prior type
+    with pytest.raises(ValueError, match="Prior must be a categorical state type"):
+        predictor.predict(prior=State([1, 2, 3]), timestamp=new_timestamp)
+
+    priors = [CategoricalState(create_categorical(ndim_state),
+                               timestamp=timestamp)
+              for _ in range(5)]
+    for prior in priors:
+        for next_time in [new_timestamp, None]:
+            # Evaluate prediction
+            Fx = F @ prior.state_vector
+            eval_prediction = StatePrediction(Fx / sum(Fx), timestamp=next_time)
+
+            # Test state prediction
+            prediction = predictor.predict(prior=prior, timestamp=next_time)
+
+            # Assert presence of transition model
+            assert hasattr(prediction, 'transition_model')
+
+            # Test prediction state vector
+            assert np.allclose(prediction.state_vector,
+                               eval_prediction.state_vector,
+                               0,
+                               atol=1.e-14)
+            assert prediction.timestamp == next_time
+
+            # Test prediction type
+            assert isinstance(prediction, CategoricalStatePrediction)
+            assert prediction.category_names == prior.category_names

--- a/stonesoup/sensor/categorical.py
+++ b/stonesoup/sensor/categorical.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+from typing import Set, Sequence
+
+from ..base import Property
+from ..models.measurement.categorical import CategoricalMeasurementModel
+from ..sensor.sensor import Sensor
+from ..types.detection import TrueDetection, TrueCategoricalDetection
+from ..types.groundtruth import GroundTruthState, GroundTruthPath
+from ..types.state import CategoricalState
+
+
+class CategoricalSensor(Sensor):
+    measurement_model: CategoricalMeasurementModel = Property(
+        doc="Categorical measurement model used in generating measurements.")
+    category_names: Sequence[str] = Property(default=None,
+                                             doc="Measurement category names.")
+
+    @property
+    def ndim_state(self):
+        return self.measurement_model.ndim_state
+
+    @property
+    def ndim_meas(self):
+        return self.measurement_model.ndim_meas
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        if self.category_names and len(self.category_names) != self.ndim_meas:
+            raise ValueError(f"{len(self.category_names)} category names were given for a sensor "
+                             f"which returns vectors of length {self.ndim_meas}")
+
+    def measure(self, ground_truths: Set[GroundTruthState], **kwargs) -> Set[TrueDetection]:
+        """Generate a categorical measurement for a given categorical state.
+
+        Parameters
+        ----------
+        ground_truths : Set[:class:`~.CategoricalGroundTruthState`]
+            A set of :class:`~.CategoricalGroundTruthState`
+
+        Returns
+        -------
+        Set[:class:`~.TrueCategoricalDetection`]
+            A set of measurements generated from the given states. The timestamps of the
+            measurements are set equal to that of the corresponding states that they were
+            calculated from. Each measurement stores the ground truth path that it was produced
+            from.
+        """
+
+        detections = set()
+        for truth in ground_truths:
+
+            wrong_type = False
+            if isinstance(truth, GroundTruthPath):
+                if not isinstance(truth[-1], CategoricalState):
+                    wrong_type = True
+            elif not isinstance(truth, CategoricalState):
+                wrong_type = True
+
+            if wrong_type:
+                raise ValueError("Categorical sensor can only observe categorical states")
+
+            measurement_vector = self.measurement_model.function(truth, **kwargs)
+            detection = TrueCategoricalDetection(state_vector=measurement_vector,
+                                                 timestamp=truth.timestamp,
+                                                 measurement_model=self.measurement_model,
+                                                 groundtruth_path=truth,
+                                                 category_names=self.category_names)
+            detections.add(detection)
+
+        return detections

--- a/stonesoup/sensor/tests/test_categorical.py
+++ b/stonesoup/sensor/tests/test_categorical.py
@@ -1,0 +1,70 @@
+# -*- coding: utf-8 -*-
+import datetime
+
+import numpy as np
+import pytest
+
+from ..categorical import CategoricalSensor
+from ...models.measurement.categorical import CategoricalMeasurementModel
+from ...models.transition.tests.test_categorical import create_categorical_matrix
+from ...types.array import CovarianceMatrix
+from ...types.detection import TrueCategoricalDetection
+from ...types.groundtruth import GroundTruthState, CategoricalGroundTruthState, \
+    GroundTruthPath
+
+
+@pytest.mark.parametrize('category_names', (['red', 'green', 'blue', 'yellow'], None))
+def test_categorical_sensor(category_names):
+    # 4 measurement categories, 2 hidden categories
+    E = create_categorical_matrix(2, 4)
+    Ecov = CovarianceMatrix(np.eye(4))
+    mapping = [0, 2]
+
+    model = CategoricalMeasurementModel(ndim_state=2,
+                                        emission_matrix=E,
+                                        emission_covariance=Ecov,
+                                        mapping=mapping)
+
+    # Test category names error
+    with pytest.raises(ValueError, match="3 category names were given for a sensor which returns "
+                                         "vectors of length 4"):
+        CategoricalSensor(measurement_model=model, category_names=['red', 'green', 'blue'])
+
+    sensor = CategoricalSensor(measurement_model=model,
+                               category_names=category_names)
+
+    now = datetime.datetime.now()
+
+    # Test ndim state
+    assert sensor.ndim_state == 2
+
+    # Test ndim meas
+    assert sensor.ndim_meas == 4
+
+    # Test measuring non-categorical error
+    with pytest.raises(ValueError, match="Categorical sensor can only observe categorical states"):
+        sensor.measure({GroundTruthState([1, 2, 3], timestamp=now)})
+    with pytest.raises(ValueError, match="Categorical sensor can only observe categorical states"):
+        sensor.measure({GroundTruthPath(GroundTruthState([1, 2, 3], timestamp=now))})
+
+    # Test measure
+    truth1 = GroundTruthPath([CategoricalGroundTruthState([0.1, 0.4, 0.5], timestamp=now)])
+    truth2 = GroundTruthPath([CategoricalGroundTruthState([0.6, 0.1, 0.3], timestamp=now)])
+    truth3 = CategoricalGroundTruthState([0.1, 0.1, 0.8], timestamp=now)
+    ground_truths = {truth1, truth2, truth3}
+
+    detections = sensor.measure(ground_truths)
+
+    assert len(detections) == len(ground_truths)
+
+    for detection in detections:
+        assert isinstance(detection, TrueCategoricalDetection)
+        assert len(detection.state_vector) == 4
+        assert np.isclose(np.sum(detection.state_vector), 1)  # is normalised
+        assert detection.groundtruth_path in ground_truths
+        assert detection.timestamp == now
+        assert detection.measurement_model == model
+        if category_names:
+            assert detection.category_names == category_names
+        else:
+            assert detection.category_names == [0, 1, 2, 3]  # default category names

--- a/stonesoup/tests/test_measures.py
+++ b/stonesoup/tests/test_measures.py
@@ -1,14 +1,14 @@
 # -*- coding: utf-8 -*-
 import datetime
 
-import pytest
 import numpy as np
+import pytest
 from scipy.spatial import distance
 
 from .. import measures
-
+from ..measures import ObservationAccuracy
 from ..types.array import StateVector, CovarianceMatrix
-from ..types.state import GaussianState
+from ..types.state import GaussianState, State
 
 # Create a time stamp to use for both states
 t = datetime.datetime.now()
@@ -55,6 +55,23 @@ def test_hellinger():
     state_v = GaussianState(v, vi, timestamp=t)
     measure = measures.GaussianHellinger()
     assert np.isclose(measure(state_u, state_v), 0.940, atol=1e-3)
+
+
+def test_observation_accuracy():
+    measure = ObservationAccuracy()
+    for _ in range(5):
+        TP = np.random.random()
+        TN = 1 - TP
+        FP = np.random.random()
+        FN = 1 - FP
+
+        u = StateVector([TP, TN])
+        v = StateVector([FP, FN])
+        U = State(u)
+        V = State(v)
+
+        assert measure(u, v) == (min([TP, FP]) + min(TN, FN)) / (max([TP, FP]) + max(TN, FN))
+        assert measure(U, V) == (min([TP, FP]) + min(TN, FN)) / (max([TP, FP]) + max(TN, FN))
 
 
 @pytest.mark.xfail(reason="Singular Matrix with all zero covariances.")

--- a/stonesoup/types/detection.py
+++ b/stonesoup/types/detection.py
@@ -1,9 +1,10 @@
 # -*- coding: utf-8 -*-
 from typing import MutableMapping
 
-from ..base import Property
 from .groundtruth import GroundTruthPath
+from .state import CategoricalState
 from .state import State, GaussianState, StateVector
+from ..base import Property
 from ..models.measurement import MeasurementModel
 
 
@@ -60,3 +61,11 @@ class MissedDetection(Detection):
 
     def __bool__(self):
         return False
+
+
+class CategoricalDetection(Detection, CategoricalState):
+    """Categorical detection type."""
+
+
+class TrueCategoricalDetection(TrueDetection, CategoricalDetection):
+    """TrueCategoricalDetection type for categorical detections that come from ground truth."""

--- a/stonesoup/types/groundtruth.py
+++ b/stonesoup/types/groundtruth.py
@@ -2,8 +2,8 @@
 import uuid
 from typing import MutableSequence, MutableMapping
 
+from .state import State, StateMutableSequence, CategoricalState
 from ..base import Property
-from .state import State, StateMutableSequence
 
 
 class GroundTruthState(State):
@@ -15,6 +15,10 @@ class GroundTruthState(State):
         super().__init__(state_vector, *args, **kwargs)
         if self.metadata is None:
             self.metadata = {}
+
+
+class CategoricalGroundTruthState(GroundTruthState, CategoricalState):
+    """Categorical Ground Truth State type"""
 
 
 class GroundTruthPath(StateMutableSequence):

--- a/stonesoup/types/hypothesis.py
+++ b/stonesoup/types/hypothesis.py
@@ -2,12 +2,13 @@
 
 from abc import abstractmethod
 from collections import UserDict
+
 import numpy as np
 
 from .base import Type
-from ..base import Property
 from .detection import Detection, MissedDetection
 from .prediction import MeasurementPrediction, Prediction
+from ..base import Property
 from ..types.numeric import Probability
 
 
@@ -23,6 +24,30 @@ class Hypothesis(Type):
     single Track and multiple Measurements of which one *might* be associated
     with it
     """
+
+
+class ProbabilityHypothesis(Hypothesis):
+    probability: Probability = Property(
+        doc="Probability that detection is true location of prediction")
+
+    def __lt__(self, other):
+        return self.probability < other.probability
+
+    def __le__(self, other):
+        return self.probability <= other.probability
+
+    def __eq__(self, other):
+        return self.probability == other.probability
+
+    def __gt__(self, other):
+        return self.probability > other.probability
+
+    def __ge__(self, other):
+        return self.probability >= other.probability
+
+    @property
+    def weight(self):
+        return self.probability
 
 
 class SingleHypothesis(Hypothesis):
@@ -73,38 +98,14 @@ class SingleDistanceHypothesis(SingleHypothesis):
             return float('inf')
 
 
-class SingleProbabilityHypothesis(SingleHypothesis):
-    """Single Measurement Probability scored hypothesis subclass.
-
-    """
-
-    probability: Probability = Property(
-        doc="Probability that detection is true location of prediction")
-
-    def __lt__(self, other):
-        return self.probability < other.probability
-
-    def __le__(self, other):
-        return self.probability <= other.probability
-
-    def __eq__(self, other):
-        return self.probability == other.probability
-
-    def __gt__(self, other):
-        return self.probability > other.probability
-
-    def __ge__(self, other):
-        return self.probability >= other.probability
-
-    @property
-    def weight(self):
-        return self.probability
+class SingleProbabilityHypothesis(ProbabilityHypothesis, SingleHypothesis):
+    """Single Measurement Probability scored hypothesis subclass."""
 
 
 class JointHypothesis(Type, UserDict):
     """Joint Hypothesis base type
 
-    A Joint Hypothesis consists of multiple Hypothesese, each with a single
+    A Joint Hypothesis consists of multiple Hypotheses, each with a single
     Track and a single Prediction.  A Joint Hypothesis can be a
     'ProbabilityJointHypothesis' or a 'DistanceJointHypothesis', with a
     probability or distance that is a function of the Hypothesis
@@ -154,17 +155,19 @@ class JointHypothesis(Type, UserDict):
         raise NotImplementedError
 
 
-class ProbabilityJointHypothesis(JointHypothesis):
-    """Probability-scored Joint Hypothesis subclass.
+class ProbabilityJointHypothesis(ProbabilityHypothesis, JointHypothesis):
+    """Probability-scored Joint Hypothesis subclass."""
 
-    """
+    probability: Probability = Property(
+        default=None,
+        doc="Probability that detection is true location of prediction. Defaults to `None`, "
+            "whereby the probability is calculated as being the product of the constituent "
+            "multiple-hypotheses' probabilities.")
 
-    probability: Probability = Property(default=None, doc='Probability of the Joint Hypothesis')
-
-    def __init__(self, hypotheses, *args, **kwargs):
-        super().__init__(hypotheses, *args, **kwargs)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         self.probability = Probability(np.prod(
-            [hypothesis.probability for hypothesis in hypotheses.values()]))
+            [hypothesis.probability for hypothesis in self.hypotheses.values()]))
 
     def normalise(self):
         sum_probability = Probability.sum(
@@ -172,24 +175,8 @@ class ProbabilityJointHypothesis(JointHypothesis):
         for hypothesis in self.hypotheses.values():
             hypothesis.probability /= sum_probability
 
-    def __lt__(self, other):
-        return self.probability < other.probability
 
-    def __le__(self, other):
-        return self.probability <= other.probability
-
-    def __eq__(self, other):
-        return self.probability == other.probability
-
-    def __gt__(self, other):
-        return self.probability > other.probability
-
-    def __ge__(self, other):
-        return self.probability >= other.probability
-
-
-class DistanceJointHypothesis(
-   JointHypothesis):
+class DistanceJointHypothesis(JointHypothesis):
     """Distance scored Joint Hypothesis subclass.
 
     Notes

--- a/stonesoup/types/prediction.py
+++ b/stonesoup/types/prediction.py
@@ -1,11 +1,12 @@
 # -*- coding: utf-8 -*-
 from typing import Any, Union
 
-from ..base import Property
 from .array import CovarianceMatrix
 from .base import Type
 from .state import (State, GaussianState, ParticleState, SqrtGaussianState, InformationState,
-                    TaggedWeightedGaussianState, WeightedGaussianState, StateMutableSequence)
+                    TaggedWeightedGaussianState, WeightedGaussianState, StateMutableSequence,
+                    CategoricalState)
+from ..base import Property
 from ..models.transition.base import TransitionModel
 
 
@@ -172,3 +173,11 @@ class ParticleMeasurementPrediction(MeasurementPrediction, ParticleState):
 
     This is a simple Particle measurement prediction object.
     """
+
+
+class CategoricalStatePrediction(Prediction, CategoricalState):
+    """Categorical state prediction type"""
+
+
+class CategoricalMeasurementPrediction(MeasurementPrediction, CategoricalState):
+    """Categorical measurement prediction type"""

--- a/stonesoup/types/state.py
+++ b/stonesoup/types/state.py
@@ -1,16 +1,16 @@
 # -*- coding: utf-8 -*-
 import datetime
+import uuid
 from collections import abc
-from typing import MutableSequence
+from typing import MutableSequence, Sequence
 
 import numpy as np
-import uuid
 
-from ..base import Property
 from .array import StateVector, CovarianceMatrix, PrecisionMatrix
 from .base import Type
-from .particle import Particles
 from .numeric import Probability
+from .particle import Particles
+from ..base import Property
 
 
 class State(Type):
@@ -338,4 +338,50 @@ class ParticleState(Type):
         cov = np.cov(self.particles.state_vector, ddof=0, aweights=np.array(self.particles.weight))
         # Fix one dimensional covariances being returned with zero dimension
         return cov
+
+
 State.register(ParticleState)  # noqa: E305
+
+
+class CategoricalState(State):
+    r"""CategoricalState type.
+
+    State object representing an object in a categorical state space. A state vector
+    :math:`\mathbf{x}_i = P(\phi_i)` defines a categorical distribution over a finite set of
+    discrete categories :math:`\Phi = \{\phi_m|m\in\Z_{\ge0}\}`."""
+
+    category_names: Sequence[str] = Property(
+        default=None,
+        doc="Sequence of category names corresponding to each state vector component. Defaults to "
+            "a list of integers."
+    )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        # Check there is a category name for each state vector component
+        if self.category_names and len(self.category_names) != self.ndim:
+            raise ValueError(f"{len(self.category_names)} category names were given for a state "
+                             f"vector with {self.ndim} elements")
+
+        # Build default list of integers if no category names given
+        if self.category_names is None:
+            self.category_names = list(range(self.ndim))
+
+        # Check all vector elements are valid probabilities
+        if any(p < 0 or p > 1 for p in self.state_vector):
+            raise ValueError("Category probabilities must lie in the closed interval [0, 1]")
+
+        # Check vector is normalised
+        if not np.isclose(np.sum(self.state_vector), 1):
+            raise ValueError("Category probabilities must sum to 1")
+
+    def __str__(self):
+        strings = [f"P({category}) = {p}"
+                   for category, p in zip(self.category_names, self.state_vector)]
+        return f"({', '.join(strings)})"
+
+    @property
+    def category(self):
+        """Return the name of the most likely category"""
+        return self.category_names[np.argmax(self.state_vector)]

--- a/stonesoup/types/state.py
+++ b/stonesoup/types/state.py
@@ -348,7 +348,7 @@ class CategoricalState(State):
 
     State object representing an object in a categorical state space. A state vector
     :math:`\mathbf{x}_i = P(\phi_i)` defines a categorical distribution over a finite set of
-    discrete categories :math:`\Phi = \{\phi_m|m\in\Z_{\ge0}\}`."""
+    discrete categories :math:`\Phi = \{\phi_m|m\in Z_{\ge0}\}`."""
 
     category_names: Sequence[str] = Property(
         default=None,

--- a/stonesoup/types/update.py
+++ b/stonesoup/types/update.py
@@ -5,7 +5,7 @@ from ..base import Property
 from .base import Type
 from .hypothesis import Hypothesis
 from .state import State, GaussianState, ParticleState, SqrtGaussianState, StateMutableSequence, \
-    InformationState
+    InformationState, CategoricalState
 from .mixture import GaussianMixture
 
 
@@ -116,3 +116,7 @@ class InformationStateUpdate(Update, InformationState):
     This is a simple Information state update object, which, as the name
     suggests, is described by a precision matrix and its corresponding state vector.
     """
+
+
+class CategoricalStateUpdate(Update, CategoricalState):
+    """Categorical state prediction type"""

--- a/stonesoup/updater/categorical.py
+++ b/stonesoup/updater/categorical.py
@@ -72,7 +72,7 @@ class HMMUpdater(Updater):
 
         Returns
         -------
-        : :class:`MeasurementPrediction`
+        : :class:`~.MeasurementPrediction`
             The measurement prediction, :math:`Y_{k|k-1}`
         """
 

--- a/stonesoup/updater/categorical.py
+++ b/stonesoup/updater/categorical.py
@@ -1,0 +1,135 @@
+# -*- coding: utf-8 -*-
+import numpy as np
+
+from ..base import Property
+from ..models.measurement.categorical import CategoricalMeasurementModel
+from ..types.prediction import MeasurementPrediction
+from ..types.state import CategoricalState
+from ..types.update import Update
+from ..updater import Updater
+
+
+class HMMUpdater(Updater):
+    r"""Models the update step of a hidden Markov model"""
+
+    measurement_model: CategoricalMeasurementModel = Property(
+        default=None,
+        doc="An observation-based measurement model. Measurements are assumed to be as defined "
+            "above. This model need not be defined if a measurement model is provided in the "
+            "measurement. If no model specified on construction, or in the measurement, then an "
+            "error will be thrown.")
+
+    def _check_measurement_model(self, measurement_model):
+        """Check that the measurement model passed actually exists. If not attach the one in the
+        updater. If that one's not specified, return an error.
+
+        Parameters
+        ----------
+        measurement_model : :class`~.MeasurementModel`
+            A measurement model to be checked
+
+        Returns
+        -------
+        : :class`~.MeasurementModel`
+            The measurement model to be used
+        """
+
+        if measurement_model is None:
+            if self.measurement_model is None:
+                raise ValueError("No measurement model specified")
+            else:
+                measurement_model = self.measurement_model
+
+        try:
+            measurement_model.emission_matrix
+        except AttributeError:
+            raise ValueError("Measurement model must be categorical. I.E. it must have an "
+                             "Emission matrix property for the HMMUpdater")
+
+        return measurement_model
+
+    def _get_emission_matrix(self, hypothesis):
+
+        measurement_model = self._check_measurement_model(hypothesis.measurement.measurement_model)
+
+        return measurement_model.emission_matrix
+
+    def predict_measurement(self, predicted_state, measurement_model=None, category_names=None,
+                            **kwargs):
+        r"""Predict the measurement implied by the predicted state mean
+
+        Parameters
+        ----------
+        predicted_state : :class:`~.State`
+            The predicted state :math:`X_{k|k-1}`.
+        measurement_model : :class:`~.MeasurementModel`
+            The measurement model. If omitted, the model in the updater object is used.
+        category_names : :class:`list`
+            List of :class:`str` measurement category names.
+        **kwargs : various
+            These are passed to :meth:`~.MeasurementModel.function` and
+            :meth:`~.MeasurementModel.matrix`.
+
+        Returns
+        -------
+        : :class:`MeasurementPrediction`
+            The measurement prediction, :math:`Y_{k|k-1}`
+        """
+
+        measurement_model = self._check_measurement_model(measurement_model)
+
+        pred_meas = measurement_model.function(predicted_state, **kwargs)
+
+        return MeasurementPrediction.from_state(predicted_state, pred_meas,
+                                                category_names=category_names)
+
+    def update(self, hypothesis, **kwargs):
+        r"""The update method. Given a hypothesised association between a predicted state or
+        predicted measurement and an actual measurement, calculate the posterior state.
+
+        Bayes' rule: :math:`p(x_k|z_{1:k}) \propto p(z_k|x_k) p(x_k|z_{1:k-1})`. The likelihood is
+        calculated as an Nx1 vector of :math:`p(z_k|x_{k|k-1})` for the :math:`z_k` actually
+        observed.
+        This is element-wise multiplied by the prior and normalised.
+
+        Parameters
+        ----------
+        hypothesis : :class:`~.SingleHypothesis`
+            the prediction-measurement association hypothesis. This hypothesis may carry a
+            predicted measurement, or a predicted state. In the latter case a predicted
+            measurement will be calculated.
+        **kwargs : various
+            These are passed to :meth:`predict_measurement`
+
+        Returns
+        -------
+        : :class:`~.CategoricalStateUpdate`
+            The posterior categorical state
+        """
+
+        prediction = hypothesis.prediction
+
+        if not isinstance(prediction, CategoricalState):
+            raise ValueError("Prediction must be a categorical state type")
+
+        # category names to be passed to measurement prediction
+        measurement_category_names = hypothesis.measurement.category_names
+
+        if hypothesis.measurement_prediction is None:
+            measurement_model = hypothesis.measurement.measurement_model
+            measurement_model = self._check_measurement_model(measurement_model)
+
+            # Attach the measurement prediction to the hypothesis
+            hypothesis.measurement_prediction = self.predict_measurement(
+                prediction, measurement_model=measurement_model,
+                category_names=measurement_category_names, **kwargs)
+
+        emission_matrix = self._get_emission_matrix(hypothesis)
+        likelihood = emission_matrix @ hypothesis.measurement.state_vector
+
+        # Bayes rule
+        posterior = np.multiply(likelihood, hypothesis.prediction.state_vector)
+        posterior = posterior / np.sum(posterior)
+
+        return Update.from_state(hypothesis.prediction, posterior,
+                                 timestamp=hypothesis.measurement.timestamp, hypothesis=hypothesis)

--- a/stonesoup/updater/tests/test_categorical.py
+++ b/stonesoup/updater/tests/test_categorical.py
@@ -1,0 +1,98 @@
+# coding: utf-8
+import datetime
+
+import numpy as np
+import pytest
+
+from ...models.measurement.categorical import CategoricalMeasurementModel
+from ...models.measurement.linear import LinearGaussian
+from ...models.transition.tests.test_categorical import create_categorical, \
+    create_categorical_matrix
+from ...types.detection import CategoricalDetection
+from ...types.hypothesis import SingleHypothesis
+from ...types.prediction import CategoricalMeasurementPrediction
+from ...types.state import CategoricalState, GaussianState
+from ...types.update import CategoricalStateUpdate
+from ...updater.categorical import HMMUpdater
+
+
+@pytest.mark.parametrize('ndim_state', (2, 3, 4))
+@pytest.mark.parametrize('ndim_meas', (2, 3, 4))
+def test_classification_updater(ndim_state, ndim_meas):
+    now = datetime.datetime.now()
+    future = now + datetime.timedelta(seconds=5)
+
+    E = create_categorical_matrix(ndim_state, ndim_meas)
+    Ecov = 0.1 * np.eye(ndim_meas)
+    measurement_model = CategoricalMeasurementModel(ndim_state=ndim_state,
+                                                    emission_matrix=E,
+                                                    emission_covariance=Ecov)
+
+    prediction = CategoricalState(create_categorical(ndim_state))
+    prediction.timestamp = future
+
+    updater = HMMUpdater(measurement_model)
+    empty_updater = HMMUpdater()
+    wrong_updater = HMMUpdater(LinearGaussian(ndim_state=ndim_state,
+                                              mapping=[0, 1],
+                                              noise_covar=np.eye(ndim_state)))
+
+    # Test measurement prediction
+    eval_measurement_prediction = measurement_model.function(prediction)
+    measurement_prediction = updater.predict_measurement(prediction)
+    assert isinstance(measurement_prediction, CategoricalMeasurementPrediction)
+    assert (np.allclose(measurement_prediction.state_vector,
+                        eval_measurement_prediction,
+                        0,
+                        atol=1.e-14))
+
+    E = measurement_model.emission_matrix
+    measurement = measurement_model.function(CategoricalState(create_categorical(E.shape[0])))
+    hypothesis = SingleHypothesis(
+        prediction=prediction,
+        measurement=CategoricalDetection(measurement, timestamp=future,
+                                         measurement_model=measurement_model)
+    )
+
+    # Test get emission matrix
+    assert (updater._get_emission_matrix(hypothesis) == E).all()
+
+    # Test update with and without measurement prediction
+    for meas_pred in [None, measurement_prediction]:
+        hypothesis.measurement_prediction = meas_pred
+        eval_posterior = np.multiply(prediction.state_vector, E @ measurement)
+        eval_posterior = eval_posterior / np.sum(eval_posterior)
+        posterior = updater.update(hypothesis)
+
+        assert isinstance(posterior, CategoricalStateUpdate)
+        assert posterior.category_names == prediction.category_names
+        assert (np.allclose(posterior.state_vector, eval_posterior, 0, atol=1.e-14))
+        assert posterior.timestamp == prediction.timestamp
+
+        # Assert presence of measurement
+        assert hasattr(posterior, 'hypothesis')
+        assert posterior.hypothesis == hypothesis
+
+    # Test measurement model error
+    empty_hypothesis = SingleHypothesis(
+        prediction=prediction,
+        measurement=CategoricalDetection(measurement, timestamp=future)
+    )
+
+    with pytest.raises(ValueError,
+                       match="No measurement model specified"):
+        empty_updater.update(empty_hypothesis)
+    with pytest.raises(ValueError,
+                       match="Measurement model must be categorical. I.E. it must have an "
+                             "Emission matrix property for the HMMUpdater"):
+        wrong_updater.update(empty_hypothesis)
+
+    # Test non-categorical prediction
+
+    bad_hypothesis = SingleHypothesis(
+        prediction=GaussianState(create_categorical(ndim_state), np.eye(ndim_state)),
+        measurement=CategoricalDetection(measurement, timestamp=future)
+    )
+
+    with pytest.raises(ValueError, match="Prediction must be a categorical state type"):
+        updater.update(bad_hypothesis)


### PR DESCRIPTION
Successive indirect observations of a target's hidden class are taken in order to attain a categorical distribution over a (discrete) set of possible hidden classes.

This branch introduces the 'categorical' components originally added in #460.

An example has been added to demonstrate use of the introduced components.