### PR TITLE
Add method to copy prior state properties of a platform across to a new state

### DIFF
--- a/stonesoup/movable/movable.py
+++ b/stonesoup/movable/movable.py
@@ -2,7 +2,7 @@
 import datetime
 from abc import abstractmethod, ABC
 from functools import lru_cache
-from typing import Sequence, Tuple, Any
+from typing import Sequence, Tuple, MutableSequence, Optional
 
 import numpy as np
 from math import cos, sin
@@ -16,7 +16,7 @@ from stonesoup.types.state import State, StateMutableSequence
 
 
 class Movable(StateMutableSequence, ABC):
-    states: Sequence[State] = Property(
+    states: MutableSequence[State] = Property(
         doc="A list of States which enables the platform's history to be "
             "accessed in simulators and for plotting. Initiated as a "
             "state, for a static platform, this would usually contain its "
@@ -27,7 +27,7 @@ class Movable(StateMutableSequence, ABC):
         doc="Mapping between platform position and state vector. For a "
             "position-only 3d platform this might be ``[0, 1, 2]``. For a "
             "position and velocity platform: ``[0, 2, 4]``")
-    velocity_mapping: Sequence[int] = Property(
+    velocity_mapping: Optional[Sequence[int]] = Property(
         default=None,
         doc="Mapping between platform velocity and state dims. If not "
             "set, it will default to ``[m+1 for m in position_mapping]``")
@@ -46,45 +46,6 @@ class Movable(StateMutableSequence, ABC):
             self.velocity_mapping = [p + 1 for p in self.position_mapping]
         if not self.states:
             raise ValueError('States must not be empty: it must contain least one state.')
-
-    @staticmethod
-    def from_state(state: State, *args: Any, **kwargs: Any) -> State:
-        """Class utility function to create a new state. The type and properties of this new state
-        are defined by `state`. Specific properties can be overwritten via `args` and `kwargs`.
-
-        This method was introduced to combat the need for deep copies in platform `move` methods,
-        and to allow platforms to use different state types, such as :class:`~.GroundTruthState`,
-        whereby the state metadata will be carried forward at each call to :meth:`move`.
-        The process here is similar to that of the :class:`~.Prediction` and :class:`~.Update`
-        `from_state` methods.
-
-        Parameters
-        ----------
-        state: State
-            :class:`~.State` to use existing properties from, and identify new state-type from.
-        \\*args: Sequence
-            Arguments to pass to newly created state, replacing those with same name in `state`.
-        \\*\\*kwargs: Mapping
-            New property names and associate value for use in newly created state, replacing those
-            on the `state` parameter.
-        """
-        # Handle being initialised with state sequence
-        if isinstance(state, StateMutableSequence):
-            state = state.state
-
-        state_type = type(state)
-
-        args_property_names = {
-            name for n, name in enumerate(state_type.properties) if n < len(args)}
-
-        new_kwargs = {
-            name: getattr(state, name)
-            for name in state_type.properties.keys()
-            if name not in args_property_names}
-
-        new_kwargs.update(kwargs)
-
-        return state_type(*args, **new_kwargs)
 
     @property
     def position(self) -> StateVector:
@@ -259,7 +220,7 @@ class FixedMovable(Movable):
 
     def move(self, timestamp: datetime.datetime, **kwargs) -> None:
         """For a fixed platform this method has no effect other than to update the timestamp."""
-        new_state = self.from_state(self.state, timestamp=timestamp)
+        new_state = State.from_state(self.state, timestamp=timestamp)
         self.states.append(new_state)
 
 
@@ -379,7 +340,7 @@ class MovingMovable(Movable):
                                                       timestamp=timestamp,
                                                       time_interval=time_interval,
                                                       **kwargs)
-        new_state = self.from_state(self.state, state_vector=state_vector, timestamp=timestamp)
+        new_state = State.from_state(self.state, state_vector=state_vector, timestamp=timestamp)
         self.states.append(new_state)
 
 
@@ -451,9 +412,9 @@ class MultiTransitionMovable(MovingMovable):
                     time_interval=self.current_interval,
                     **kwargs
                 )
-                temp_state = self.from_state(self.state,
-                                             state_vector=temp_state_vector,
-                                             timestamp=timestamp)
+                temp_state = State.from_state(self.state,
+                                              state_vector=temp_state_vector,
+                                              timestamp=timestamp)
 
                 time_interval -= self.current_interval
                 self.transition_index = (self.transition_index + 1) % len(self.transition_models)
@@ -466,9 +427,9 @@ class MultiTransitionMovable(MovingMovable):
                     time_interval=time_interval,
                     **kwargs
                 )
-                temp_state = self.from_state(self.state,
-                                             state_vector=temp_state_vector,
-                                             timestamp=timestamp)
+                temp_state = State.from_state(self.state,
+                                              state_vector=temp_state_vector,
+                                              timestamp=timestamp)
                 self.current_interval -= time_interval
                 break
         self.states.append(temp_state)

--- a/stonesoup/movable/tests/test_movable.py
+++ b/stonesoup/movable/tests/test_movable.py
@@ -1,13 +1,14 @@
 from datetime import datetime, timedelta
 
-import pytest
 import numpy as np
+import pytest
 
 from stonesoup.models.transition.linear import ConstantVelocity, ConstantTurn, \
     CombinedLinearGaussianTransitionModel
-from stonesoup.movable import MovingMovable, FixedMovable, MultiTransitionMovable
+from stonesoup.movable import Movable, MovingMovable, FixedMovable, MultiTransitionMovable
 from stonesoup.types.array import StateVector
-from stonesoup.types.state import State
+from stonesoup.types.groundtruth import GroundTruthState
+from stonesoup.types.state import State, GaussianState
 
 
 def test_fixed_movable_velocity_mapping_error():
@@ -46,7 +47,7 @@ def test_empty_state_error():
 
 def test_multi_transition_movable_errors():
     # First check no error
-    models = [ConstantVelocity(0), ConstantTurn(0, np.pi/2)]
+    models = [ConstantVelocity(0), ConstantTurn(0, np.pi / 2)]
     now = datetime.now()
     times = [timedelta(seconds=10), timedelta(seconds=10)]
     _ = MultiTransitionMovable(states=State(StateVector([0, 0, 0, 0, 0, 0])),
@@ -104,3 +105,99 @@ def test_multi_transition_movable_move():
     movable.move(now + timedelta(seconds=10))
     assert movable.state.state_vector is not input_state_vector
     assert movable.state.timestamp is not now
+
+
+def test_from_state():
+    start = datetime.now()
+    kwargs = {"state_vector": np.arange(4), "timestamp": start}
+
+    states = [
+        State(**kwargs),
+        GaussianState(**kwargs, covar=np.eye(4)),
+        GroundTruthState(**kwargs, metadata={"colour": "blue"})
+    ]
+
+    for state in states:
+
+        # test replacement arg
+        new_state = Movable.from_state(state, np.ones(4))
+        assert isinstance(new_state, type(state))
+        assert np.array_equal(new_state.state_vector.flatten(), np.ones(4))
+        assert new_state.timestamp == start
+        if isinstance(state, GaussianState):
+            assert np.array_equal(new_state.covar, state.covar)
+        elif isinstance(state, GroundTruthState):
+            assert new_state.metadata == state.metadata
+
+        # test replacement kwarg
+        new_time = start + timedelta(seconds=5)
+        new_state = Movable.from_state(state, timestamp=new_time)
+        assert isinstance(new_state, type(state))
+        assert np.array_equal(new_state.state_vector, state.state_vector)
+        assert new_state.timestamp == new_time
+        if isinstance(state, GaussianState):
+            assert np.array_equal(new_state.covar, state.covar)
+        elif isinstance(state, GroundTruthState):
+            assert new_state.metadata == state.metadata
+
+        # test replacement arg and kwarg
+        new_time = start + timedelta(seconds=5)
+        new_state = Movable.from_state(state, np.ones(4), timestamp=new_time)
+        assert isinstance(new_state, type(state))
+        assert np.array_equal(new_state.state_vector.flatten(), np.ones(4))
+        assert new_state.timestamp == new_time
+        if isinstance(state, GaussianState):
+            assert np.array_equal(new_state.covar, state.covar)
+        elif isinstance(state, GroundTruthState):
+            assert new_state.metadata == state.metadata
+
+    # test covar overwrite
+    new_state = Movable.from_state(states[1], covar=2 * np.eye(4))
+    assert isinstance(new_state, type(states[1]))
+    assert np.array_equal(new_state.state_vector, states[1].state_vector)
+    assert new_state.timestamp == states[1].timestamp
+    assert np.array_equal(new_state.covar, 2 * np.eye(4))
+
+    # test metadata overwrite
+    new_metadata = {"size": "big"}
+    new_state = Movable.from_state(states[2], metadata=new_metadata)
+    assert isinstance(new_state, type(states[2]))
+    assert np.array_equal(new_state.state_vector, states[2].state_vector)
+    assert new_state.timestamp == states[2].timestamp
+    assert new_state.metadata == new_metadata
+
+
+def test_preserved_state():
+    state_vector = np.zeros(4)
+    start = datetime.now()
+    states = [
+        State(state_vector=state_vector, timestamp=start),
+        GaussianState(state_vector=state_vector, timestamp=start, covar=np.eye(4)),
+        GroundTruthState(state_vector=state_vector, timestamp=start,
+                         metadata={"colour": "blue"})
+    ]
+
+    transition_model = CombinedLinearGaussianTransitionModel([ConstantVelocity(0.1),
+                                                              ConstantVelocity(0.1)])
+
+    for state in states:
+        movables = [
+            FixedMovable(states=[state], position_mapping=(0, 2)),
+            MovingMovable(states=[state], position_mapping=(0, 2),
+                          transition_model=transition_model),
+            MultiTransitionMovable(states=[state], position_mapping=(0, 2),
+                                   transition_models=[transition_model],
+                                   transition_times=[timedelta(seconds=10)])
+        ]
+
+        for movable in movables:
+            movable.move(state.timestamp + timedelta(seconds=5))
+            assert len(movable) == 2
+            new_state = movable.state
+            assert new_state != state
+            assert isinstance(new_state, type(state))
+            assert new_state.timestamp == state.timestamp + timedelta(seconds=5)
+            if isinstance(state, GaussianState):
+                new_state.covar  # covar exists in new state
+            elif isinstance(state, GroundTruthState):
+                assert new_state.metadata == state.metadata  # metadata carried-over to new state

--- a/stonesoup/movable/tests/test_movable.py
+++ b/stonesoup/movable/tests/test_movable.py
@@ -5,7 +5,7 @@ import pytest
 
 from stonesoup.models.transition.linear import ConstantVelocity, ConstantTurn, \
     CombinedLinearGaussianTransitionModel
-from stonesoup.movable import Movable, MovingMovable, FixedMovable, MultiTransitionMovable
+from stonesoup.movable import MovingMovable, FixedMovable, MultiTransitionMovable
 from stonesoup.types.array import StateVector
 from stonesoup.types.groundtruth import GroundTruthState
 from stonesoup.types.state import State, GaussianState
@@ -105,66 +105,6 @@ def test_multi_transition_movable_move():
     movable.move(now + timedelta(seconds=10))
     assert movable.state.state_vector is not input_state_vector
     assert movable.state.timestamp is not now
-
-
-def test_from_state():
-    start = datetime.now()
-    kwargs = {"state_vector": np.arange(4), "timestamp": start}
-
-    states = [
-        State(**kwargs),
-        GaussianState(**kwargs, covar=np.eye(4)),
-        GroundTruthState(**kwargs, metadata={"colour": "blue"})
-    ]
-
-    for state in states:
-
-        # test replacement arg
-        new_state = Movable.from_state(state, np.ones(4))
-        assert isinstance(new_state, type(state))
-        assert np.array_equal(new_state.state_vector.flatten(), np.ones(4))
-        assert new_state.timestamp == start
-        if isinstance(state, GaussianState):
-            assert np.array_equal(new_state.covar, state.covar)
-        elif isinstance(state, GroundTruthState):
-            assert new_state.metadata == state.metadata
-
-        # test replacement kwarg
-        new_time = start + timedelta(seconds=5)
-        new_state = Movable.from_state(state, timestamp=new_time)
-        assert isinstance(new_state, type(state))
-        assert np.array_equal(new_state.state_vector, state.state_vector)
-        assert new_state.timestamp == new_time
-        if isinstance(state, GaussianState):
-            assert np.array_equal(new_state.covar, state.covar)
-        elif isinstance(state, GroundTruthState):
-            assert new_state.metadata == state.metadata
-
-        # test replacement arg and kwarg
-        new_time = start + timedelta(seconds=5)
-        new_state = Movable.from_state(state, np.ones(4), timestamp=new_time)
-        assert isinstance(new_state, type(state))
-        assert np.array_equal(new_state.state_vector.flatten(), np.ones(4))
-        assert new_state.timestamp == new_time
-        if isinstance(state, GaussianState):
-            assert np.array_equal(new_state.covar, state.covar)
-        elif isinstance(state, GroundTruthState):
-            assert new_state.metadata == state.metadata
-
-    # test covar overwrite
-    new_state = Movable.from_state(states[1], covar=2 * np.eye(4))
-    assert isinstance(new_state, type(states[1]))
-    assert np.array_equal(new_state.state_vector, states[1].state_vector)
-    assert new_state.timestamp == states[1].timestamp
-    assert np.array_equal(new_state.covar, 2 * np.eye(4))
-
-    # test metadata overwrite
-    new_metadata = {"size": "big"}
-    new_state = Movable.from_state(states[2], metadata=new_metadata)
-    assert isinstance(new_state, type(states[2]))
-    assert np.array_equal(new_state.state_vector, states[2].state_vector)
-    assert new_state.timestamp == states[2].timestamp
-    assert new_state.metadata == new_metadata
 
 
 def test_preserved_state():

--- a/stonesoup/types/state.py
+++ b/stonesoup/types/state.py
@@ -83,8 +83,21 @@ class CreatableFromState:
     class_mapping = {}
 
     def __init_subclass__(cls, **kwargs):
-        state_type = cls.__bases__[-1]
-        base_class = cls.__bases__[0]
+        bases = cls.__bases__
+        if CreatableFromState in bases:
+            # Direct subclasses should not be added to the class mapping, only subclasses of
+            # subclasses
+            return
+        if len(bases) != 2:
+            raise TypeError('A CreatableFromState subclass must have exactly two superclasses')
+        base_class, state_type = cls.__bases__
+        if not issubclass(base_class, CreatableFromState):
+            raise TypeError('The first superclass of a CreatableFromState subclass must be a '
+                            'CreatableFromState (or a subclass)')
+        if not issubclass(state_type, State):
+            # Non-state subclasses do not need adding to the class mapping, as they should not
+            # be created from States
+            return
         if base_class not in CreatableFromState.class_mapping:
             CreatableFromState.class_mapping[base_class] = {}
         CreatableFromState.class_mapping[base_class][state_type] = cls

--- a/stonesoup/types/tests/test_state.py
+++ b/stonesoup/types/tests/test_state.py
@@ -6,6 +6,7 @@ import scipy.linalg
 import pytest
 
 from stonesoup.base import Property
+from stonesoup.types.groundtruth import GroundTruthState
 from ..angle import Bearing
 from ..array import StateVector, CovarianceMatrix
 from ..numeric import Probability
@@ -344,3 +345,63 @@ def test_state_mutable_sequence_error_message():
     test_obj.test_property = 5
     with pytest.raises(AttributeError, match="Custom error message"):
         _ = test_obj.complicated_attribute
+
+
+def test_from_state():
+    start = datetime.datetime.now()
+    kwargs = {"state_vector": np.arange(4), "timestamp": start}
+
+    states = [
+        State(**kwargs),
+        GaussianState(**kwargs, covar=np.eye(4)),
+        GroundTruthState(**kwargs, metadata={"colour": "blue"})
+    ]
+
+    for state in states:
+
+        # test replacement arg
+        new_state = State.from_state(state, np.ones(4))
+        assert isinstance(new_state, type(state))
+        assert np.array_equal(new_state.state_vector.flatten(), np.ones(4))
+        assert new_state.timestamp == start
+        if isinstance(state, GaussianState):
+            assert np.array_equal(new_state.covar, state.covar)
+        elif isinstance(state, GroundTruthState):
+            assert new_state.metadata == state.metadata
+
+        # test replacement kwarg
+        new_time = start + datetime.timedelta(seconds=5)
+        new_state = State.from_state(state, timestamp=new_time)
+        assert isinstance(new_state, type(state))
+        assert np.array_equal(new_state.state_vector, state.state_vector)
+        assert new_state.timestamp == new_time
+        if isinstance(state, GaussianState):
+            assert np.array_equal(new_state.covar, state.covar)
+        elif isinstance(state, GroundTruthState):
+            assert new_state.metadata == state.metadata
+
+        # test replacement arg and kwarg
+        new_time = start + datetime.timedelta(seconds=5)
+        new_state = State.from_state(state, np.ones(4), timestamp=new_time)
+        assert isinstance(new_state, type(state))
+        assert np.array_equal(new_state.state_vector.flatten(), np.ones(4))
+        assert new_state.timestamp == new_time
+        if isinstance(state, GaussianState):
+            assert np.array_equal(new_state.covar, state.covar)
+        elif isinstance(state, GroundTruthState):
+            assert new_state.metadata == state.metadata
+
+    # test covar overwrite
+    new_state = State.from_state(states[1], covar=2 * np.eye(4))
+    assert isinstance(new_state, type(states[1]))
+    assert np.array_equal(new_state.state_vector, states[1].state_vector)
+    assert new_state.timestamp == states[1].timestamp
+    assert np.array_equal(new_state.covar, 2 * np.eye(4))
+
+    # test metadata overwrite
+    new_metadata = {"size": "big"}
+    new_state = State.from_state(states[2], metadata=new_metadata)
+    assert isinstance(new_state, type(states[2]))
+    assert np.array_equal(new_state.state_vector, states[2].state_vector)
+    assert new_state.timestamp == states[2].timestamp
+    assert new_state.metadata == new_metadata

--- a/stonesoup/types/tests/test_state.py
+++ b/stonesoup/types/tests/test_state.py
@@ -7,6 +7,7 @@ import pytest
 
 from stonesoup.base import Property
 from stonesoup.types.groundtruth import GroundTruthState
+from stonesoup.types.state import CreatableFromState
 from ..angle import Bearing
 from ..array import StateVector, CovarianceMatrix
 from ..numeric import Probability
@@ -405,3 +406,14 @@ def test_from_state():
     assert np.array_equal(new_state.state_vector, states[2].state_vector)
     assert new_state.timestamp == states[2].timestamp
     assert new_state.metadata == new_metadata
+
+
+# noinspection PyUnusedLocal
+def test_creatable_from_state_error():
+    class SubclassCfs(CreatableFromState):
+        pass
+    with pytest.raises(TypeError,
+                       match='The first superclass of a CreatableFromState subclass must be a '
+                             'CreatableFromState \\(or a subclass\\)'):
+        class SubSubclassCfs(State, SubclassCfs):
+            pass

--- a/stonesoup/types/update.py
+++ b/stonesoup/types/update.py
@@ -1,72 +1,20 @@
 # -*- coding: utf-8 -*-
-from typing import Any, Optional
 
+from stonesoup.types.state import CreatableFromState
 from ..base import Property
 from .base import Type
 from .hypothesis import Hypothesis
-from .state import State, GaussianState, ParticleState, SqrtGaussianState, StateMutableSequence, \
-    InformationState
+from .state import State, GaussianState, ParticleState, SqrtGaussianState, InformationState
 from .mixture import GaussianMixture
 
 
-def _from_state(
-        cls,
-        state: State,
-        *args: Any,
-        update_type: Optional['Update'] = None,
-        **kwargs: Any) -> 'Update':
-    """Return new Update instance of suitable type using existing properties
-
-    Parameters
-    ----------
-    state: State
-        :class:`~.State` to use existing properties from, and identify update type from
-    \\*args: Sequence
-        Arguments to pass to newly created update, replacing those with same name on ``state``
-        parameter.
-    update_type: :class:`~.Update`, optional
-        Type to use for update, overriding one from :attr:`class_mapping`.
-    \\*\\*kwargs: Mapping
-        New property names and associate value for use in newly created update, replacing those
-        on the ``state`` parameter.
-    """
-    # Handle being initialised with state sequence
-    if isinstance(state, StateMutableSequence):
-        state = state.state
-    try:
-        state_type = next(type_ for type_ in type(state).mro() if type_ in cls.class_mapping)
-    except StopIteration:
-        raise TypeError(f'{cls.__name__} type not defined for {type(state).__name__}')
-    if update_type is None:
-        update_type = cls.class_mapping[state_type]
-
-    args_property_names = {name for n, name in enumerate(update_type.properties) if n < len(args)}
-    # Use current state kwargs that also properties of update type, it not provided in args
-    new_kwargs = {
-        name: getattr(state, name)
-        for name in state_type.properties.keys() & update_type.properties.keys()
-        if name not in args_property_names}
-    # And replace them with any newly defined kwargs
-    new_kwargs.update(kwargs)
-
-    return update_type(*args, **new_kwargs)
-
-
-class Update(Type):
+class Update(Type, CreatableFromState):
     """ Update type
 
     The base update class. Updates are returned by :class:'~.Updater' objects
     and contain the information that was used to perform the updating"""
 
     hypothesis: Hypothesis = Property(doc="Hypothesis used for updating")
-
-    class_mapping = {}
-    from_state = classmethod(_from_state)
-
-    def __init_subclass__(cls, **kwargs):
-        state_type = cls.__bases__[-1]
-        Update.class_mapping[state_type] = cls
-        super().__init_subclass__(**kwargs)
 
 
 class StateUpdate(Update, State):

--- a/stonesoup/updater/particle.py
+++ b/stonesoup/updater/particle.py
@@ -213,7 +213,7 @@ class GromovFlowKalmanParticleUpdater(GromovFlowParticleUpdater):
         kalman_prediction = self.kalman_updater.predict_measurement(
             Prediction.from_state(
                 state_prediction, state_prediction.state_vector, state_prediction.covar,
-                destination_type=GaussianStatePrediction),
+                target_type=GaussianStatePrediction),
             *args, **kwargs)
 
         return ParticleMeasurementPrediction(

--- a/stonesoup/updater/particle.py
+++ b/stonesoup/updater/particle.py
@@ -213,7 +213,7 @@ class GromovFlowKalmanParticleUpdater(GromovFlowParticleUpdater):
         kalman_prediction = self.kalman_updater.predict_measurement(
             Prediction.from_state(
                 state_prediction, state_prediction.state_vector, state_prediction.covar,
-                prediction_type=GaussianStatePrediction),
+                destination_type=GaussianStatePrediction),
             *args, **kwargs)
 
         return ParticleMeasurementPrediction(


### PR DESCRIPTION
The motivation behind this change is to allow the use of GroundTruthState types in platforms.
Previously, a platform's (movement controller's) `move` method hard-coded a standard `State` append.
This lead to loss of metadata when initiating a platform with a GroundTruthState, since the metadata property was not copied across to the new state.