### PR TITLE
Add cache version environment variable to CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: v3-dependencies-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}
+          key: dependencies-{{ .Environment.CACHE_VERSION }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}
       - run:
           name: Install Dependencies
           command: |
@@ -29,7 +29,7 @@ jobs:
       - save_cache:
           paths:
             - ./venv
-          key: v3-dependencies-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}
+          key: dependencies-{{ .Environment.CACHE_VERSION }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}
       - run:
           name: Run Tests
           command: |
@@ -69,7 +69,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: v3-dependencies-test-310-{{ checksum "setup.py" }}
+          key: dependencies-{{ .Environment.CACHE_VERSION }}-test-310-{{ checksum "setup.py" }}
       - run:
           name: Install Dependencies
           command: |
@@ -80,7 +80,7 @@ jobs:
       - save_cache:
           paths:
             - ./venv
-          key: v3-dependencies-test-310-{{ checksum "setup.py" }}
+          key: dependencies-{{ .Environment.CACHE_VERSION }}-test-310-{{ checksum "setup.py" }}
       - run:
           name: Build Docs
           command: |


### PR DESCRIPTION
This allows more flexibility to clear cache of dependencies in case of any build issues, or cache corruption.