### PR TITLE
Modify ParticleState so it has StateVectors and remove unnecessary Particles class

### DIFF
--- a/docs/examples/ParticleFlow.py
+++ b/docs/examples/ParticleFlow.py
@@ -121,14 +121,13 @@ handles, labels = [], []
 
 for predictor, updater, colour, filter, particle_count \
         in zip(predictors, updaters, colours, filters, particle_counts):
-    prior = ParticleState(particles[:particle_count], timestamp=start_time)
+    prior = ParticleState(None, particle_list=particles[:particle_count], timestamp=start_time)
 
     prediction = predictor.predict(prior, timestamp=measurement.timestamp)
     hypothesis = SingleHypothesis(prediction, measurement)
     post = updater.update(hypothesis)
 
-    data = np.array([particle.state_vector for particle in post.particles])
-    handles.append(ax.scatter(data[:, 0], data[:, 2], color=colour, s=2))
+    handles.append(ax.scatter(post.state_vector[0, :], post.state_vector[2, :], color=colour, s=2))
 
     labels.append(filter)
 
@@ -180,7 +179,7 @@ siap_gen = SIAPMetrics(position_measure=Euclidean((0, 2)), velocity_measure=Eucl
 for predictor, updater, colour, filter, particle_count \
         in zip(predictors, updaters, colours, filters, particle_counts):
     track = Track()
-    prior = ParticleState(particles[:particle_count], timestamp=start_time)
+    prior = ParticleState(None, particle_list=particles[:particle_count], timestamp=start_time)
 
     for measurement in measurements:
         prediction = predictor.predict(prior, timestamp=measurement.timestamp)

--- a/docs/tutorials/03_UnscentedKalmanFilterTutorial.py
+++ b/docs/tutorials/03_UnscentedKalmanFilterTutorial.py
@@ -218,7 +218,7 @@ samples = multivariate_normal.rvs(prediction.state_vector.ravel(),
 particles = [
     Particle(sample.reshape(-1, 1), weight=Probability(1/number_particles)) for sample in samples]
 # Create prior particle state.
-pred_samples = ParticleState(particles, timestamp=start_time)
+pred_samples = ParticleState(None, particle_list=particles, timestamp=start_time)
 
 from stonesoup.resampler.particle import SystematicResampler
 resampler = SystematicResampler()

--- a/docs/tutorials/04_ParticleFilter.py
+++ b/docs/tutorials/04_ParticleFilter.py
@@ -154,8 +154,10 @@ updater = ParticleUpdater(measurement_model, resampler)
 # %%
 # Initialise a prior
 # ^^^^^^^^^^^^^^^^^^
-# To start we create a prior estimate. This is a set of :class:`~.Particle` and we sample from
-# Gaussian distribution (using the same parameters we had in the previous examples).
+# To start we create a prior estimate. This is a :class:`~.ParticleState` which describes
+# the state as a distribution of particles using :class:`~.StateVectors` and weights,.
+# This is sampled from the Gaussian distribution (using the same parameters we
+# had in the previous examples).
 
 from scipy.stats import multivariate_normal
 

--- a/docs/tutorials/04_ParticleFilter.py
+++ b/docs/tutorials/04_ParticleFilter.py
@@ -159,7 +159,6 @@ updater = ParticleUpdater(measurement_model, resampler)
 
 from scipy.stats import multivariate_normal
 
-from stonesoup.types.particle import Particles
 from stonesoup.types.numeric import Probability  # Similar to a float type
 from stonesoup.types.state import ParticleState
 from stonesoup.types.array import StateVectors
@@ -171,13 +170,10 @@ samples = multivariate_normal.rvs(np.array([0, 1, 0, 1]),
                                   np.diag([1.5, 0.5, 1.5, 0.5]),
                                   size=number_particles)
 
-# Create state vectors and weights for particles
-particles = Particles(state_vector=StateVectors(samples.T),
-                      weight=np.array([Probability(1/number_particles)]*number_particles)
-                      )
-
 # Create prior particle state.
-prior = ParticleState(particles, timestamp=start_time)
+prior = ParticleState(state_vector=StateVectors(samples.T),
+                      weight=np.array([Probability(1/number_particles)]*number_particles),
+                      timestamp=start_time)
 # %%
 # Run the tracker
 # ^^^^^^^^^^^^^^^

--- a/docs/tutorials/04_ParticleFilter.py
+++ b/docs/tutorials/04_ParticleFilter.py
@@ -155,7 +155,7 @@ updater = ParticleUpdater(measurement_model, resampler)
 # Initialise a prior
 # ^^^^^^^^^^^^^^^^^^
 # To start we create a prior estimate. This is a :class:`~.ParticleState` which describes
-# the state as a distribution of particles using :class:`~.StateVectors` and weights,.
+# the state as a distribution of particles using :class:`~.StateVectors` and weights.
 # This is sampled from the Gaussian distribution (using the same parameters we
 # had in the previous examples).
 

--- a/stonesoup/initiator/simple.py
+++ b/stonesoup/initiator/simple.py
@@ -263,8 +263,9 @@ class GaussianParticleInitiator(ParticleInitiator):
                 Particle(sample.reshape(-1, 1), weight=weight)
                 for sample in samples]
             track[-1] = ParticleStateUpdate(
-                particles,
+                None,
                 track.hypothesis,
+                particle_list=particles,
                 fixed_covar=track.covar if self.use_fixed_covar else None,
                 timestamp=track.timestamp)
 

--- a/stonesoup/initiator/tests/test_simple.py
+++ b/stonesoup/initiator/tests/test_simple.py
@@ -359,7 +359,7 @@ def test_gaussian_particle(gaussian_initiator):
 
     for track in tracks:
         assert isinstance(track.state, ParticleStateUpdate)
-        print(track.state.mean)
+
         if track.state.mean > 0:
             assert np.allclose(track.state.mean, np.array([[5]]), atol=0.4)
             assert track.state.hypothesis.measurement is detections[0]

--- a/stonesoup/initiator/tests/test_simple.py
+++ b/stonesoup/initiator/tests/test_simple.py
@@ -361,10 +361,10 @@ def test_gaussian_particle(gaussian_initiator):
         assert isinstance(track.state, ParticleStateUpdate)
         print(track.state.mean)
         if track.state.mean > 0:
-            assert np.allclose(track.state_vector, np.array([[5]]), atol=0.4)
+            assert np.allclose(track.state.mean, np.array([[5]]), atol=0.4)
             assert track.state.hypothesis.measurement is detections[0]
         else:
-            assert np.allclose(track.state_vector, np.array([[-5]]), atol=0.4)
+            assert np.allclose(track.state.mean, np.array([[-5]]), atol=0.4)
             assert track.state.hypothesis.measurement is detections[1]
         assert track.timestamp == timestamp
 

--- a/stonesoup/initiator/tests/test_simple.py
+++ b/stonesoup/initiator/tests/test_simple.py
@@ -359,7 +359,8 @@ def test_gaussian_particle(gaussian_initiator):
 
     for track in tracks:
         assert isinstance(track.state, ParticleStateUpdate)
-        if track.state_vector > 0:
+        print(track.state.mean)
+        if track.state.mean > 0:
             assert np.allclose(track.state_vector, np.array([[5]]), atol=0.4)
             assert track.state.hypothesis.measurement is detections[0]
         else:

--- a/stonesoup/measures.py
+++ b/stonesoup/measures.py
@@ -185,16 +185,25 @@ class Mahalanobis(Measure):
             objects
 
         """
+        if hasattr(state1, 'mean'):
+            state_vector1 = state1.mean
+        else:
+            state_vector1 = state1.state_vector
+        if hasattr(state2, 'mean'):
+            state_vector2 = state2.mean
+        else:
+            state_vector2 = state2.state_vector
+
         if self.mapping is not None:
-            u = state1.state_vector[self.mapping, 0]
-            v = state2.state_vector[self.mapping2, 0]
+            u = state_vector1[self.mapping, 0]
+            v = state_vector2[self.mapping2, 0]
             # extract the mapped covariance data
             rows = np.array(self.mapping, dtype=np.intp)
             columns = np.array(self.mapping, dtype=np.intp)
             cov = state1.covar[rows[:, np.newaxis], columns]
         else:
-            u = state1.state_vector[:, 0]
-            v = state2.state_vector[:, 0]
+            u = state_vector1[:, 0]
+            v = state_vector2[:, 0]
             cov = state1.covar
 
         vi = np.linalg.inv(cov)

--- a/stonesoup/measures.py
+++ b/stonesoup/measures.py
@@ -82,6 +82,15 @@ class Euclidean(Measure):
 
         """
         # Calculate Euclidean distance between two state
+        if hasattr(state1, 'mean'):
+            state_vector1 = state1.mean
+        else:
+            state_vector1 = state1.state_vector
+        if hasattr(state2, 'mean'):
+            state_vector2 = state2.mean
+        else:
+            state_vector2 = state2.state_vector
+
         if self.mapping is not None:
             return distance.euclidean(state_vector1[self.mapping, 0],
                                       state_vector2[self.mapping2, 0])
@@ -127,6 +136,15 @@ class EuclideanWeighted(Measure):
             :class:`~.State` objects
 
         """
+        if hasattr(state1, 'mean'):
+            state_vector1 = state1.mean
+        else:
+            state_vector1 = state1.state_vector
+        if hasattr(state2, 'mean'):
+            state_vector2 = state2.mean
+        else:
+            state_vector2 = state2.state_vector
+
         if self.mapping is not None:
             return distance.euclidean(state_vector1[self.mapping, 0],
                                       state_vector2[self.mapping2, 0],

--- a/stonesoup/measures.py
+++ b/stonesoup/measures.py
@@ -83,10 +83,10 @@ class Euclidean(Measure):
         """
         # Calculate Euclidean distance between two state
         if self.mapping is not None:
-            return distance.euclidean(state1.state_vector[self.mapping, 0],
-                                      state2.state_vector[self.mapping2, 0])
+            return distance.euclidean(state_vector1[self.mapping, 0],
+                                      state_vector2[self.mapping2, 0])
         else:
-            return distance.euclidean(state1.state_vector[:, 0], state2.state_vector[:, 0])
+            return distance.euclidean(state_vector1[:, 0], state_vector2[:, 0])
 
 
 class EuclideanWeighted(Measure):
@@ -128,12 +128,12 @@ class EuclideanWeighted(Measure):
 
         """
         if self.mapping is not None:
-            return distance.euclidean(state1.state_vector[self.mapping, 0],
-                                      state2.state_vector[self.mapping2, 0],
+            return distance.euclidean(state_vector1[self.mapping, 0],
+                                      state_vector2[self.mapping2, 0],
                                       self.weighting)
         else:
-            return distance.euclidean(state1.state_vector[:, 0],
-                                      state2.state_vector[:, 0],
+            return distance.euclidean(state_vector1[:, 0],
+                                      state_vector2[:, 0],
                                       self.weighting)
 
 

--- a/stonesoup/metricgenerator/tests/test_plotter.py
+++ b/stonesoup/metricgenerator/tests/test_plotter.py
@@ -9,7 +9,6 @@ from ...types.track import Track
 from ...types.groundtruth import GroundTruthPath
 from ...types.state import State, GaussianState, ParticleState
 from ...types.detection import Detection
-from ...types.particle import Particles
 from ...types.array import StateVectors
 
 
@@ -24,8 +23,8 @@ def test_twodplotter():
                                           timestamp=timestamp1 + datetime.timedelta(
                                           seconds=i),
                                           covar=np.diag([0.5, 0.5])) for i in range(11)])}
-    tracksB = {Track(states=[ParticleState(particles=Particles(
-        state_vector=StateVectors([[1], [2]])),
+    tracksB = {Track(states=[ParticleState(
+        state_vector=StateVectors([[1], [2]]),
         timestamp=timestamp1 + datetime.timedelta(
             seconds=i)) for i in range(11)])}
     truths = {GroundTruthPath(states=[State(np.array([[1], [2]]),

--- a/stonesoup/models/measurement/tests/test_models.py
+++ b/stonesoup/models/measurement/tests/test_models.py
@@ -16,8 +16,7 @@ from ....functions import pol2cart
 from ....functions import rotz, rotx, roty, cart2sphere
 from ....types.angle import Bearing, Elevation
 from ....types.array import StateVector, StateVectors
-from ....types.state import State, CovarianceMatrix
-from ....types.particle import Particles
+from ....types.state import State, CovarianceMatrix, ParticleState
 
 
 def h1d(state_vector, pos_map, translation_offset, rotation_offset):
@@ -717,7 +716,7 @@ def test_rangeratemodels_with_particles(h, modelclass, state_vec, ndim_state, po
                                     [state_vec[5, 0]]
                                     ])
 
-    state = Particles(state_vec, weight=[1/nparticles] * nparticles)
+    state = ParticleState(state_vec, weight=[1/nparticles] * nparticles)
 
     # Check default translation_offset, rotation_offset and velocity is applied
     model_test = modelclass(ndim_state=ndim_state,
@@ -1133,8 +1132,7 @@ def test_models_with_particles(h, ModelClass, state_vec, R,
                                         [state_vec[2, 0]]
                                         ])
 
-    state = Particles(state_vector=state_vec,
-                      weight=[1/nparticles] * nparticles)
+    state = ParticleState(state_vector=state_vec, weight=[1/nparticles] * nparticles)
 
     # Check default translation_offset, rotation_offset and velocity is applied
     model_test = ModelClass(ndim_state=ndim_state,

--- a/stonesoup/platform/tests/test_platform_simple.py
+++ b/stonesoup/platform/tests/test_platform_simple.py
@@ -6,7 +6,7 @@ import pytest
 
 from ..tests import test_platform_base
 from ...types.state import State
-from stonesoup.platform import MovingPlatform, FixedPlatform
+from ...platform import MovingPlatform, FixedPlatform
 from ...models.transition.linear import ConstantVelocity, CombinedLinearGaussianTransitionModel
 from ...sensor.radar.radar import RadarBearingRange
 from ...types.array import StateVector, CovarianceMatrix

--- a/stonesoup/plotter.py
+++ b/stonesoup/plotter.py
@@ -265,7 +265,7 @@ class Plotter:
                                         [state.mean[mapping[1]] for state in track],
                                         [state.mean[mapping[2]] for state in track],
                                         **tracks_kwargs)
-            except:
+            except AttributeError:
                 if self.dimension is Dimension.TWO:
                     line = self.ax.plot([state.state_vector[mapping[0]] for state in track],
                                         [state.state_vector[mapping[1]] for state in track],

--- a/stonesoup/plotter.py
+++ b/stonesoup/plotter.py
@@ -8,8 +8,6 @@ from matplotlib.patches import Ellipse
 from matplotlib.legend_handler import HandlerPatch
 
 from .types import detection
-from .models.base import LinearModel, NonLinearModel
-from .types.update import ParticleStateUpdate
 from .models.base import LinearModel, Model
 
 from enum import Enum

--- a/stonesoup/plotter.py
+++ b/stonesoup/plotter.py
@@ -8,6 +8,8 @@ from matplotlib.patches import Ellipse
 from matplotlib.legend_handler import HandlerPatch
 
 from .types import detection
+from .models.base import LinearModel, NonLinearModel
+from .types.update import ParticleStateUpdate
 from .models.base import LinearModel, Model
 
 from enum import Enum
@@ -253,15 +255,27 @@ class Plotter:
         # Plot tracks
         track_colors = {}
         for track in tracks:
-            if self.dimension is Dimension.TWO:
-                line = self.ax.plot([state.state_vector[mapping[0]] for state in track],
-                                    [state.state_vector[mapping[1]] for state in track],
-                                    **tracks_kwargs)
-            else:
-                line = self.ax.plot([state.state_vector[mapping[0]] for state in track],
-                                    [state.state_vector[mapping[1]] for state in track],
-                                    [state.state_vector[mapping[2]] for state in track],
-                                    **tracks_kwargs)
+            try:
+                if self.dimension is Dimension.TWO:
+                    line = self.ax.plot([state.mean[mapping[0]] for state in track],
+                                        [state.mean[mapping[1]] for state in track],
+                                        **tracks_kwargs)
+                else:
+                    line = self.ax.plot([state.mean[mapping[0]] for state in track],
+                                        [state.mean[mapping[1]] for state in track],
+                                        [state.mean[mapping[2]] for state in track],
+                                        **tracks_kwargs)
+            except:
+                if self.dimension is Dimension.TWO:
+                    line = self.ax.plot([state.state_vector[mapping[0]] for state in track],
+                                        [state.state_vector[mapping[1]] for state in track],
+                                        **tracks_kwargs)
+                else:
+                    line = self.ax.plot([state.state_vector[mapping[0]] for state in track],
+                                        [state.state_vector[mapping[1]] for state in track],
+                                        [state.state_vector[mapping[2]] for state in track],
+                                        **tracks_kwargs)
+                continue
             track_colors[track] = plt.getp(line[0], 'color')
 
         # Assuming a single track or all plotted as the same colour then the following will work.
@@ -328,7 +342,7 @@ class Plotter:
                 # Plot particles
                 for track in tracks:
                     for state in track:
-                        data = state.particles.state_vector[mapping[:2], :]
+                        data = state.state_vector[mapping[:2], :]
                         self.ax.plot(data[0], data[1], linestyle='', marker=".",
                                      markersize=1, alpha=0.5)
 

--- a/stonesoup/predictor/particle.py
+++ b/stonesoup/predictor/particle.py
@@ -48,10 +48,6 @@ class ParticlePredictor(Predictor):
             num_samples=len(prior),
             **kwargs)
 
-        # new_particles = Particles(state_vector=new_state_vector,
-        #                           weight=prior.particles.weight,
-        #                           parent=prior.particles.parent)
-
         return Prediction.from_state(prior, state_vector=new_state_vector, weight=prior.weight,
                                      timestamp=timestamp, particle_list=None,
                                      transition_model=self.transition_model)
@@ -96,12 +92,6 @@ class ParticleFlowKalmanPredictor(ParticlePredictor):
             GaussianState(prior.state_vector, prior.covar, prior.timestamp),
             *args, **kwargs)
 
-        # The second parameter here in a particle state is the weight...?
-        # or is that the fixed_covar property
-        # return ParticleStatePrediction(particle_prediction.state_vector,
-        #                              particle_prediction.weight,
-        #    fixed_covar=kalman_prediction.covar,
-        #    timestamp=particle_prediction.timestamp)
         return Prediction.from_state(prior, state_vector=particle_prediction.state_vector,
                                      weight=particle_prediction.weight,
                                      timestamp=particle_prediction.timestamp,

--- a/stonesoup/predictor/particle.py
+++ b/stonesoup/predictor/particle.py
@@ -4,7 +4,7 @@ from .base import Predictor
 from ._utils import predict_lru_cache
 from .kalman import KalmanPredictor, ExtendedKalmanPredictor
 from ..base import Property
-from ..types.particle import Particles
+# from ..types.particle import Particles
 from ..types.prediction import Prediction, ParticleStatePrediction
 from ..types.state import GaussianState
 
@@ -43,16 +43,16 @@ class ParticlePredictor(Predictor):
             time_interval = None
 
         new_state_vector = self.transition_model.function(
-            prior.particles,
+            prior,
             noise=True,
             time_interval=time_interval,
-            num_samples=len(prior.particles),
+            num_samples=len(prior),
             **kwargs)
-        new_particles = Particles(state_vector=new_state_vector,
-                                  weight=prior.particles.weight,
-                                  parent=prior.particles.parent)
+        # new_particles = Particles(state_vector=new_state_vector,
+        #                           weight=prior.particles.weight,
+        #                           parent=prior.particles.parent)
 
-        return Prediction.from_state(prior, particles=new_particles, timestamp=timestamp,
+        return Prediction.from_state(prior, state_vector=new_state_vector, timestamp=timestamp,
                                      transition_model=self.transition_model)
 
 

--- a/stonesoup/predictor/tests/test_particle.py
+++ b/stonesoup/predictor/tests/test_particle.py
@@ -45,7 +45,7 @@ def test_particle(predictor_class):
                        Particle(np.array([[30], [30]]),
                                 1 / 9),
                        ]
-    prior = ParticleState(prior_particles, timestamp=timestamp)
+    prior = ParticleState(None, particle_list=prior_particles, timestamp=timestamp)
 
     eval_particles = [Particle(cv.matrix(timestamp=new_timestamp,
                                          time_interval=time_interval)
@@ -55,7 +55,7 @@ def test_particle(predictor_class):
     eval_mean = np.mean(np.hstack([i.state_vector for i in eval_particles]),
                         axis=1).reshape(2, 1)
 
-    eval_prediction = ParticleStatePrediction(eval_particles, new_timestamp)
+    eval_prediction = ParticleStatePrediction(None, new_timestamp, particle_list=eval_particles)
 
     predictor = predictor_class(transition_model=cv)
 
@@ -63,6 +63,6 @@ def test_particle(predictor_class):
 
     assert np.allclose(prediction.mean, eval_mean)
     assert prediction.timestamp == new_timestamp
-    assert np.all([eval_prediction.particles[i].state_vector ==
-                   prediction.particles[i].state_vector for i in range(9)])
-    assert np.all([prediction.particles[i].weight == 1 / 9 for i in range(9)])
+    assert np.all([eval_prediction.state_vector[:, i] ==
+                   prediction.state_vector[:, i] for i in range(9)])
+    assert np.all([prediction.weight[i] == 1 / 9 for i in range(9)])

--- a/stonesoup/reader/tests/test_image.py
+++ b/stonesoup/reader/tests/test_image.py
@@ -3,7 +3,7 @@ import pytest
 import numpy as np
 from PIL import Image
 
-from stonesoup.reader.image import SingleImageFileReader
+from ...reader.image import SingleImageFileReader
 
 
 @pytest.fixture()

--- a/stonesoup/resampler/particle.py
+++ b/stonesoup/resampler/particle.py
@@ -4,7 +4,8 @@ import numpy as np
 from .base import Resampler
 from ..base import Property
 from ..types.numeric import Probability
-from ..types.particle import Particles
+# from ..types.particle import Particles
+from ..types.state import ParticleState
 
 
 class SystematicResampler(Resampler):
@@ -23,8 +24,8 @@ class SystematicResampler(Resampler):
             The resampled particles
         """
 
-        if not isinstance(particles, Particles):
-            particles = Particles(particle_list=particles)
+        if not isinstance(particles, ParticleState):
+            particles = ParticleState(particle_list=particles)
         n_particles = len(particles)
         weight = Probability(1 / n_particles)
 
@@ -42,10 +43,12 @@ class SystematicResampler(Resampler):
         # that pushed the score over the current value
         u_j = u_i + (1 / n_particles) * np.arange(n_particles)
         index = weight_order[np.searchsorted(cdf, np.log(u_j))]
-        new_particles = Particles(state_vector=particles.state_vector[:, index],
-                                  weight=[weight] * n_particles,
-                                  parent=Particles(state_vector=particles.state_vector[:, index],
-                                                   weight=particles.weight[index]))
+        new_particles = ParticleState(state_vector=particles.state_vector[:, index],
+                                      weight=[weight] * n_particles,
+                                      parent=ParticleState(state_vector=particles.state_vector[:, index],
+                                                           weight=particles.weight[index],
+                                                           timestamp=particles.timestamp),
+                                      timestamp=particles.timestamp)
         return new_particles
 
 

--- a/stonesoup/resampler/particle.py
+++ b/stonesoup/resampler/particle.py
@@ -4,7 +4,6 @@ import numpy as np
 from .base import Resampler
 from ..base import Property
 from ..types.numeric import Probability
-# from ..types.particle import Particles
 from ..types.state import ParticleState
 
 

--- a/stonesoup/resampler/particle.py
+++ b/stonesoup/resampler/particle.py
@@ -85,8 +85,8 @@ class ESSResampler(Resampler):
         particles : list of :class:`~.Particle`
             The particles, either unchanged or resampled, depending on weight degeneracy
         """
-        if not isinstance(particles, Particles):
-            particles = Particles(particle_list=particles)
+        if not isinstance(particles, ParticleState):
+            particles = ParticleState(None, particle_list=particles)
         if self.threshold is None:
             self.threshold = len(particles) / 2
         if 1 / np.sum(np.square(particles.weight)) < self.threshold:  # If ESS too small, resample

--- a/stonesoup/resampler/particle.py
+++ b/stonesoup/resampler/particle.py
@@ -44,10 +44,11 @@ class SystematicResampler(Resampler):
         u_j = u_i + (1 / n_particles) * np.arange(n_particles)
         index = weight_order[np.searchsorted(cdf, np.log(u_j))]
         new_particles = ParticleState(state_vector=particles.state_vector[:, index],
-                                      weight=[weight] * n_particles,
-                                      parent=ParticleState(state_vector=particles.state_vector[:, index],
-                                                           weight=particles.weight[index],
-                                                           timestamp=particles.timestamp),
+                                      weight=[weight]*n_particles,
+                                      parent=ParticleState(
+                                          state_vector=particles.state_vector[:, index],
+                                          weight=particles.weight[index],
+                                          timestamp=particles.timestamp),
                                       timestamp=particles.timestamp)
         return new_particles
 

--- a/stonesoup/resampler/particle.py
+++ b/stonesoup/resampler/particle.py
@@ -25,7 +25,7 @@ class SystematicResampler(Resampler):
         """
 
         if not isinstance(particles, ParticleState):
-            particles = ParticleState(particle_list=particles)
+            particles = ParticleState(None, particle_list=particles)
         n_particles = len(particles)
         weight = Probability(1 / n_particles)
 

--- a/stonesoup/resampler/particle.py
+++ b/stonesoup/resampler/particle.py
@@ -15,13 +15,13 @@ class SystematicResampler(Resampler):
 
         Parameters
         ----------
-        particles : list of :class:`~.Particle`
-            The particles to be resampled according to their weight
+        particles : :class:`~.ParticleState` or list of :class:`~.Particle`
+            The particles or particle state to be resampled according to their weights
 
         Returns
         -------
-        particles : list of :class:`~.Particle`
-            The resampled particles
+        particle state: :class:`~.ParticleState`
+            The particle state after resampling
         """
 
         if not isinstance(particles, ParticleState):

--- a/stonesoup/resampler/tests/test_particle.py
+++ b/stonesoup/resampler/tests/test_particle.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 import numpy as np
 
-from ...types.particle import Particle, \
-    Particles
+from ...types.particle import Particle
+from ...types.state import ParticleState
 from ..particle import SystematicResampler
 from ..particle import ESSResampler
 
@@ -49,7 +49,7 @@ def test_systematic_even():
 def test_ess_zero():
     particles = [Particle(np.array([[i]]), weight=(i+1) / 55)
                  for i in range(10)]
-    particles = Particles(particle_list=particles)  # Needed for assert line
+    particles = ParticleState(None, particle_list=particles)  # Needed for assert line
 
     resampler = ESSResampler(0)  # Should never resample
 
@@ -72,7 +72,7 @@ def test_ess_n():
 def test_ess_inequality():
     particles = [Particle(np.array([[i]]), weight=(i + 1) / 55)
                  for i in range(10)]
-    particles = Particles(particle_list=particles)
+    particles = ParticleState(None, particle_list=particles)
 
     resampler1 = ESSResampler(3025/385)  # This resampler should not resample
     resampler2 = ESSResampler(3025/385 + 0.01)  # This resampler should resample

--- a/stonesoup/tests/test_measures.py
+++ b/stonesoup/tests/test_measures.py
@@ -18,11 +18,13 @@ u = StateVector([[10.], [1.], [10.], [1.]])
 ui = CovarianceMatrix(np.diag([100., 10., 100., 10.]))
 
 state_u = GaussianState(u, ui, timestamp=t)
+stateB_u = State(u, timestamp=t)
 
 v = StateVector([[11.], [10.], [100.], [2.]])
 vi = CovarianceMatrix(np.diag([20., 3., 7., 10.]))
 
 state_v = GaussianState(v, vi, timestamp=t)
+stateB_v = State(v, timestamp=t)
 
 
 def test_measure_raise_error():
@@ -41,6 +43,7 @@ def test_euclideanweighted():
     weight = np.array([1, 2, 3, 1])
     measure = measures.EuclideanWeighted(weight)
     assert measure(state_u, state_v) == distance.euclidean(u[:, 0], v[:, 0], weight)
+    assert measure(stateB_u, stateB_v) == distance.euclidean(u[:, 0], v[:, 0], weight)
 
 
 def test_mahalanobis():

--- a/stonesoup/types/particle.py
+++ b/stonesoup/types/particle.py
@@ -1,13 +1,8 @@
 # -*- coding: utf-8 -*-
 
-from typing import MutableSequence
-
-import numpy as np
-
 from ..base import Property
-from .array import StateVector, StateVectors
+from .array import StateVector
 from .base import Type
-from .numeric import Probability
 
 
 class Particle(Type):
@@ -26,64 +21,6 @@ class Particle(Type):
         if state_vector is not None and not isinstance(state_vector, StateVector):
             state_vector = StateVector(state_vector)
         super().__init__(state_vector, weight, parent, *args, **kwargs)
-
-    @property
-    def ndim(self):
-        return self.state_vector.shape[0]
-
-
-class Particles(Type):
-    """
-    Particle type
-
-    A collection of particles. Contains a state and weight for each particle
-    """
-    state_vector: StateVectors = Property(default=None, doc="State vectors of particles")
-    weight: MutableSequence[Probability] = Property(default=None, doc='Weights of particles')
-    parent: 'Particles' = Property(default=None, doc='Parent particles')
-    particle_list: MutableSequence[Particle] = Property(default=None,
-                                                        doc='List of Particle objects')
-
-    def __init__(self, state_vector=None, weight=None, parent=None, particle_list=None,
-                 *args, **kwargs):
-        if (particle_list is not None) and (state_vector is not None or weight is not None):
-            raise ValueError("Use either a list of Particle objects or StateVectors and weights,"
-                             " but not both.")
-
-        if particle_list and isinstance(particle_list, list):
-            state_vector = StateVectors([particle.state_vector for particle in particle_list])
-            weight = np.array([Probability(particle.weight) for particle in particle_list])
-            parent_list = [particle.parent for particle in particle_list]
-
-            if parent_list.count(None) == 0:
-                parent = Particles(particle_list=parent_list)
-            elif 0 < parent_list.count(None) < len(parent_list):
-                raise ValueError("Either all particles should have"
-                                 " parents or none of them should.")
-
-        if parent:
-            parent.parent = None
-
-        if state_vector is not None and not isinstance(state_vector, StateVectors):
-            state_vector = StateVectors(state_vector)
-        if weight is not None and isinstance(weight, np.ndarray):
-            weight = np.array(weight)
-
-        super().__init__(state_vector, weight, parent, particle_list, *args, **kwargs)
-
-    def __getitem__(self, item):
-        if self.parent:
-            p = self.parent[item]
-        else:
-            p = None
-
-        particle = Particle(state_vector=self.state_vector[:, item],
-                            weight=self.weight[item],
-                            parent=p)
-        return particle
-
-    def __len__(self):
-        return self.state_vector.shape[1]
 
     @property
     def ndim(self):

--- a/stonesoup/types/state.py
+++ b/stonesoup/types/state.py
@@ -486,6 +486,10 @@ class ParticleState(State):
                             parent=p)
         return particle
 
+    @property
+    def particles(self):
+        return [particle for particle in self]
+
     def __len__(self):
         return self.state_vector.shape[1]
 

--- a/stonesoup/types/state.py
+++ b/stonesoup/types/state.py
@@ -25,8 +25,7 @@ class State(Type):
     def __init__(self, state_vector, *args, **kwargs):
         # Don't cast away subtype of state_vector if not necessary
         if state_vector is not None \
-                and not isinstance(state_vector, StateVector)\
-                and not isinstance(state_vector, StateVectors):
+                and not isinstance(state_vector, (StateVector, StateVectors)):
             state_vector = StateVector(state_vector)
         super().__init__(state_vector, *args, **kwargs)
 
@@ -457,17 +456,17 @@ class ParticleState(State):
             parent_list = [particle.parent for particle in self.particle_list]
 
             if parent_list.count(None) == 0:
-                self.parent = ParticleState(particle_list=parent_list)
+                self.parent = ParticleState(None, particle_list=parent_list)
             elif 0 < parent_list.count(None) < len(parent_list):
                 raise ValueError("Either all particles should have"
                                  " parents or none of them should.")
 
         if self.parent:
-            self.parent.parent = None
+            self.parent.parent = None  # Removed to avoid using significant memory
 
         if self.state_vector is not None and not isinstance(self.state_vector, StateVectors):
             self.state_vector = StateVectors(self.state_vector)
-        if self.weight is not None and isinstance(self.weight, np.ndarray):
+        if self.weight is not None and not isinstance(self.weight, np.ndarray):
             self.weight = np.array(self.weight)
 
     def __getitem__(self, item):

--- a/stonesoup/types/state.py
+++ b/stonesoup/types/state.py
@@ -433,9 +433,6 @@ class ParticleState(State):
     This is a particle state object which describes the state as a
     distribution of particles"""
 
-    # timestamp: datetime.datetime = Property(default=None,
-    #                                         doc="Timestamp of the state. Default None.")
-    # state_vector: StateVectors = Property(default=None, doc="State vectors of particles")
     weight: MutableSequence[Probability] = Property(default=None, doc='Weights of particles')
     parent: 'ParticleState' = Property(default=None, doc='Parent particles')
     particle_list: MutableSequence[Particle] = Property(default=None,
@@ -473,8 +470,6 @@ class ParticleState(State):
         if self.weight is not None and isinstance(self.weight, np.ndarray):
             self.weight = np.array(self.weight)
 
-        # super().__init__(*args, **kwargs)
-
     def __getitem__(self, item):
         if self.parent:
             p = self.parent[item]
@@ -505,12 +500,6 @@ class ParticleState(State):
                             weights=self.weight)
         # Convert type as may have type of weights
         return result
-
-    # ###From Particles class###
-    # @property
-    # def state_vector(self):
-    #     """The mean value of the particle states"""
-    #     return self.mean
 
     @property
     def covar(self):

--- a/stonesoup/types/state.py
+++ b/stonesoup/types/state.py
@@ -2,7 +2,7 @@
 import datetime
 import uuid
 from collections import abc
-from typing import MutableSequence, Union, Any, Optional, Sequence
+from typing import MutableSequence, Any, Optional, Sequence
 import typing
 
 import numpy as np
@@ -20,7 +20,7 @@ class State(Type):
     Most simple state type, which only has time and a state vector."""
     timestamp: datetime.datetime = Property(
         default=None, doc="Timestamp of the state. Default None.")
-    state_vector: Union[StateVector, StateVectors] = Property(doc='State vector.')
+    state_vector: StateVector = Property(doc='State vector.')
 
     def __init__(self, state_vector, *args, **kwargs):
         # Don't cast away subtype of state_vector if not necessary
@@ -432,6 +432,7 @@ class ParticleState(State):
     This is a particle state object which describes the state as a
     distribution of particles"""
 
+    state_vector: StateVectors = Property(doc='State vectors.')
     weight: MutableSequence[Probability] = Property(default=None, doc='Weights of particles')
     parent: 'ParticleState' = Property(default=None, doc='Parent particles')
     particle_list: MutableSequence[Particle] = Property(default=None,

--- a/stonesoup/types/state.py
+++ b/stonesoup/types/state.py
@@ -447,13 +447,16 @@ class ParticleState(State):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        if (self.particle_list is not None) and (self.state_vector is not None or self.weight is not None):
+        if (self.particle_list is not None) and \
+                (self.state_vector is not None or self.weight is not None):
             raise ValueError("Use either a list of Particle objects or StateVectors and weights,"
                              " but not both.")
 
         if self.particle_list and isinstance(self.particle_list, list):
-            self.state_vector = StateVectors([particle.state_vector for particle in self.particle_list])
-            self.weight = np.array([Probability(particle.weight) for particle in self.particle_list])
+            self.state_vector = \
+                StateVectors([particle.state_vector for particle in self.particle_list])
+            self.weight = \
+                np.array([Probability(particle.weight) for particle in self.particle_list])
             parent_list = [particle.parent for particle in self.particle_list]
 
             if parent_list.count(None) == 0:

--- a/stonesoup/types/tests/test_particle.py
+++ b/stonesoup/types/tests/test_particle.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
-import pytest
+# import pytest
 import numpy as np
 
-from ..particle import Particle, Particles
+from ..particle import Particle
 
 
 def test_particle():
@@ -19,46 +19,3 @@ def test_particle():
 
     assert particle3.parent is particle2
     assert particle3.parent.parent is None
-
-
-def test_particles():
-    particles1 = Particles(np.array([[0, 0, 0]]), weight=[0.1, 0.1, 0.1])
-    particle1 = Particle(np.array([[0]]), weight=0.1)
-
-    assert np.array_equal(particles1.state_vector, np.array([[0, 0, 0]]))
-    assert np.array_equal(particles1.weight, np.array([0.1, 0.1, 0.1]))
-    assert np.array_equal(particles1[0].state_vector, particle1.state_vector)
-    assert particles1[0].weight == particle1.weight
-    assert particles1[0].parent == particle1.parent
-    assert particles1.ndim == 1
-
-    particles2 = Particles(np.array([[0, 0, 0]]), weight=[0.1, 0.1, 0.1], parent=particles1)
-
-    assert particles2.parent is particles1
-
-    particles3 = Particles(np.array([[0, 0, 0]]), weight=[0.1, 0.1, 0.1], parent=particles2)
-
-    assert particles3.parent is particles2
-    assert particles3.parent.parent is None
-
-    particle_list = [Particle(np.array([[0]]), weight=0.1),
-                     Particle(np.array([[0]]), weight=0.1),
-                     Particle(np.array([[0]]), weight=0.1),
-                     ]
-    particles_from_list = Particles(particle_list=particle_list)
-
-    assert np.array_equal(particles_from_list.state_vector, particles1.state_vector)
-    assert np.array_equal(particles_from_list.weight, particles1.weight)
-    assert particles_from_list.parent == particles1.parent
-
-    with pytest.raises(ValueError):
-        # Should never happen that only some particles have parents. Should give ValueError.
-        particle_list_fail = [Particle(np.array([[0]]), weight=0.1, parent=None),
-                              Particle(np.array([[0]]), weight=0.1, parent=particle1),
-                              Particle(np.array([[0]]), weight=0.1, parent=None),
-                              ]
-
-        Particles(particle_list=particle_list_fail)
-
-        # Cannot set Particles object with both a particle list and a state vector/weight
-        Particles(np.array([[0, 0, 0]]), weight=[0.1, 0.1, 0.1], particle_list=particle_list)

--- a/stonesoup/types/tests/test_particle.py
+++ b/stonesoup/types/tests/test_particle.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-# import pytest
 import numpy as np
 
 from ..particle import Particle

--- a/stonesoup/types/tests/test_prediction.py
+++ b/stonesoup/types/tests/test_prediction.py
@@ -14,6 +14,7 @@ from ..prediction import (
 from ..state import (
     State, GaussianState, SqrtGaussianState, TaggedWeightedGaussianState, ParticleState)
 from ..track import Track
+from ..array import StateVectors
 
 
 def test_stateprediction():
@@ -166,8 +167,8 @@ def test_from_state(prediction_type):
         assert prediction.weight == 0.5
         assert prediction.tag == state.tag
 
-    state = ParticleState([Particle([[0]], weight=0.5)], timestamp=datetime.datetime.now())
-    prediction = prediction_type.from_state(state, particles=[Particle([[1]], weight=0.8)])
+    state = ParticleState(StateVectors([[1]]), weight=0.5, timestamp=datetime.datetime.now())
+    prediction = prediction_type.from_state(state)
     if prediction_type is Prediction:
         assert isinstance(prediction, ParticleStatePrediction)
     else:

--- a/stonesoup/types/tests/test_prediction.py
+++ b/stonesoup/types/tests/test_prediction.py
@@ -4,7 +4,6 @@ import datetime
 import numpy as np
 import pytest
 
-from ..particle import Particle
 from ..prediction import (
     Prediction, MeasurementPrediction,
     StatePrediction, StateMeasurementPrediction,

--- a/stonesoup/types/tests/test_state.py
+++ b/stonesoup/types/tests/test_state.py
@@ -10,7 +10,6 @@ from stonesoup.types.state import CreatableFromState
 from ..angle import Bearing
 from ..array import StateVector, CovarianceMatrix, StateVectors
 from ..numeric import Probability
-from ..particle import Particle
 from ..state import State, GaussianState, ParticleState, \
     StateMutableSequence, WeightedGaussianState, SqrtGaussianState, CategoricalState
 from ...base import Property
@@ -140,7 +139,7 @@ def test_particlestate():
     num_particles = 10
     weight = Probability(1/num_particles)
     particles = StateVectors(np.concatenate(
-        (np.tile([[0]],num_particles//2), np.tile([[100]],num_particles//2)), axis=1))
+        (np.tile([[0]], num_particles//2), np.tile([[100]], num_particles//2)), axis=1))
     weights = np.tile(weight, num_particles)
 
     # Test state without timestamp
@@ -160,7 +159,7 @@ def test_particlestate():
     #  [0,0,0,0,0,200,200,200,200,200]]
     # use same weights
     particles = StateVectors(np.concatenate((np.tile([[0], [0]], num_particles//2),
-                                             np.tile([[100], [200]],num_particles//2)),
+                                             np.tile([[100], [200]], num_particles//2)),
                                             axis=1))
 
     state = ParticleState(particles, weight=weights)

--- a/stonesoup/types/tests/test_state.py
+++ b/stonesoup/types/tests/test_state.py
@@ -8,7 +8,7 @@ import scipy.linalg
 from stonesoup.types.groundtruth import GroundTruthState
 from stonesoup.types.state import CreatableFromState
 from ..angle import Bearing
-from ..array import StateVector, CovarianceMatrix
+from ..array import StateVector, CovarianceMatrix, StateVectors
 from ..numeric import Probability
 from ..particle import Particle
 from ..state import State, GaussianState, ParticleState, \
@@ -135,42 +135,38 @@ def test_particlestate():
     with pytest.raises(TypeError):
         ParticleState()
 
-    # 1D
+    # Create 10 1d particles: [[0,0,0,0,0,100,100,100,100,100]]
+    # with equal weight
     num_particles = 10
-    state_vector1 = StateVector([[0.]])
-    state_vector2 = StateVector([[100.]])
     weight = Probability(1/num_particles)
-    particles = []
-    particles.extend(Particle(
-        state_vector1, weight=weight) for _ in range(num_particles//2))
-    particles.extend(Particle(
-        state_vector2, weight=weight) for _ in range(num_particles//2))
+    particles = StateVectors(np.concatenate(
+        (np.tile([[0]],num_particles//2), np.tile([[100]],num_particles//2)), axis=1))
+    weights = np.tile(weight, num_particles)
 
     # Test state without timestamp
-    state = ParticleState(particles)
-    assert np.allclose(state.state_vector, StateVector([[50]]))
+    state = ParticleState(particles, weight=weights)
+    assert np.allclose(state.mean, StateVector([[50]]))
     assert np.allclose(state.covar, CovarianceMatrix([[2500]]))
 
     # Test state with timestamp
     timestamp = datetime.datetime.now()
-    state = ParticleState(particles, timestamp=timestamp)
-    assert np.allclose(state.state_vector, StateVector([[50]]))
+    state = ParticleState(particles, weight=weights, timestamp=timestamp)
+    assert np.allclose(state.mean, StateVector([[50]]))
     assert np.allclose(state.covar, CovarianceMatrix([[2500]]))
     assert state.timestamp == timestamp
 
-    # 2D
-    state_vector1 = StateVector([[0.], [0.]])
-    state_vector2 = StateVector([[100.], [200.]])
-    particles = []
-    particles.extend(Particle(
-        state_vector1, weight=weight) for _ in range(num_particles//2))
-    particles.extend(Particle(
-        state_vector2, weight=weight) for _ in range(num_particles//2))
+    # Now create 10 2d particles:
+    # [[0,0,0,0,0,100,100,100,100,100],
+    #  [0,0,0,0,0,200,200,200,200,200]]
+    # use same weights
+    particles = StateVectors(np.concatenate((np.tile([[0], [0]], num_particles//2),
+                                             np.tile([[100], [200]],num_particles//2)),
+                                            axis=1))
 
-    state = ParticleState(particles)
+    state = ParticleState(particles, weight=weights)
     assert isinstance(state, State)
     assert ParticleState in State.subclasses
-    assert np.allclose(state.state_vector, StateVector([[50], [100]]))
+    assert np.allclose(state.mean, StateVector([[50], [100]]))
     assert np.allclose(state.covar, CovarianceMatrix([[2500, 5000], [5000, 10000]]))
 
 
@@ -178,43 +174,56 @@ def test_particlestate_weighted():
     num_particles = 10
 
     # Half particles at high weight at 0
-    state_vector1 = StateVector([[0.]])
-    weight1 = Probability(0.75 / (num_particles / 2))
-
-    # Other half of particles low weight at 100
-    state_vector2 = StateVector([[100]])
-    weight2 = Probability(0.25 / (num_particles / 2))
-
-    particles = []
-    particles.extend(Particle(
-        state_vector1, weight=weight1) for _ in range(num_particles//2))
-    particles.extend(Particle(
-        state_vector2, weight=weight2) for _ in range(num_particles//2))
+    # Create 10 1d particles: [[0,0,0,0,0,100,100,100,100,100]]
+    # with different weights this time. First half have 0.75 and the second half 0.25.
+    particles = StateVectors([np.concatenate(
+        (np.tile(0, num_particles // 2), np.tile(100, num_particles // 2)))])
+    weights = np.concatenate(
+        (np.tile(Probability(0.75 / (num_particles / 2)), num_particles // 2),
+         np.tile(Probability(0.25 / (num_particles / 2)), num_particles // 2)))
 
     # Check particles sum to 1 still
-    assert pytest.approx(1) == sum(particle.weight for particle in particles)
+    assert pytest.approx(1) == sum(weight for weight in weights)
 
     # Test state vector is now weighted towards 0 from 50 (non-weighted mean)
-    state = ParticleState(particles)
-    assert np.allclose(state.state_vector, StateVector([[25]]))
+    state = ParticleState(particles, weight=weights)
+    assert np.allclose(state.mean, StateVector([[25]]))
     assert np.allclose(state.covar, CovarianceMatrix([[1875]]))
 
 
 def test_particlestate_angle():
     num_particles = 10
 
-    state_vector1 = StateVector([[Bearing(np.pi + 0.1)], [-10.]])
-    state_vector2 = StateVector([[Bearing(np.pi - 0.1)], [20.]])
+    # Create 10 2d particles of bearing type:
+    # [[pi+0.1,pi+0.1,pi+0.1,pi+0.1,pi+0.1,pi-0.1,pi-0.1,pi-0.1,pi-0.1,pi-0.1],
+    #  [   -10,   -10,   -10,   -10,   -10,    20,    20,    20,    20,    20]]
+    # use same weights
+    particles = StateVectors(
+        np.concatenate((np.tile([[Bearing(np.pi + 0.1)], [-10]], num_particles//2),
+                        np.tile([[Bearing(np.pi - 0.1)], [20]], num_particles//2)), axis=1))
+
+    # TODO: Work out why the probability type doesn't work here
     weight = Probability(1/num_particles)
-    particles = []
-    particles.extend(Particle(
-        state_vector1, weight=weight) for _ in range(num_particles//2))
-    particles.extend(Particle(
-        state_vector2, weight=weight) for _ in range(num_particles//2))
+    weights = np.tile(weight, num_particles)
+    weights2 = np.tile(0.1, num_particles)
+
+    print(particles)
+
+    print(weights)
+    print(type(weights))
 
     # Test state without timestamp
-    state = ParticleState(particles)
-    assert np.allclose(state.state_vector, StateVector([[np.pi], [5.]]))
+    state = ParticleState(particles, weight=weights)
+
+    print(np.average(state.state_vector, axis=1))
+    print(np.average(state.state_vector, axis=1, weights=weights))
+    print(np.average(state.state_vector, axis=1, weights=weights2))
+    # TODO Eh ????!!?!?!? WTF?
+
+    print(sum(weights))
+    print(state.mean)
+    print(state.covar)
+    assert np.allclose(state.mean, StateVector([[np.pi], [5.]]))
     assert np.allclose(state.covar, CovarianceMatrix([[0.01, -1.5], [-1.5, 225]]))
 
 

--- a/stonesoup/types/tests/test_state.py
+++ b/stonesoup/types/tests/test_state.py
@@ -198,31 +198,19 @@ def test_particlestate_angle():
     # [[pi+0.1,pi+0.1,pi+0.1,pi+0.1,pi+0.1,pi-0.1,pi-0.1,pi-0.1,pi-0.1,pi-0.1],
     #  [   -10,   -10,   -10,   -10,   -10,    20,    20,    20,    20,    20]]
     # use same weights
+    # Be extremely cautious with the use of integers in the statevectors here.
+    # There's interplay between the Bearing and Probability types and resulting
+    # rounding approximations can fail the test.
     particles = StateVectors(
-        np.concatenate((np.tile([[Bearing(np.pi + 0.1)], [-10]], num_particles//2),
-                        np.tile([[Bearing(np.pi - 0.1)], [20]], num_particles//2)), axis=1))
+        np.concatenate((np.tile([[Bearing(np.pi + 0.1)], [-10.0]], num_particles//2),
+                        np.tile([[Bearing(np.pi - 0.1)], [20.0]], num_particles//2)), axis=1))
 
-    # TODO: Work out why the probability type doesn't work here
     weight = Probability(1/num_particles)
     weights = np.tile(weight, num_particles)
-    weights2 = np.tile(0.1, num_particles)
-
-    print(particles)
-
-    print(weights)
-    print(type(weights))
 
     # Test state without timestamp
     state = ParticleState(particles, weight=weights)
 
-    print(np.average(state.state_vector, axis=1))
-    print(np.average(state.state_vector, axis=1, weights=weights))
-    print(np.average(state.state_vector, axis=1, weights=weights2))
-    # TODO Eh ????!!?!?!? WTF?
-
-    print(sum(weights))
-    print(state.mean)
-    print(state.covar)
     assert np.allclose(state.mean, StateVector([[np.pi], [5.]]))
     assert np.allclose(state.covar, CovarianceMatrix([[0.01, -1.5], [-1.5, 225]]))
 

--- a/stonesoup/types/tests/test_state.py
+++ b/stonesoup/types/tests/test_state.py
@@ -185,8 +185,10 @@ def test_particlestate():
     particle_list2 = [Particle([0, 0],
                       weight=weight,
                       parent=parent) for parent in parent_list]
-    state = ParticleState(None, particle_list=particle_list2, timestamp=timestamp)
+    state = ParticleState(None, particle_list=particle_list2,
+                          timestamp=timestamp, fixed_covar=[1, 1])
     assert isinstance(state.parent, ParticleState)
+    assert state.covar == [1, 1]
 
     particle_list3 = particle_list[1:]
     particle_parent = Particle([0, 0], weight=weight)

--- a/stonesoup/types/tests/test_track.py
+++ b/stonesoup/types/tests/test_track.py
@@ -6,7 +6,7 @@ import pytest
 from ..detection import Detection
 from ..hypothesis import SingleHypothesis
 from ..update import Update
-from ..particle import Particle
+from ..numeric import Probability
 from ..state import State, GaussianState, ParticleState
 from ..track import Track
 
@@ -20,7 +20,7 @@ def test_track_empty():
 @pytest.mark.parametrize('state', [
     State(np.array([[0]]), datetime.datetime.now()),
     GaussianState(np.array([[0]]), np.array([[0]]), datetime.datetime.now()),
-    ParticleState([Particle(np.array([[0]]), 1)], datetime.datetime.now()),
+    ParticleState([[0]], datetime.datetime.now(), [Probability(1)]),
     ],
     ids=['State', 'GaussianState', 'ParticleState'])
 def test_track_state(state):

--- a/stonesoup/types/tests/test_track.py
+++ b/stonesoup/types/tests/test_track.py
@@ -42,7 +42,8 @@ def test_track_state(state):
 
     # Particle
     if hasattr(state, 'particles'):
-        assert track.particles == state.particles
+        for track_particle, state_particle in zip(track.particles, state.particles):
+            assert track_particle.state_vector == state_particle.state_vector
     else:
         with pytest.raises(AttributeError):
             track.particles

--- a/stonesoup/types/tests/test_track.py
+++ b/stonesoup/types/tests/test_track.py
@@ -3,10 +3,9 @@ import datetime
 
 import numpy as np
 import pytest
-from stonesoup.types.detection import Detection
-from stonesoup.types.hypothesis import SingleHypothesis
-from stonesoup.types.update import Update
-
+from ..detection import Detection
+from ..hypothesis import SingleHypothesis
+from ..update import Update
 from ..particle import Particle
 from ..state import State, GaussianState, ParticleState
 from ..track import Track

--- a/stonesoup/types/tests/test_update.py
+++ b/stonesoup/types/tests/test_update.py
@@ -4,6 +4,7 @@ import datetime
 import numpy as np
 import pytest
 
+from ..array import StateVector
 from ..detection import Detection
 from ..hypothesis import SingleHypothesis
 from ..particle import Particle
@@ -110,30 +111,24 @@ def test_particlestateupdate():
                           1 / 9),
                  ]
     timestamp = datetime.datetime.now()
-    prediction = ParticleStatePrediction(particles=particles,
-                                         timestamp=timestamp)
-    meas_pred = ParticleMeasurementPrediction(
-        particles=particles,
-        timestamp=timestamp)
+    prediction = ParticleStatePrediction(None, particle_list=particles, timestamp=timestamp)
+    meas_pred = ParticleMeasurementPrediction(None, particle_list=particles, timestamp=timestamp)
     measurement = Detection(state_vector=np.array([[5], [7]]),
                             timestamp=timestamp)
-    state_update = ParticleStateUpdate(particles,
-                                       SingleHypothesis(
-                                           prediction=prediction,
-                                           measurement=measurement,
-                                           measurement_prediction=meas_pred),
-                                       timestamp=timestamp)
+    state_update = ParticleStateUpdate(None, SingleHypothesis(prediction=prediction,
+                                                              measurement=measurement,
+                                                              measurement_prediction=meas_pred),
+                                       particle_list=particles, timestamp=timestamp)
 
     eval_mean = np.mean(np.hstack([i.state_vector for i in particles]),
                         axis=1).reshape(2, 1)
     assert np.allclose(eval_mean, state_update.mean)
     assert np.all([particles[i].state_vector ==
-                   state_update.particles[i].state_vector for i in range(9)])
-    assert np.array_equal(prediction, state_update.hypothesis.prediction)
-    assert np.array_equal(meas_pred,
-                          state_update.hypothesis.measurement_prediction)
-    assert np.array_equal(measurement, state_update.hypothesis.measurement)
-    assert np.array_equal(timestamp, state_update.timestamp)
+                   StateVector(state_update.state_vector[:, i]) for i in range(9)])
+    assert prediction == state_update.hypothesis.prediction
+    assert meas_pred == state_update.hypothesis.measurement_prediction
+    assert measurement == state_update.hypothesis.measurement
+    assert timestamp == state_update.timestamp
 
 
 def test_from_state():
@@ -166,7 +161,8 @@ def test_from_state():
     assert update.covar[0] == 3
 
     state = ParticleState([Particle([[0]], weight=0.5)], timestamp=datetime.datetime.now())
-    update = Update.from_state(state, particles=[Particle([[1]], weight=0.8)], hypothesis=None)
+    update = Update.from_state(state, None, particle_list=[Particle([[1]], weight=0.5)],
+                               hypothesis=None)
     assert isinstance(update, ParticleStateUpdate)
     assert update.timestamp == state.timestamp
     assert update.state_vector[0] == 1

--- a/stonesoup/updater/particle.py
+++ b/stonesoup/updater/particle.py
@@ -43,7 +43,7 @@ class ParticleUpdater(Updater):
         : :class:`~.ParticleState`
             The state posterior
         """
-        predicted_state = hypothesis.prediction
+        predicted_state = copy.copy(hypothesis.prediction)
 
         if hypothesis.measurement.measurement_model is None:
             measurement_model = self.measurement_model

--- a/stonesoup/updater/particle.py
+++ b/stonesoup/updater/particle.py
@@ -62,8 +62,6 @@ class ParticleUpdater(Updater):
         if self.resampler is not None:
             predicted_state = self.resampler.resample(predicted_state)
 
-        # print(hypothesis)
-
         return Update.from_state(
             state=hypothesis.prediction,
             state_vector=predicted_state.state_vector,
@@ -79,14 +77,6 @@ class ParticleUpdater(Updater):
 
         if measurement_model is None:
             measurement_model = self.measurement_model
-
-        # new_particles = []
-        # for particle in state_prediction.particles:
-        #    new_state_vector = measurement_model.function(particle, **kwargs)
-        #    new_particles.append(
-        #        Particle(new_state_vector,
-        #                 weight=particle.weight,
-        #                 parent=particle.parent))
 
         new_state_vector = measurement_model.function(state_prediction, **kwargs)
         new_weight = state_prediction.weight

--- a/stonesoup/updater/particle.py
+++ b/stonesoup/updater/particle.py
@@ -132,8 +132,7 @@ class GromovFlowParticleUpdater(Updater):
         inv_R = inv(R)
 
         # Start by making our own copy of the particle before we move them...
-        # particles = [copy.copy(particle) for particle in hypothesis.prediction.particles]
-        particles = hypothesis.prediction
+        particles = [copy.copy(particle) for particle in hypothesis.prediction.particles]
 
         def function(state, lambda_):
             try:
@@ -153,15 +152,13 @@ class GromovFlowParticleUpdater(Updater):
 
             return f, B
 
-        # for particle in particles:
-        #    particle.state_vector = sde_euler_maruyama_integration(function, time_steps, particle)
-        new_state_vector = sde_euler_maruyama_integration(function, time_steps, particles)
+        for particle in particles:
+            particle.state_vector = sde_euler_maruyama_integration(function, time_steps, particle)
 
         return ParticleStateUpdate(
-            new_state_vector,
+            None,
             hypothesis,
-            weight=hypothesis.prediction.weight,
-            particle_list=None,
+            particle_list=particles,
             timestamp=hypothesis.measurement.timestamp)
 
     predict_measurement = ParticleUpdater.predict_measurement
@@ -207,7 +204,7 @@ class GromovFlowKalmanParticleUpdater(GromovFlowParticleUpdater):
         kalman_hypothesis = copy.copy(hypothesis)
         # Convert to GaussianState
         kalman_hypothesis.prediction = GaussianStatePrediction(
-            particle_pred.state_vector, particle_pred.covar, particle_pred.timestamp)
+            particle_pred.mean, particle_pred.covar, particle_pred.timestamp)
         # Needed for cross covar
         kalman_hypothesis.measurement_prediction = None
         kalman_update = self.kalman_updater.update(kalman_hypothesis, **kwargs)


### PR DESCRIPTION
Currently in stone soup we have a `ParticleState` which is not actually a state and contains `Particles` which have `StateVectors` and weights. This can make working with the particle filter a bit confusing as there are so many layers of particle types.

This pull request changes this structure so that everything needed is in the `ParticleState` and the `Particles` class has been removed. The new `ParticleState` contains `StateVectors` and weights meaning it can be substituted for anywhere that `Particles` was previously used.

`ParticleState` can be initiated using `StateVectors` and a sequence of weights or by using a list of particles (`Particle` types). 

This closes issue #537