### PR TITLE
Drop Python 3.6 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,6 @@ workflows:
   version: 2
   test:
     jobs:
-      - test-36
       - test-37
       - test-38
       - test-39
@@ -12,9 +11,9 @@ workflows:
     jobs:
       - docs
 jobs:
-  test-36: &test-template
+  test-37: &test-template
     docker:
-      - image: cimg/python:3.6
+      - image: cimg/python:3.7
     steps:
       - checkout
       - restore_cache:
@@ -47,10 +46,6 @@ jobs:
               -f test-reports/coverage.xml \
               -F unittests \
               -n ${CIRCLE_BUILD_NUM}
-  test-37:
-    <<: *test-template
-    docker:
-      - image: cimg/python:3.7
   test-38:
     <<: *test-template
     docker:

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -5,6 +5,6 @@ coverage:
         threshold: 0.1%
 codecov:
   notify:
-    after_n_builds: 6
+    after_n_builds: 5
 comment:
-  after_n_builds: 6
+  after_n_builds: 5

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Stone Soup uses the following dependencies:
 
 | Name | License |
 | ---- | ------- |
-| [Python](https://www.python.org/) (v3.6+) | PSFL |
+| [Python](https://www.python.org/) (v3.7+) | PSFL |
 | [numpy](https://numpy.org/) | BSD |
 | [SciPy](https://www.scipy.org/) | BSD |
 | [matplotlib](https://matplotlib.org/) | [PSF/BSD-compatible](https://matplotlib.org/users/license.html) |

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(name='stonesoup',
           'Topic :: Scientific/Engineering',
       ],
       packages=find_packages(exclude=('docs', '*.tests')),
-      python_requires='>=3.6',
+      python_requires='>=3.7',
       setup_requires=['setuptools_scm', 'setuptools_scm_git_archive'],
       use_scm_version=True,
       install_requires=[

--- a/stonesoup/base.py
+++ b/stonesoup/base.py
@@ -229,10 +229,6 @@ class BaseMeta(ABCMeta):
 
     _repr = BaseRepr()
 
-    @classmethod
-    def __prepare__(mcls, name, bases, **kwargs):
-        return OrderedDict()
-
     def __new__(mcls, name, bases, namespace):
         if '__init__' not in namespace:
             # Must replace init so we don't overwrite parent class's


### PR DESCRIPTION
Python 3.6 itself is no longer support, so no need to continue testing.

As dictionary order is now preserved, the base class no longer needs to be based on `OrderedDict`.