### PR TITLE
Pass 1d-arrays to scipy.distance

### DIFF
--- a/stonesoup/measures.py
+++ b/stonesoup/measures.py
@@ -82,10 +82,10 @@ class Euclidean(Measure):
         """
         # Calculate Euclidean distance between two state
         if self.mapping is not None:
-            return distance.euclidean(state1.state_vector[self.mapping, :],
-                                      state2.state_vector[self.mapping2, :])
+            return distance.euclidean(state1.state_vector[self.mapping, 0],
+                                      state2.state_vector[self.mapping2, 0])
         else:
-            return distance.euclidean(state1.state_vector, state2.state_vector)
+            return distance.euclidean(state1.state_vector[:, 0], state2.state_vector[:, 0])
 
 
 class EuclideanWeighted(Measure):
@@ -127,12 +127,12 @@ class EuclideanWeighted(Measure):
 
         """
         if self.mapping is not None:
-            return distance.euclidean(state1.state_vector[self.mapping, :],
-                                      state2.state_vector[self.mapping2, :],
+            return distance.euclidean(state1.state_vector[self.mapping, 0],
+                                      state2.state_vector[self.mapping2, 0],
                                       self.weighting)
         else:
-            return distance.euclidean(state1.state_vector,
-                                      state2.state_vector,
+            return distance.euclidean(state1.state_vector[:, 0],
+                                      state2.state_vector[:, 0],
                                       self.weighting)
 
 
@@ -167,15 +167,15 @@ class Mahalanobis(Measure):
 
         """
         if self.mapping is not None:
-            u = state1.state_vector[self.mapping, :]
-            v = state2.state_vector[self.mapping2, :]
+            u = state1.state_vector[self.mapping, 0]
+            v = state2.state_vector[self.mapping2, 0]
             # extract the mapped covariance data
             rows = np.array(self.mapping, dtype=np.intp)
             columns = np.array(self.mapping, dtype=np.intp)
             cov = state1.covar[rows[:, np.newaxis], columns]
         else:
-            u = state1.state_vector
-            v = state2.state_vector
+            u = state1.state_vector[:, 0]
+            v = state2.state_vector[:, 0]
             cov = state1.covar
 
         vi = np.linalg.inv(cov)

--- a/stonesoup/metricgenerator/tests/test_tracktotruthmetrics.py
+++ b/stonesoup/metricgenerator/tests/test_tracktotruthmetrics.py
@@ -140,7 +140,7 @@ def test_assoc_distances_sum_t(generator, mapping):
         distance_sum = generator._assoc_distances_sum_t(manager,
                                                         tstart + datetime.timedelta(seconds=i),
                                                         getattr(generator, mapping),
-                                                        1)
+                                                        None)
         assert distance_sum == 1
 
     associations = {assoc1, assoc2}
@@ -150,7 +150,7 @@ def test_assoc_distances_sum_t(generator, mapping):
         distance_sum = generator._assoc_distances_sum_t(manager,
                                                         tstart + datetime.timedelta(seconds=i),
                                                         getattr(generator, mapping),
-                                                        1)
+                                                        None)
         assert distance_sum == 2
 
 
@@ -197,7 +197,7 @@ def test_assoc_distances_sum_t_2maps(generator, mapping, mapping2):
         distance_sum = generator._assoc_distances_sum_t(manager,
                                                         tstart + datetime.timedelta(seconds=i),
                                                         getattr(generator, mapping),
-                                                        1,
+                                                        None,
                                                         getattr(generator, mapping2))
         assert distance_sum == 1
 
@@ -208,7 +208,7 @@ def test_assoc_distances_sum_t_2maps(generator, mapping, mapping2):
         distance_sum = generator._assoc_distances_sum_t(manager,
                                                         tstart + datetime.timedelta(seconds=i),
                                                         getattr(generator, mapping),
-                                                        1,
+                                                        None,
                                                         getattr(generator, mapping2))
         assert distance_sum == 2
 
@@ -773,7 +773,7 @@ def test_compute_metric(generator):
            sum(generator._assoc_distances_sum_t(manager,
                                                 timestamp,
                                                 generator.position_mapping,
-                                                1,
+                                                None,
                                                 generator.position_mapping2)
                for timestamp in manager.list_timestamps()) \
            / generator._na_sum(manager, manager.list_timestamps())
@@ -790,7 +790,7 @@ def test_compute_metric(generator):
         numerator = generator._assoc_distances_sum_t(manager,
                                                      timestamp,
                                                      generator.position_mapping,
-                                                     1,
+                                                     None,
                                                      generator.position_mapping2)
         if generator._na_t(manager, timestamp) != 0:
             assert t_metric.value == numerator / generator._na_t(manager, timestamp)
@@ -807,7 +807,7 @@ def test_compute_metric(generator):
     numerator = sum(generator._assoc_distances_sum_t(manager,
                                                      timestamp,
                                                      generator.velocity_mapping,
-                                                     1,
+                                                     None,
                                                      generator.velocity_mapping2)
                     for timestamp in manager.list_timestamps())
     assert va.value == numerator / generator._na_sum(manager, manager.list_timestamps())
@@ -824,7 +824,7 @@ def test_compute_metric(generator):
         numerator = generator._assoc_distances_sum_t(manager,
                                                      timestamp,
                                                      generator.velocity_mapping,
-                                                     1,
+                                                     None,
                                                      generator.velocity_mapping2)
         if generator._na_t(manager, timestamp) != 0:
             assert t_metric.value == numerator / generator._na_t(manager, timestamp)

--- a/stonesoup/mixturereducer/gaussianmixture.py
+++ b/stonesoup/mixturereducer/gaussianmixture.py
@@ -162,7 +162,7 @@ class GaussianMixtureReducer(MixtureReducer):
             for component in remaining_components.copy():
                 # Calculate distance between component and best component
                 distance = dist.mahalanobis(
-                    best_component.mean, component.mean, best_component.covar)
+                    best_component.mean[:, 0], component.mean[:, 0], best_component.covar)
                 # Merge if similar
                 if distance < self.merge_threshold:
                     remaining_components.remove(component)

--- a/stonesoup/tests/test_measures.py
+++ b/stonesoup/tests/test_measures.py
@@ -34,19 +34,19 @@ def test_measure_raise_error():
 def test_euclidean():
 
     measure = measures.Euclidean()
-    assert measure(state_u, state_v) == distance.euclidean(u, v)
+    assert measure(state_u, state_v) == distance.euclidean(u[:, 0], v[:, 0])
 
 
 def test_euclideanweighted():
-    weight = np.array([[1], [2], [3], [1]])
+    weight = np.array([1, 2, 3, 1])
     measure = measures.EuclideanWeighted(weight)
-    assert measure(state_u, state_v) == distance.euclidean(u, v, weight)
+    assert measure(state_u, state_v) == distance.euclidean(u[:, 0], v[:, 0], weight)
 
 
 def test_mahalanobis():
     measure = measures.Mahalanobis()
-    assert measure(state_u, state_v) == distance.mahalanobis(u,
-                                                             v,
+    assert measure(state_u, state_v) == distance.mahalanobis(u[:, 0],
+                                                             v[:, 0],
                                                              np.linalg.inv(ui))
 
 
@@ -121,12 +121,12 @@ def test_hellinger_partial_mapping(mapping_type):
 def test_mahalanobis_full_mapping(mapping_type):
     mapping = mapping_type(np.arange(len(u)))
     measure = measures.Mahalanobis(mapping=mapping)
-    assert measure(state_u, state_v) == distance.mahalanobis(u,
-                                                             v,
+    assert measure(state_u, state_v) == distance.mahalanobis(u[:, 0],
+                                                             v[:, 0],
                                                              np.linalg.inv(ui))
     measure = measures.Mahalanobis(mapping=mapping, mapping2=mapping)
-    assert measure(state_u, state_v) == distance.mahalanobis(u,
-                                                             v,
+    assert measure(state_u, state_v) == distance.mahalanobis(u[:, 0],
+                                                             v[:, 0],
                                                              np.linalg.inv(ui))
 
 
@@ -135,99 +135,99 @@ def test_mahalanobis_partial_mapping(mapping_type):
     measure = measures.Mahalanobis(mapping=mapping)
     reduced_ui = CovarianceMatrix(np.diag([100, 10]))
     assert measure(state_u, state_v) == \
-        distance.mahalanobis([[10], [1]],
-                             [[11], [10]], np.linalg.inv(reduced_ui))
+        distance.mahalanobis([10, 1],
+                             [11, 10], np.linalg.inv(reduced_ui))
     mapping = np.array([0, 3])
     reduced_ui = CovarianceMatrix(np.diag([100, 10]))
     measure = measures.Mahalanobis(mapping=mapping)
     assert measure(state_u, state_v) == \
-        distance.mahalanobis([[10], [1]],
-                             [[11], [2]], np.linalg.inv(reduced_ui))
+        distance.mahalanobis([10, 1],
+                             [11, 2], np.linalg.inv(reduced_ui))
 
     mapping = mapping_type([0, 1])
     measure = measures.Mahalanobis(mapping=mapping, mapping2=mapping)
     assert measure(state_u, state_v) == \
-        distance.mahalanobis([[10], [1]],
-                             [[11], [10]], np.linalg.inv(reduced_ui))
+        distance.mahalanobis([10, 1],
+                             [11, 10], np.linalg.inv(reduced_ui))
     mapping = np.array([0, 3])
     measure = measures.Mahalanobis(mapping=mapping, mapping2=mapping)
     assert measure(state_u, state_v) == \
-        distance.mahalanobis([[10], [1]],
-                             [[11], [2]], np.linalg.inv(reduced_ui))
+        distance.mahalanobis([10, 1],
+                             [11, 2], np.linalg.inv(reduced_ui))
 
     mapping = mapping_type([0, 1])
     mapping2 = np.array([0, 3])
     measure = measures.Mahalanobis(mapping=mapping, mapping2=mapping2)
     assert measure(state_u, state_v) == \
-        distance.mahalanobis([[10], [1]],
-                             [[11], [2]], np.linalg.inv(reduced_ui))
+        distance.mahalanobis([10, 1],
+                             [11, 2], np.linalg.inv(reduced_ui))
 
 
 def test_euclidean_full_mapping(mapping_type):
     mapping = mapping_type(np.arange(len(u)))
     measure = measures.Euclidean(mapping=mapping)
-    assert measure(state_u, state_v) == distance.euclidean(u, v)
+    assert measure(state_u, state_v) == distance.euclidean(u[:, 0], v[:, 0])
     measure = measures.Euclidean(mapping=mapping, mapping2=mapping)
-    assert measure(state_u, state_v) == distance.euclidean(u, v)
+    assert measure(state_u, state_v) == distance.euclidean(u[:, 0], v[:, 0])
 
 
 def test_euclidean_partial_mapping(mapping_type):
     mapping = mapping_type([0, 1])
     measure = measures.Euclidean(mapping=mapping)
     assert measure(state_u, state_v) == \
-        distance.euclidean([[10], [1]], [[11], [10]])
+        distance.euclidean([10, 1], [11, 10])
     mapping = np.array([0, 3])
     measure = measures.Euclidean(mapping=mapping)
     assert measure(state_u, state_v) == \
-        distance.euclidean([[10], [1]], [[11], [2]])
+        distance.euclidean([10, 1], [11, 2])
 
     mapping = mapping_type([0, 1])
     measure = measures.Euclidean(mapping=mapping, mapping2=mapping)
     assert measure(state_u, state_v) == \
-        distance.euclidean([[10], [1]], [[11], [10]])
+        distance.euclidean([10, 1], [11, 10])
     mapping = np.array([0, 3])
     measure = measures.Euclidean(mapping=mapping, mapping2=mapping)
     assert measure(state_u, state_v) == \
-        distance.euclidean([[10], [1]], [[11], [2]])
+        distance.euclidean([10, 1], [11, 2])
 
     mapping = mapping_type([0, 1])
     mapping2 = np.array([0, 3])
     measure = measures.Euclidean(mapping=mapping, mapping2=mapping2)
     assert measure(state_u, state_v) == \
-        distance.euclidean([[10], [1]], [[11], [2]])
+        distance.euclidean([10, 1], [11, 2])
 
 
 def test_euclideanweighted_full_mapping(mapping_type):
     mapping = mapping_type(np.arange(len(u)))
-    weight = np.array([[1], [2], [3], [1]])
+    weight = np.array([1, 2, 3, 1])
     measure = measures.EuclideanWeighted(weight, mapping=mapping)
-    assert measure(state_u, state_v) == distance.euclidean(u, v, weight)
+    assert measure(state_u, state_v) == distance.euclidean(u[:, 0], v[:, 0], weight)
     measure = measures.EuclideanWeighted(weight, mapping=mapping, mapping2=mapping)
-    assert measure(state_u, state_v) == distance.euclidean(u, v, weight)
+    assert measure(state_u, state_v) == distance.euclidean(u[:, 0], v[:, 0], weight)
 
 
 def test_euclideanweighted_partial_mapping(mapping_type):
     mapping = mapping_type([0, 1])
-    weight = np.array([[1], [2]])
+    weight = np.array([1, 2])
     measure = measures.EuclideanWeighted(weight, mapping=mapping)
     assert measure(state_u, state_v) == \
-        distance.euclidean([[10], [1]], [[11], [10]], weight)
+        distance.euclidean([10, 1], [11, 10], weight)
     mapping = np.array([0, 3])
     measure = measures.EuclideanWeighted(weight, mapping=mapping)
     assert measure(state_u, state_v) == \
-        distance.euclidean([[10], [1]], [[11], [2]], weight)
+        distance.euclidean([10, 1], [11, 2], weight)
 
     mapping = mapping_type([0, 1])
     measure = measures.EuclideanWeighted(weight, mapping=mapping, mapping2=mapping)
     assert measure(state_u, state_v) == \
-        distance.euclidean([[10], [1]], [[11], [10]], weight)
+        distance.euclidean([10, 1], [11, 10], weight)
     mapping = np.array([0, 3])
     measure = measures.EuclideanWeighted(weight, mapping=mapping, mapping2=mapping)
     assert measure(state_u, state_v) == \
-        distance.euclidean([[10], [1]], [[11], [2]], weight)
+        distance.euclidean([10, 1], [11, 2], weight)
 
     mapping = np.array([0, 1])
     mapping2 = np.array([0, 3])
     measure = measures.EuclideanWeighted(weight, mapping=mapping, mapping2=mapping2)
     assert measure(state_u, state_v) == \
-        distance.euclidean([[10], [1]], [[11], [2]], weight)
+        distance.euclidean([10, 1], [11, 2], weight)


### PR DESCRIPTION
Squeezing arrays inside the `scipy.distance` functions has been deprecated in SciPy 1.7, and will raise error from SciPy 1.9