### PR TITLE
Fix probability hypothesis equality check

### DIFF
--- a/stonesoup/types/hypothesis.py
+++ b/stonesoup/types/hypothesis.py
@@ -37,7 +37,7 @@ class ProbabilityHypothesis(Hypothesis):
         return self.probability <= other.probability
 
     def __eq__(self, other):
-        return self.probability == other.probability
+        return isinstance(other, ProbabilityHypothesis) and self.probability == other.probability
 
     def __gt__(self, other):
         return self.probability > other.probability

--- a/stonesoup/types/tests/test_hypothesis.py
+++ b/stonesoup/types/tests/test_hypothesis.py
@@ -80,12 +80,14 @@ def test_single_probability_hypothesis_comparison():
         prediction, detection, 0.9, measurement_prediction)
     h2 = SingleProbabilityHypothesis(
         prediction, detection, 0.1, measurement_prediction)
+    h3 = SingleHypothesis(prediction, detection, measurement_prediction)
 
     assert h1 > h2
     assert h2 < h1
     assert h1 <= h1
     assert h1 >= h1
     assert h1 == h1
+    assert h1 != h3
 
 
 def test_probability_joint_hypothesis():


### PR DESCRIPTION
On checking equality between a `SingleProbabilityHypothesis` and `SingleHypothesis`, an error can be raised. Since the `ProbabilityHypothesis` __eq__ method simply checks whether the hypotheses' probabilities are equal. Since the `SingleHypothesis` has no `probability` attribute, an AttributeError is raised.
A simple fix is to check for type equality first.