### PR TITLE
Return metrics in a dictionary

### DIFF
--- a/docs/examples/Metrics.py
+++ b/docs/examples/Metrics.py
@@ -163,13 +163,13 @@ metrics = metric_manager.generate_metrics()
 # So first we'll loop through the metrics and print out the basic metrics, which simply gives
 # details on number of tracks versus targets.
 for metric in metrics:
-    if not any(s in metric.title for s in ('SIAP', 'OSPA', 'plot')):
-        print("{0.title}: {0.value}".format(metric))
+    if not any(s in metric for s in ('SIAP', 'OSPA', 'plot')):
+        print(f"{metric} : {metrics.get(metric).value}")
 
 # %%
 # Next we'll take a look at the OSPA metric, plotting it to show how it varies over time. In this
 # example, targets are created and remove randomly, so expect this to be fairly variable.
-ospa_metric = {metric for metric in metrics if metric.title == "OSPA distances"}.pop()
+ospa_metric = metrics['OSPA distances']
 
 fig = plt.figure()
 ax = fig.add_subplot(1, 1, 1)
@@ -184,9 +184,9 @@ _ = ax.set_xlabel("Time")
 # indication, as well as provide a description for each metric.
 from stonesoup.metricgenerator.metrictables import SIAPTableGenerator
 
-siap_averages = {metric for metric in metrics
-                 if metric.title.startswith("SIAP") and not metric.title.endswith(" at times")}
-siap_time_based = {metric for metric in metrics if metric.title.endswith(' at times')}
+siap_averages = {metrics.get(metric) for metric in metrics
+                 if metric.startswith("SIAP") and not metric.endswith(" at times")}
+siap_time_based = {metrics.get(metric) for metric in metrics if metric.endswith(' at times')}
 
 _ = SIAPTableGenerator(siap_averages).compute_metric()
 

--- a/docs/examples/ParticleFlow.py
+++ b/docs/examples/ParticleFlow.py
@@ -201,8 +201,8 @@ for predictor, updater, colour, filter, particle_count \
         [siap_gen], associator=TrackToTruth(association_threshold=np.inf))
     metric_manager.add_data(tracks={track}, groundtruth_paths={truth})
 
-    pa[filter] = {metric for metric in metric_manager.generate_metrics()
-                  if metric.title.startswith("SIAP Position Accuracy at times")}.pop()
+    metrics = metric_manager.generate_metrics()
+    pa[filter] = metrics.get("SIAP Position Accuracy at times")
 
 # %%
 # Positional Accuracy

--- a/stonesoup/metricgenerator/manager.py
+++ b/stonesoup/metricgenerator/manager.py
@@ -85,8 +85,7 @@ class SimpleManager(MetricManager):
             if not isinstance(metric_list, list):
                 metric_list = [metric_list]
             for metric in metric_list:
-                key = metric.title.replace(' at times', '')  # Shorten key a little
-                metrics[key] = metric
+                metrics[metric.title] = metric
         return metrics
 
     def list_timestamps(self):

--- a/stonesoup/metricgenerator/manager.py
+++ b/stonesoup/metricgenerator/manager.py
@@ -78,17 +78,16 @@ class SimpleManager(MetricManager):
         if self.associator is not None and self.association_set is None:
             self.associate_tracks()
 
-        metrics = set()
+        metrics = {}
         for generator in self.generators:
-            metric = generator.compute_metric(self)
-            # Metrics can be lists or not, there's probably a neater way to do
-            # this
-            if isinstance(metric, list):
-                metrics.update(metric)
-            else:
-                metrics.add(metric)
-
-        return set(metrics)
+            metric_list = generator.compute_metric(self)
+            # If not already a list, force it to be one below
+            if not isinstance(metric_list, list):
+                metric_list = [metric_list]
+            for metric in metric_list:
+                key = metric.title.replace(' at times', '')  # Shorten key a little
+                metrics[key] = metric
+        return metrics
 
     def list_timestamps(self):
         """List all the timestamps used in the tracks and truth, in order

--- a/stonesoup/metricgenerator/tests/test_basicmetrics.py
+++ b/stonesoup/metricgenerator/tests/test_basicmetrics.py
@@ -51,11 +51,10 @@ def test_basicmetrics():
                                            end_timestamp=start_time +
                                            datetime.timedelta(seconds=4)),
                                        generator=generator)}
-
     for metric_name in ["Number of targets",
                         "Number of tracks", "Track-to-target ratio"]:
         calc_metric = [i for i in correct_metrics if i.title == metric_name][0]
-        meas_metric = [i for i in metrics if i.title == metric_name][0]
+        meas_metric = [metrics[i] for i in metrics if i == metric_name][0]
         assert calc_metric.value == meas_metric.value
         assert calc_metric.time_range.start_timestamp == \
             meas_metric.time_range.start_timestamp

--- a/stonesoup/metricgenerator/tests/test_basicmetrics.py
+++ b/stonesoup/metricgenerator/tests/test_basicmetrics.py
@@ -54,7 +54,7 @@ def test_basicmetrics():
     for metric_name in ["Number of targets",
                         "Number of tracks", "Track-to-target ratio"]:
         calc_metric = [i for i in correct_metrics if i.title == metric_name][0]
-        meas_metric = [metrics[i] for i in metrics if i == metric_name][0]
+        meas_metric = metrics.get(metric_name)
         assert calc_metric.value == meas_metric.value
         assert calc_metric.time_range.start_timestamp == \
             meas_metric.time_range.start_timestamp

--- a/stonesoup/metricgenerator/tests/test_manager.py
+++ b/stonesoup/metricgenerator/tests/test_manager.py
@@ -89,26 +89,37 @@ def test_listtimestamps():
 
 
 def test_generate_metrics():
-    class DummyGenerator(MetricGenerator):
+    class DummyGenerator1(MetricGenerator):
 
         def compute_metric(self, manager, *args, **kwargs):
-            return Metric(title="Test metric",
-                          value=5,
+            return Metric(title="Test metric1",
+                          value=25,
                           generator=self)
 
-    generator1 = DummyGenerator()
-    generator2 = DummyGenerator()
+    class DummyGenerator2(MetricGenerator):
+
+        def compute_metric(self, manager, *args, **kwargs):
+            return Metric(title="Test metric2 at times",
+                          value=50,
+                          generator=self)
+
+    generator1 = DummyGenerator1()
+    generator2 = DummyGenerator2()
 
     manager = SimpleManager(generators=[generator1, generator2])
 
     metrics = manager.generate_metrics()
-    metric1 = [i for i in metrics if i.generator == generator1][0]
-    metric2 = [i for i in metrics if i.generator == generator2][0]
+    metric1 = [metrics[i] for i in metrics if metrics[i].generator == generator1][0]
+    metric2 = [metrics[i] for i in metrics if metrics[i].generator == generator2][0]
 
     assert len(metrics) == 2
-    assert metric1.title == "Test metric"
-    assert np.array_equal(metric1.value, 5)
+    assert metric1.title == "Test metric1"
+    assert metrics.get("Test metric1") == metric1
+    assert np.array_equal(metric1.value, 25)
     assert np.array_equal(metric1.generator, generator1)
-    assert metric2.title == "Test metric"
-    assert np.array_equal(metric2.value, 5)
+    assert metric2.title == "Test metric2 at times"
+    assert metrics.get("Test metric2") == metric2
+    # ' at times' should have been removed to shorten the key
+    assert metrics.get("Test metric2 at times") is None
+    assert np.array_equal(metric2.value, 50)
     assert np.array_equal(metric2.generator, generator2)

--- a/stonesoup/metricgenerator/tests/test_manager.py
+++ b/stonesoup/metricgenerator/tests/test_manager.py
@@ -109,8 +109,8 @@ def test_generate_metrics():
     manager = SimpleManager(generators=[generator1, generator2])
 
     metrics = manager.generate_metrics()
-    metric1 = [metrics[i] for i in metrics if metrics[i].generator == generator1][0]
-    metric2 = [metrics[i] for i in metrics if metrics[i].generator == generator2][0]
+    metric1 = [metrics.get(i) for i in metrics if metrics[i].generator == generator1][0]
+    metric2 = [metrics.get(i) for i in metrics if metrics[i].generator == generator2][0]
 
     assert len(metrics) == 2
     assert metric1.title == "Test metric1"
@@ -118,8 +118,6 @@ def test_generate_metrics():
     assert np.array_equal(metric1.value, 25)
     assert np.array_equal(metric1.generator, generator1)
     assert metric2.title == "Test metric2 at times"
-    assert metrics.get("Test metric2") == metric2
-    # ' at times' should have been removed to shorten the key
-    assert metrics.get("Test metric2 at times") is None
+    assert metrics.get("Test metric2 at times") == metric2
     assert np.array_equal(metric2.value, 50)
     assert np.array_equal(metric2.generator, generator2)


### PR DESCRIPTION
This branch makes metrics return as a dictionary, with the keys being equal to `metric.title`.   
In response to #469.  