### PR TITLE
Make measurement model optional in measurement-based initiators

### DIFF
--- a/stonesoup/initiator/simple.py
+++ b/stonesoup/initiator/simple.py
@@ -166,15 +166,15 @@ class MultiMeasurementInitiator(GaussianInitiator):
     Does cause slight delay in initiation to tracker."""
 
     prior_state: GaussianState = Property(doc="Prior state information")
-    measurement_model: MeasurementModel = Property(
-        default=None,
-        doc="Measurement model. Can be left as None if all detections have a "
-            "valid measurement model.")
     deleter: Deleter = Property(doc="Deleter used to delete the track.")
     data_associator: DataAssociator = Property(
         doc="Association algorithm to pair predictions to detections.")
     updater: Updater = Property(
         doc="Updater used to update the track object to the new state.")
+    measurement_model: MeasurementModel = Property(
+        default=None,
+        doc="Measurement model. Can be left as None if all detections have a "
+            "valid measurement model.")
     min_points: int = Property(
         default=2, doc="Minimum number of track points required to confirm a track.")
     updates_only: bool = Property(

--- a/stonesoup/initiator/tests/test_simple.py
+++ b/stonesoup/initiator/tests/test_simple.py
@@ -278,7 +278,8 @@ def test_multi_measurement(updates_only):
 
     measurement_initiator = MultiMeasurementInitiator(
         GaussianState([[0], [0], [0], [0]], np.diag([0, 15, 0, 15])),
-        measurement_model, deleter, data_associator, updater, updates_only=updates_only)
+        deleter, data_associator, updater,
+        measurement_model=measurement_model, updates_only=updates_only)
 
     timestamp = datetime.datetime.now()
     first_detections = {Detection(np.array([[5], [2]]), timestamp),
@@ -318,7 +319,7 @@ def test_measurement_model(initiator):
     # model. The SimpleMeasurementInitiator will raise an error in the if/else
     # blocks.
     with pytest.raises(ValueError):
-        _ = initiator.initiate(dummy_detection, timestamp)
+        _ = initiator.initiate({dummy_detection}, timestamp)
 
 
 @pytest.mark.parametrize("gaussian_initiator", [


### PR DESCRIPTION
A followup to close #588, we make the `measurement_model` attribute optional in initiators which are based on detections (namely the `SinglePointInitiator`, `SimpleMeasurementInitiator`, and `MultiMeasurementInitiator` classes). Detections are often paired with a measurement model, so the initiator will use that model in the new state. However, if the initiator is not given a measurement model and is passed a detection which also does not have a measurement model, it will raise a ValueError.

I have also made a test to ensure that the ValueError is raised correctly. I think there is no need to test the `MultiMeasurementInitiator` because the error will be raised in the `ExtendedKalmanUpdater` class, which is already tested. But I can add a test for this one as well if it would be best.