### PR TITLE
Add metadatas limit to StatesLengthLimiter

### DIFF
--- a/stonesoup/initiator/tests/test_wrapper.py
+++ b/stonesoup/initiator/tests/test_wrapper.py
@@ -24,7 +24,8 @@ def test_states_length_limiter(max_len):
     measurements = []
     for i in range(10):
         measurements.append(Detection(np.array([[i*2.0]]),
-                                      timestamp=start_time+timedelta(seconds=i*100)))
+                                      timestamp=start_time+timedelta(seconds=i*100),
+                                      metadata={"colour": np.random.choice(["red", "blue"])}))
 
     # Tracking components
     # ===================
@@ -60,3 +61,4 @@ def test_states_length_limiter(max_len):
         assert len(track) <= max_len
 
     assert len(track) == max_len
+    assert len(track.metadatas) == max_len

--- a/stonesoup/initiator/wrapper.py
+++ b/stonesoup/initiator/wrapper.py
@@ -27,4 +27,5 @@ class StatesLengthLimiter(Initiator):
         tracks = self.initiator.initiate(*args, **kwargs)
         for track in tracks:
             track.states = collections.deque(track.states, self.max_length)
+            track.metadatas = collections.deque(track.metadatas, self.max_length)
         return tracks


### PR DESCRIPTION
To address #540 , the StatesLengthLimiter initiator wrapper now modifies a track's `metadatas` property to be a deque object, and limits the length to the same limit as the track's `states`.