### PR TITLE
Introduce resampler that checks if resampling required

### DIFF
--- a/stonesoup/resampler/particle.py
+++ b/stonesoup/resampler/particle.py
@@ -49,17 +49,45 @@ class SystematicResampler(Resampler):
         return new_particles
 
 
-class ESSResampler(SystematicResampler):
+class ESSResampler(Resampler):
+    """ESSResampler class
+        This wrapper uses a :class:`~.Resampler` to resample the particles inside
+        an instant of :class:`~.Particles`, but only after checking if this is necessary
+        by comparing Effective Sample Size (ESS) with a supplied threshold (numeric).
+        Kish's ESS is used, as in Section 3.5 of [1]_.   Doucet-Johansen, 2008.
+
+        References
+        ----------
+        .. [1] Doucet A., Johansen A.M., 2009, Tutorial on Particle Filtering \
+        and Smoothing: Fifteen years later, Handbook of Nonlinear Filtering, Vol. 12.
+
+        """
 
     threshold: float = Property(default=None,
-                                doc='Threshold compared with ESS to decide whether to resample')
+                                doc='Threshold compared with ESS to decide whether to resample. \
+                                    Default is number of particles divided by 2, \
+                                        set in resample method')
+    resampler: Resampler = Property(default=SystematicResampler,
+                                    doc='Resampler to wrap, which is called \
+                                        when ESS below threshold')
 
     def resample(self, particles):
+        """
+        Parameters
+        ----------
+        particles : list of :class:`~.Particle`
+            The particles to be resampled according to their weight
+
+        Returns
+        -------
+        particles : list of :class:`~.Particle`
+            The particles, either unchanged or resampled, depending on weight degeneracy
+        """
         if not isinstance(particles, Particles):
             particles = Particles(particle_list=particles)
         if self.threshold is None:
             self.threshold = len(particles) / 2
         if 1 / np.sum(np.square(particles.weight)) < self.threshold:  # If ESS too small, resample
-            return super().resample(particles)
+            return self.resampler.resample(self.resampler, particles)
         else:
             return particles

--- a/stonesoup/resampler/tests/test_particle.py
+++ b/stonesoup/resampler/tests/test_particle.py
@@ -1,16 +1,18 @@
 # -*- coding: utf-8 -*-
 import numpy as np
 
-from ...types.particle import Particle
+from ...types.particle import Particle, \
+    Particles
 from ..particle import SystematicResampler
+from ..particle import ESSResampler
 
 
 def test_systematic_equal():
     particles = [Particle(np.array([[i]]), weight=1/20) for i in range(20)]
 
-    resamlper = SystematicResampler()
+    resampler = SystematicResampler()
 
-    new_particles = resamlper.resample(particles)
+    new_particles = resampler.resample(particles)
 
     # Particles equal weight, so should end up with similar particles.
     assert all(np.array_equal(np.array([[i]]), new_particle.state_vector)
@@ -21,9 +23,9 @@ def test_systematic_single():
     particles = [Particle(np.array([[i]]), weight=1 if i == 10 else 0)
                  for i in range(20)]
 
-    resamlper = SystematicResampler()
+    resampler = SystematicResampler()
 
-    new_particles = resamlper.resample(particles)
+    new_particles = resampler.resample(particles)
 
     # Weight all at single particle at index/vector 10, so all should be
     # at same point
@@ -35,10 +37,55 @@ def test_systematic_even():
     particles = [Particle(np.array([[i]]), weight=1/10 if i % 2 == 0 else 0)
                  for i in range(20)]
 
-    resamlper = SystematicResampler()
+    resampler = SystematicResampler()
 
-    new_particles = resamlper.resample(particles)
+    new_particles = resampler.resample(particles)
 
     # Weight all at even particles, so new should all be at even vector
     assert all(np.array_equal(np.array([[i//2*2]]), new_particle.state_vector)
                for i, new_particle in enumerate(new_particles))
+
+
+def test_ess_zero():
+    particles = [Particle(np.array([[i]]), weight=(i+1) / 55)
+                 for i in range(10)]
+    particles = Particles(particle_list=particles)  # Needed for assert line
+
+    resampler = ESSResampler(0)  # Should never resample
+
+    new_particles = resampler.resample(particles)  # Should not have changed
+
+    assert new_particles == particles
+
+
+def test_ess_n():
+    particles = [Particle(np.array([[i]]), weight=(i+1) / 55)
+                 for i in range(10)]
+
+    resampler = ESSResampler(10)  # This resampler should always resample
+
+    new_particles = resampler.resample(particles)  # All weights should be equal due to resampling
+
+    assert all([w == 1/10 for w in new_particles.weight])
+
+
+def test_ess_inequality():
+    particles = [Particle(np.array([[i]]), weight=(i + 1) / 55)
+                 for i in range(10)]
+    particles = Particles(particle_list=particles)
+
+    resampler1 = ESSResampler(3025/385)  # This resampler should not resample
+    resampler2 = ESSResampler(3025/385 + 0.01)  # This resampler should resample
+
+    new_particles1 = resampler1.resample(particles)
+    new_particles2 = resampler2.resample(particles)
+
+    assert new_particles1 == particles and all([w == 1 / 10 for w in new_particles2.weight])
+
+
+def test_ess_empty_threshold():
+    particles = [Particle(np.array([[i]]), weight=(i + 1) / 55)
+                 for i in range(10)]
+    resampler = ESSResampler()
+    resampler.resample(particles)
+    assert resampler.threshold == 5


### PR DESCRIPTION
This change is in response to #495 
The new ESSResampler class checks whether the ESS (Effective Sample Size) is below a given threshold before proceeding, otherwise simply returning the original particles without any resampling.  