### PR TITLE
Add constant jerk model simulation for platforms

### DIFF
--- a/docs/examples/Smooth_Platform_Coordinate_Transitions.py
+++ b/docs/examples/Smooth_Platform_Coordinate_Transitions.py
@@ -216,7 +216,7 @@ fig
 # Constant Jerk
 # ^^^^^^^^^^^^^
 # The next method is :meth:`~simulator.ConstantJerkSimulator.create_models`
-
+#
 # This method takes a series of states with cartesian kinematic state space elements and returns a
 # chain (list) of :class:`~.ConstantJerkSimulator` transition models and transition times.
 #
@@ -246,7 +246,7 @@ states = [
 
 
 # %%
-# Plotting the three target destinations (in blue) and the target initial bearing in green:
+# Plotting the three target destinations in blue and orientations in green:
 
 fig = plt.figure(figsize=(10, 6))
 ax = fig.add_subplot(1, 1, 1)

--- a/docs/examples/Smooth_Platform_Coordinate_Transitions.py
+++ b/docs/examples/Smooth_Platform_Coordinate_Transitions.py
@@ -35,8 +35,8 @@ Creating Smooth Transitions Between Coordinates
 
 
 # %%
-# A Simple Demo
-# -------------
+# A Simple Demo of Constant Acceleration
+# --------------------------------------
 # Start with the target (platform) facing top-right (45 degrees clockwise from North).
 # The target begins at the origin, at time = start.
 #
@@ -150,8 +150,8 @@ fig
 
 
 # %%
-# Running through multiple coordinates
-# ------------------------------------
+# Running through multiple coordinates with Constant Acceleration
+# ---------------------------------------------------------------
 # A demonstration using several coordinates.
 
 np.random.seed(101)
@@ -231,8 +231,8 @@ fig
 
 
 # %%
-# A Simple Demo
-# -------------
+# A Simple Demo of Constant Jerk
+# ------------------------------
 # We will use the same set-up as before, but specify an initial and final velocity as well.
 
 start = datetime.now()
@@ -295,8 +295,8 @@ fig
 
 
 # %%
-# Running through multiple coordinates
-# ------------------------------------
+# Running through multiple coordinates with Constant Jerk
+# -------------------------------------------------------
 # A demonstration using several coordinates.
 
 ndim_state = np.random.randint(4, 6)

--- a/docs/examples/Smooth_Platform_Coordinate_Transitions.py
+++ b/docs/examples/Smooth_Platform_Coordinate_Transitions.py
@@ -215,7 +215,7 @@ fig
 # %%
 # Constant Jerk
 # ^^^^^^^^^^^^^
-# The next method is :meth:`~simulator.ConstantJerkSimulator.create_models`
+# The next method is :meth:`~.simulator.transition.ConstantJerkSimulator.create_models`
 #
 # This method takes a series of states with cartesian kinematic state space elements and returns a
 # chain (list) of :class:`~.ConstantJerkSimulator` transition models and transition times.
@@ -224,10 +224,10 @@ fig
 # noiseless, constant jerk transition in the kinematic, cartesian subspace of the state space.
 #
 # The user will need to provide both initial and final position and velocities. This can be of any
-# dimension. For example, constant jerk in the space :math:`(x, vx, y, vy)` and
-# :math:`(x, vx, y, vy, z, vz`)` are valid (elements need not be in this order, as a position
-# mapping and velocity mapping can be passed to the method to specify where the position and
-# velocity components are respectively).
+# dimension. For example, constant jerk in the space :math:`(x, \dot{x}, y, \dot{y})` and
+# :math:`(x, \dot{x}, y, \dot{y}, z, \dot{z})` are valid (elements need not be in this order, as a
+# position  mapping and velocity mapping can be passed to the method to specify where the position
+# and velocity components are respectively).
 
 
 # %%
@@ -262,8 +262,8 @@ for state in states:
 
 # %%
 # To create the list of transition models and durations, pass the list of states, position mapping
-# and velocity mapping (optional) to the :meth:`~simulator.ConstantJerkSimulator.create_models`
-# method.
+# and velocity mapping (optional) to the
+# :meth:`~.simulator.transition.ConstantJerkSimulator.create_models` method.
 
 from stonesoup.simulator.transition import ConstantJerkSimulator
 transition_models, transition_times = ConstantJerkSimulator.create_models(states,

--- a/docs/examples/Smooth_Platform_Coordinate_Transitions.py
+++ b/docs/examples/Smooth_Platform_Coordinate_Transitions.py
@@ -6,8 +6,17 @@ Creating Smooth Transitions Between Coordinates
 """
 
 # %%
-# This is a demonstration of the :meth:`~simulator.transition.get_smooth_transition_models`
-# method for use with the :class:`~.MultiTransitionMovingPlatform`.
+# This is a demonstration of two methods for calculating transition models between given
+# coordinates in a cartesian state space.
+# These methods are intended to be used in conjunction with
+# :class:`~.MultiTransitionMovingPlatform`, which can be passed a list of models and
+# model-durations, such that, for example, the platform could undergo constant velocity transition
+# for 5 minutes, followed by constant acceleration for 2 minutes.
+
+# %%
+# Constant Acceleration
+# ^^^^^^^^^^^^^^^^^^^^^
+# The first method is :meth:`~simulator.transition.get_smooth_transition_models`.
 #
 # This method takes a series of 2D cartesian coordinates, and returns a chain (list) of
 # :class:`~.ConstantTurn` transition models, alongside a list of transition times that each
@@ -26,8 +35,8 @@ Creating Smooth Transitions Between Coordinates
 
 
 # %%
-# Simple demonstration
-# ^^^^^^^^^^^^^^^^^^^^
+# A Simple Demo
+# -------------
 # Start with the target (platform) facing top-right (45 degrees clockwise from North).
 # The target begins at the origin, at time = start.
 #
@@ -142,7 +151,7 @@ fig
 
 # %%
 # Running through multiple coordinates
-# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+# ------------------------------------
 # A demonstration using several coordinates.
 
 np.random.seed(101)
@@ -189,8 +198,6 @@ platform = MultiTransitionMovingPlatform(states=platform_state,
 
 # %%
 
-# sphinx_gallery_thumbnail_number = 4
-
 platform_coords = []
 sim_rate = 100  # 'sim_rate'-seconds each time-step.
 for i in range(int((times[-1] - times[0]).total_seconds()/sim_rate)):
@@ -202,4 +209,137 @@ ax.plot([coord[0] for coord in platform_coords],
         [coord[1] for coord in platform_coords],
         color='blue',
         linewidth=3)
+fig
+
+
+# %%
+# Constant Jerk
+# ^^^^^^^^^^^^^
+# The next method is :meth:`~simulator.ConstantJerkSimulator.create_models`
+
+# This method takes a series of states with cartesian kinematic state space elements and returns a
+# chain (list) of :class:`~.ConstantJerkSimulator` transition models and transition times.
+#
+# The :class:`~.ConstantJerkSimulator` type of transition model is an implementation of a
+# noiseless, constant jerk transition in the kinematic, cartesian subspace of the state space.
+#
+# The user will need to provide both initial and final position and velocities. This can be of any
+# dimension. For example, constant jerk in the space :math:`(x, vx, y, vy)` and
+# :math:`(x, vx, y, vy, z, vz`)` are valid (elements need not be in this order, as a position
+# mapping and velocity mapping can be passed to the method to specify where the position and
+# velocity components are respectively).
+
+
+# %%
+# A Simple Demo
+# -------------
+# We will use the same set-up as before, but specify an initial and final velocity as well.
+
+start = datetime.now()
+position_mapping = (0, 2)
+velocity_mapping = (1, 3)
+states = [
+    State(StateVector([0, 1, 0, 1]), start),  # at origin, pointing NE
+    State(StateVector([-10, 0, 10, -2]), start + timedelta(seconds=5)),  # at (-10, 10), pointing N
+    State(StateVector([-20, 0, 0, 0]), start + timedelta(seconds=10))  # at (-20, 10), 0 velocity
+]
+
+
+# %%
+# Plotting the three target destinations (in blue) and the target initial bearing in green:
+
+fig = plt.figure(figsize=(10, 6))
+ax = fig.add_subplot(1, 1, 1)
+ax.set_xlabel("$x$")
+ax.set_ylabel("$y$")
+ax.axis('equal')
+ax.scatter(*zip(*[state.state_vector[(0, 2), :] for state in states]),
+           color='lightskyblue', s=100, edgecolors='black')
+for state in states:
+    x, vx, y, vy = state.state_vector
+    ax.plot((x, x+vx), (y, y+vy), color='lightgreen', linewidth=2)
+
+
+# %%
+# To create the list of transition models and durations, pass the list of states, position mapping
+# and velocity mapping (optional) to the :meth:`~simulator.ConstantJerkSimulator.create_models`
+# method.
+
+from stonesoup.simulator.transition import ConstantJerkSimulator
+transition_models, transition_times = ConstantJerkSimulator.create_models(states,
+                                                                          position_mapping,
+                                                                          velocity_mapping)
+
+for transition_time, transition_model in zip(transition_times, transition_models):
+    print(f"Duration: {transition_time}s, Model: {type(transition_model)},"
+          f"Initial Accels: {transition_model.init_A}, Final Accels: {transition_model.final_A}, "
+          f"Jerk Values: {transition_model.jerk}")
+
+# %%
+# Create a :class:`~.MultiTransitionMovingPlatform` using the output transition models and times.
+platform = MultiTransitionMovingPlatform(states=states[0],
+                                         position_mapping=position_mapping,
+                                         transition_models=transition_models,
+                                         transition_times=transition_times)
+
+
+# %%
+# Plot the platform path (light blue).
+
+while platform.timestamp < states[-1].timestamp:
+    platform.move(timestamp=platform.timestamp+timedelta(seconds=0.01))
+
+ax.plot(*np.array([state.state_vector[(0, 2), :].flatten() for state in platform.states]).T,
+        color='lightskyblue', linewidth=3)
+fig
+
+
+# %%
+# Running through multiple coordinates
+# ------------------------------------
+# A demonstration using several coordinates.
+
+ndim_state = np.random.randint(4, 6)
+states = [State(np.random.rand(ndim_state, 1), start + timedelta(minutes=i))
+          for i in range(5)]
+for state in states:
+    state.state_vector[position_mapping, :] *= 100  # increase distances between states
+if ndim_state > 4:
+    for state in states[1:]:
+        for i in range(4, ndim_state):
+            # non-kinematic elements stay the same
+            state.state_vector[i] = states[0].state_vector[i]
+
+fig = plt.figure(figsize=(10, 6))
+ax = fig.add_subplot(1, 1, 1)
+ax.set_xlabel("$x$")
+ax.set_ylabel("$y$")
+ax.axis('equal')
+ax.scatter(*zip(*[state.state_vector[(0, 2), :] for state in states]),
+           color='lightskyblue', s=100, edgecolors='black')
+for state in states:
+    x, vx, y, vy, *_ = state.state_vector
+    ax.plot((x, x+vx), (y, y+vy), color='lightgreen', linewidth=2)
+
+
+# %%
+
+transition_models, transition_times = ConstantJerkSimulator.create_models(states,
+                                                                          position_mapping,
+                                                                          velocity_mapping)
+platform = MultiTransitionMovingPlatform(states=states[0],
+                                         position_mapping=position_mapping,
+                                         transition_models=transition_models,
+                                         transition_times=transition_times)
+
+
+# %%
+
+# sphinx_gallery_thumbnail_number = 8
+
+while platform.timestamp < states[-1].timestamp:
+    platform.move(timestamp=platform.timestamp+timedelta(seconds=0.01))
+
+ax.plot(*np.array([state.state_vector[(0, 2), :].flatten() for state in platform.states]).T,
+        color='lightskyblue', linewidth=3)
 fig

--- a/stonesoup/simulator/tests/test_transition.py
+++ b/stonesoup/simulator/tests/test_transition.py
@@ -5,12 +5,12 @@ from datetime import datetime, timedelta
 import numpy as np
 import pytest
 
-from stonesoup.simulator.transition import create_smooth_transition_models
-from stonesoup.types.state import State
-from stonesoup.types.array import StateVector
+from ..transition import create_smooth_transition_models, ConstantJerkSimulator
+from ...types.array import StateVector
+from ...types.state import State
 
 start = datetime.now()
-times = [start + timedelta(seconds=10*i) for i in range(3)]
+times = [start + timedelta(seconds=10 * i) for i in range(3)]
 
 
 def get_coords_list():
@@ -103,3 +103,71 @@ def test_transitions_list(coords, turn_rate):
             # expect target to be at next coordinates at each time-step
             assert np.isclose(target.state_vector[0], x_coords[index])
             assert np.isclose(target.state_vector[2], y_coords[index])
+
+
+def test_constant_jerk():
+
+    start = datetime.now()
+    position_mapping = [0, 2]
+
+    # test state dimension disparity error
+    with pytest.raises(ValueError,
+                       match="Initial and final states must share the same number of dimensions. "
+                             "Initial state has ndim = 4 but final state has ndim = 3"):
+        ConstantJerkSimulator(position_mapping=position_mapping,
+                              velocity_mapping=None,
+                              init_state=State([1, 2, 3, 4], start),
+                              final_state=State([1, 2, 3], start + timedelta(minutes=1)))
+
+    # test default velocity mapping
+    model = ConstantJerkSimulator(position_mapping=position_mapping, velocity_mapping=None,
+                                  init_state=State([1, 2, 3, 4], start),
+                                  final_state=State([5, 6, 7, 8], start + timedelta(minutes=1)))
+    assert model.velocity_mapping == [1, 3]
+
+    for _ in range(5):
+        ndim_state = np.random.randint(4, 6)
+        init_state = State(100 * np.random.rand(ndim_state, 1), start)
+        final_state = State(100 * np.random.rand(ndim_state, 1),
+                            start + timedelta(minutes=1))
+        if ndim_state > 4:
+            for i in range(4, ndim_state):
+                # non-kinematic elements stay the same
+                final_state.state_vector[i] = init_state.state_vector[i]
+
+        model = ConstantJerkSimulator(position_mapping=position_mapping, velocity_mapping=None,
+                                      init_state=init_state, final_state=final_state)
+
+        # test transitioned to correct state
+        new_vector = model.function(init_state, timedelta(minutes=1))
+
+        assert np.allclose(new_vector, final_state.state_vector)
+
+    # test create models
+    ndim_state = np.random.randint(4, 6)
+    states = [State(100 * np.random.rand(ndim_state, 1), start + timedelta(minutes=i))
+              for i in range(5)]
+    if ndim_state > 4:
+        for state in states[1:]:
+            for i in range(4, ndim_state):
+                # non-kinematic elements stay the same
+                state.state_vector[i] = states[0].state_vector[i]
+
+    transition_models, transition_times = \
+        ConstantJerkSimulator.create_models(states, position_mapping)
+
+    assert len(transition_models) == len(transition_times) == 4  # one less than len(states)
+    for prev_state, next_state, model, duration in zip(states[:-1], states[1:],
+                                                       transition_models, transition_times):
+
+        exp_duration = next_state.timestamp - prev_state.timestamp
+        assert exp_duration == duration
+        assert model.init_state == prev_state
+        assert model.final_state == next_state
+
+    current_state = states[0]
+    for i, (model, duration) in enumerate(zip(transition_models, transition_times)):
+        new_vector = model.function(current_state, duration)
+        exp_state = states[i+1]
+        assert np.allclose(new_vector, exp_state.state_vector)
+        current_state = exp_state

--- a/stonesoup/simulator/transition.py
+++ b/stonesoup/simulator/transition.py
@@ -15,7 +15,7 @@ from ..types.state import State
 
 
 def create_smooth_transition_models(initial_state, x_coords, y_coords, times, turn_rate):
-    """Generate a list of constant-turn and constant acceleration transition models alongside a
+    r"""Generate a list of constant-turn and constant acceleration transition models alongside a
     list of transition times to provide smooth transitions between 2D cartesian coordinates and
     time pairs.
     An assumption is that the initial_state's x, y coordinates are the first elements of x_ccords
@@ -23,7 +23,8 @@ def create_smooth_transition_models(initial_state, x_coords, y_coords, times, tu
 
     Parameters
     ----------
-    initial_state: :class:`~.State` The initial state of the platform.
+    initial_state: :class:`~.State`
+        The initial state of the platform.
     x_coords:
         A list of int/float x-coordinates (cartesian) in the order that the target must follow.
     y_coords:
@@ -46,8 +47,9 @@ def create_smooth_transition_models(initial_state, x_coords, y_coords, times, tu
     Notes
     -----
     x_coords, y_coords and times must be of same length.
-    This method assumes a cartesian state space with velocities eg. (x, vx, y, vy). It returns
-    transition models for 2 cartesian coordinates and their corresponding velocities.
+    This method assumes a cartesian state space with velocities eg.
+    :math:`(x, \dot{x}, y, \dot{y})`. It returns transition models for 2 cartesian coordinates and
+    their corresponding velocities.
     """
 
     state = deepcopy(initial_state)  # don't alter platform state with calculations
@@ -318,14 +320,14 @@ class ConstantJerkSimulator(TransitionModel):
     Solution given by :math:`\vec{\ddddot{x}} = \vec{0}`
 
     The user will provide an initial and final state, each of which containing initial cartesian
-    position and velocities. For example, :math:`(x, vx, y, vy)`.
+    position and velocities. For example, :math:`(x, \dot{x}, y, \dot{y})`.
 
     Components of the state vector that are not position or velocity are kept constant.
     Initial and final accelerations are uniquely defined by this input.
 
     Notes
     -----
-        * Acceleration instantaneously changes at each target state
+    Acceleration instantaneously changes at each target state
     """
     position_mapping: Sequence[int] = Property(
         doc="Mapping between platform position and state vector.")
@@ -418,7 +420,7 @@ class ConstantJerkSimulator(TransitionModel):
 
     @staticmethod
     def calculate_pos(init_x, init_v, init_a, jerk, T):
-        """Calculate position, along a particular axis.
+        r"""Calculate position, along a particular axis.
 
         Parameters
         ----------
@@ -443,96 +445,20 @@ class ConstantJerkSimulator(TransitionModel):
 
     @staticmethod
     def calculate_vel(init_v, init_a, jerk, T):
-        """Calculate velocity, along a particular axis.
-
-        Parameters
-        ----------
-        init_v: float
-            Initial velocity along axis
-        init_a: float
-            Initial acceleration along axis
-        jerk: float
-            Constant jerk value along axis
-        T: float
-            Number for seconds to carry-out jerk transition
-
-        Returns
-        -------
-        float
-            New velocity along axis, given by:
-            :math:`V' = \frac{J_0 T^2}{2} + A_0 T + V_0`
-        """
         return (jerk * T ** 2) / 2 + init_a * T + init_v
 
     @staticmethod
     def calculate_init_accel(init_x, final_x, init_v, final_v, T):
-        """Calculate initial acceleration, along a particular axis.
-
-        Parameters
-        ----------
-        init_x: float
-            Initial position along axis
-        final_x: float
-            Final position along axis
-        init_v: float
-            Initial velocity along axis
-        final_v: float
-            Final velocity along axis
-        T: float
-            Number for seconds to get from initial to final state
-
-        Returns
-        -------
-        float
-            Initial acceleration along axis, given by:
-            :math:`A_0 = \frac{6}{T^2}(X_1 - X_0 - \frac{2 V_0 T}{3} - \frac{V_1 T}{3})`
-        """
         return (6 / T ** 2) * (final_x - init_x - (2 * init_v * T / 3) - (final_v * T / 3))
 
     @staticmethod
     def calculate_final_accel(init_v, final_v, init_a, T):
-        """Calculate final acceleration, along a particular axis.
-
-        Parameters
-        ----------
-        init_v: float
-            Initial velocity along axis
-        final_v: float
-            Final velocity along axis
-        init_a: float
-            Initial acceleration along axis
-        T: float
-            Number for seconds to get from initial to final state
-
-        Returns
-        -------
-        float
-            Final acceleration along axis, given by:
-            :math:`A_1 = \frac{2}{T} (V_1 - V_0) - A_0`
-        """
         if T == 0:
             return 0
         return (2 / T) * (final_v - init_v) - init_a
 
     @staticmethod
     def calculate_jerk(init_a, final_a, T):
-        """Calculate constant jerk, along a particular axis.
-
-        Parameters
-        ----------
-        init_a: float
-            Initial acceleration along axis
-        final_a: float
-            Final acceleration along axis
-        T: float
-            Number for seconds to get from initial to final state
-
-        Returns
-        -------
-        float
-            Constant jerk along axis, given by:
-            :math:`J = \frac{A_1 - A_0}{T}`
-        """
         return (final_a - init_a) / T
 
     @classmethod

--- a/stonesoup/simulator/transition.py
+++ b/stonesoup/simulator/transition.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 from copy import deepcopy
 from datetime import timedelta
-from typing import Tuple
+from itertools import combinations
+from typing import Tuple, Sequence
 
 import numpy as np
 
@@ -306,3 +307,253 @@ class Point2PointStop(TransitionModel):
             return StateVector([x + dx, vx, y + dy, vy])
         else:
             return state.state_vector  # if already at destination, stay
+
+
+class ConstantJerkSimulator(TransitionModel):
+    r"""Constant, noiseless, jerk transition model for cartesian space.
+
+    The state space has no acceleration or jerk elements. I.E. the only kinematic components are
+    position and velocity.
+
+    Solution given by :math:`\vec{\ddddot{x}} = \vec{0}`
+
+    The user will provide an initial and final state, each of which containing initial cartesian
+    position and velocities. For example, :math:`(x, vx, y, vy)`.
+
+    Components of the state vector that are not position or velocity are kept constant.
+    Initial and final accelerations are uniquely defined by this input.
+
+    Notes
+    -----
+        * Acceleration instantaneously changes at each target state
+    """
+    position_mapping: Sequence[int] = Property(
+        doc="Mapping between platform position and state vector.")
+    velocity_mapping: Sequence[int] = Property(
+        default=None,
+        doc="Mapping between platform velocity and state vector. Defaults to `[m+1 for m in "
+            "position_mapping]`")
+    init_state: State = Property(
+        doc="Initial state to move from. Must be `ndim_state` dimensions.")
+    final_state: State = Property(
+        doc="Final state to move to. Must be `ndim_state` dimensions.")
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        if self.init_state.state_vector.shape[0] != self.final_state.state_vector.shape[0]:
+            raise ValueError(
+                f"Initial and final states must share the same number of dimensions. Initial "
+                f"state has ndim = {self.init_state.state_vector.shape[0]} but final state has "
+                f"ndim = {self.final_state.state_vector.shape[0]}")
+
+        if self.velocity_mapping is None:
+            self.velocity_mapping = [p + 1 for p in self.position_mapping]
+
+        # Full duration of transition
+        self.duration = (self.final_state.timestamp - self.init_state.timestamp).total_seconds()
+
+        # Initial position
+        self.init_X = self.init_state.state_vector[self.position_mapping, :]
+        # Initial velocity
+        self.init_V = self.init_state.state_vector[self.velocity_mapping, :]
+
+        # Final position
+        self.final_X = self.final_state.state_vector[self.position_mapping, :]
+        # Final velocity
+        self.final_V = self.final_state.state_vector[self.velocity_mapping, :]
+
+        self.init_A, self.final_A, self.jerk = list(), list(), list()
+        for init_x, init_v, final_x, final_v in zip(self.init_X, self.init_V,
+                                                    self.final_X, self.final_V):
+            init_a = self.calculate_init_accel(init_x, final_x,
+                                               init_v, final_v,
+                                               self.duration)
+            self.init_A.append(init_a)
+
+            final_a = self.calculate_final_accel(init_v, final_v, init_a, self.duration)
+            self.final_A.append(final_a)
+            self.jerk.append(self.calculate_jerk(init_a, final_a, self.duration))
+
+    @property
+    def ndim_state(self):
+        """Number of state space dimensions."""
+        return self.init_state.state_vector.shape[0]
+
+    def covar(self, **kwargs):
+        """Must be added due to inheritance."""
+        raise NotImplementedError('Covariance not defined')
+
+    def pdf(self, state1, state2, **kwargs):
+        """Must be added due to inheritance."""
+        raise NotImplementedError('pdf not defined')
+
+    def rvs(self, num_samples=1, **kwargs):
+        """Must be added due to inheritance."""
+        raise NotImplementedError('rvs not defined')
+
+    def function(self, state, time_interval, **kwargs):
+        """Apply a constant jerk transition to `state`, for `time_interval` duration, keeping
+        elements of state vector that are not position or velocity constant."""
+
+        # Total time that will have passed since initial state up until transition is complete
+        delta_t = (state.timestamp + time_interval - self.init_state.timestamp).total_seconds()
+
+        # New position and velocity calculated only from `delta_t`
+        # Assumed that `state` lies on the constant jerk path connecting `initial_state` with
+        # `final_state`
+
+        new_position = list()
+        new_velocity = list()
+        for init_x, init_v, init_a, jerk in zip(self.init_X, self.init_V, self.init_A, self.jerk):
+            new_position.append(self.calculate_pos(init_x, init_v, init_a, jerk, delta_t))
+            new_velocity.append(self.calculate_vel(init_v, init_a, jerk, delta_t))
+
+        # Non-kinematic components remain constant
+        new_sv = np.copy(state.state_vector).astype(float)  # May initiate with integers
+        new_sv[self.position_mapping, 0] = new_position
+        new_sv[self.velocity_mapping, 0] = new_velocity
+
+        return StateVector(new_sv)
+
+    @staticmethod
+    def calculate_pos(init_x, init_v, init_a, jerk, T):
+        """Calculate position, along a particular axis.
+
+        Parameters
+        ----------
+        init_x: float
+            Initial position along axis
+        init_v: float
+            Initial velocity along axis
+        init_a: float
+            Initial acceleration along axis
+        jerk: float
+            Constant jerk value along axis
+        T: float
+            Number for seconds to carry-out jerk transition
+
+        Returns
+        -------
+        float
+            New position along axis, given by:
+            :math:`X' = \frac{J_0 T^3}{6} + \frac{A_0 T^2}{2} + V_0 T + X_0`
+        """
+        return (jerk * T ** 3) / 6 + (init_a * T ** 2) / 2 + init_v * T + init_x
+
+    @staticmethod
+    def calculate_vel(init_v, init_a, jerk, T):
+        """Calculate velocity, along a particular axis.
+
+        Parameters
+        ----------
+        init_v: float
+            Initial velocity along axis
+        init_a: float
+            Initial acceleration along axis
+        jerk: float
+            Constant jerk value along axis
+        T: float
+            Number for seconds to carry-out jerk transition
+
+        Returns
+        -------
+        float
+            New velocity along axis, given by:
+            :math:`V' = \frac{J_0 T^2}{2} + A_0 T + V_0`
+        """
+        return (jerk * T ** 2) / 2 + init_a * T + init_v
+
+    @staticmethod
+    def calculate_init_accel(init_x, final_x, init_v, final_v, T):
+        """Calculate initial acceleration, along a particular axis.
+
+        Parameters
+        ----------
+        init_x: float
+            Initial position along axis
+        final_x: float
+            Final position along axis
+        init_v: float
+            Initial velocity along axis
+        final_v: float
+            Final velocity along axis
+        T: float
+            Number for seconds to get from initial to final state
+
+        Returns
+        -------
+        float
+            Initial acceleration along axis, given by:
+            :math:`A_0 = \frac{6}{T^2}(X_1 - X_0 - \frac{2 V_0 T}{3} - \frac{V_1 T}{3})`
+        """
+        return (6 / T ** 2) * (final_x - init_x - (2 * init_v * T / 3) - (final_v * T / 3))
+
+    @staticmethod
+    def calculate_final_accel(init_v, final_v, init_a, T):
+        """Calculate final acceleration, along a particular axis.
+
+        Parameters
+        ----------
+        init_v: float
+            Initial velocity along axis
+        final_v: float
+            Final velocity along axis
+        init_a: float
+            Initial acceleration along axis
+        T: float
+            Number for seconds to get from initial to final state
+
+        Returns
+        -------
+        float
+            Final acceleration along axis, given by:
+            :math:`A_1 = \frac{2}{T} (V_1 - V_0) - A_0`
+        """
+        if T == 0:
+            return 0
+        return (2 / T) * (final_v - init_v) - init_a
+
+    @staticmethod
+    def calculate_jerk(init_a, final_a, T):
+        """Calculate constant jerk, along a particular axis.
+
+        Parameters
+        ----------
+        init_a: float
+            Initial acceleration along axis
+        final_a: float
+            Final acceleration along axis
+        T: float
+            Number for seconds to get from initial to final state
+
+        Returns
+        -------
+        float
+            Constant jerk along axis, given by:
+            :math:`J = \frac{A_1 - A_0}{T}`
+        """
+        return (final_a - init_a) / T
+
+    @classmethod
+    def create_models(cls, states: Sequence[State], position_mapping, velocity_mapping=None):
+        """Generate a list of :class:`~.ConstantJerkSimulator` and transition durations, given a
+        list of states."""
+
+        if not all(state.ndim == state2.ndim for state, state2 in combinations(states, 2)):
+            raise ValueError("All states must have the same ndim")
+
+        transition_models, transition_times = list(), list()
+
+        for current_state, next_state in zip(states[:-1], states[1:]):
+
+            transition_times.append(next_state.timestamp - current_state.timestamp)
+
+            transition_models.append(
+                cls(position_mapping=position_mapping,
+                    velocity_mapping=velocity_mapping,
+                    init_state=current_state,
+                    final_state=next_state)
+            )
+
+        return transition_models, transition_times


### PR DESCRIPTION
Another method for calculating a series of smooth transitions between a series of target states, using a constant jerk (acceleration time derivative) model.