### PR TITLE
Add multi-distance hypothesiser

### DIFF
--- a/stonesoup/hypothesiser/distance.py
+++ b/stonesoup/hypothesiser/distance.py
@@ -1,7 +1,11 @@
 # -*- coding: utf-8 -*-
+import warnings
+from typing import Sequence
+
 from .base import Hypothesiser
 from ..base import Property
 from ..measures import Measure
+from ..models.measurement import MeasurementModel
 from ..predictor import Predictor
 from ..types.detection import MissedDetection
 from ..types.hypothesis import SingleDistanceHypothesis
@@ -85,5 +89,67 @@ class DistanceHypothesiser(Hypothesiser):
                         detection,
                         distance,
                         measurement_prediction))
+
+        return MultipleHypothesis(sorted(hypotheses, reverse=True))
+
+
+class MultiDistanceHypothesiser(Hypothesiser):
+    """Prediction Hypothesiser based on a set of Measures
+
+    Similar to the :class:`~.DistanceHypothesiser` this class scores prediction-detection pairs
+    using their distance in a measurement space. However, this class attempts to use the
+    detection's measurement model to determine a suitable Measure and distance to use. These are
+    provided by the user.
+    To do so, the class utilises a list of :class:`~.DistanceHypothesiser` and corresponding
+    measurement models. When a detection is received of particular model, the class will attempt
+    to find the model's corresponding hypothesiser and use its output.
+    """
+
+    hypothesisers: Sequence[DistanceHypothesiser] = Property(
+        doc="Sequence of hypothesisers to utilise output of.")
+    measurement_models: Sequence[MeasurementModel] = Property(
+        doc="Sequence of measurement models that will be compared against incoming detections. "
+            "Must be same length as hypothesisers sequence."
+    )
+
+    def __init__(self, *args, **kwargs):
+
+        super().__init__(*args, **kwargs)
+
+        if len(self.hypothesisers) != len(self.measurement_models):
+            raise ValueError("Number of hypothesisers must equal number of measurement models in "
+                             "MultiDistanceHypothesiser")
+
+    def hypothesise(self, track, detections, timestamp, **kwargs):
+        """Passes detections that do not have measurement model or have a model with no
+        corresponding hypothesiser, to the first hypothesiser in the sequence. Uses the
+        null-hypothesis of the first hypothesiser and will ignore those of the other
+        :attr:`hypothesisers`."""
+
+        # Keep track of detections attributed to each hypothesiser
+        hypothesisers_detections = {hypothesiser: set() for hypothesiser in self.hypothesisers}
+
+        # True detection hypotheses
+        for detection in detections:
+            try:
+                detection_measurement_model = detection.measurement_model
+                index_of_model = self.measurement_models.index(detection_measurement_model)
+            except (AttributeError, ValueError):
+                # detection either doesn't have measurement model
+                # or its model is not accounted for in class model sequence
+                index_of_model = 0  # first in sequence is default hypothesiser
+                warnings.warn("Defaulting to first hypothesiser")
+            relevant_hypothesiser = self.hypothesisers[index_of_model]
+            hypothesisers_detections[relevant_hypothesiser].add(detection)
+
+        # Add good-detection hypotheses
+        multiple_hypotheses = {
+            hypothesiser.hypothesise(track, relevant_detections, timestamp, **kwargs)
+            for hypothesiser, relevant_detections in hypothesisers_detections.items()
+        }
+        hypotheses = [hypothesis
+                      for n, multi_hypothesis in enumerate(multiple_hypotheses)
+                      for hypothesis in multi_hypothesis
+                      if hypothesis or n == 0]
 
         return MultipleHypothesis(sorted(hypotheses, reverse=True))

--- a/stonesoup/hypothesiser/tests/test_distance.py
+++ b/stonesoup/hypothesiser/tests/test_distance.py
@@ -1,14 +1,22 @@
 # -*- coding: utf-8 -*-
-from operator import attrgetter
 import datetime
+from operator import attrgetter
 
 import numpy as np
+import pytest
 
-from ..distance import DistanceHypothesiser
+from ..distance import DistanceHypothesiser, MultiDistanceHypothesiser
+from ... import measures
+from ...measures import Euclidean
+from ...models.measurement.linear import LinearGaussian
+from ...models.measurement.nonlinear import CartesianToBearingRange
+from ...models.transition.linear import CombinedLinearGaussianTransitionModel, \
+    ConstantVelocity
+from ...predictor.kalman import KalmanPredictor
 from ...types.detection import Detection
 from ...types.state import GaussianState
 from ...types.track import Track
-from ... import measures
+from ...updater.kalman import ExtendedKalmanUpdater
 
 
 def test_mahalanobis(predictor, updater):
@@ -67,3 +75,80 @@ def test_distance_include_all(predictor, updater):
     last_hypothesis = hypotheses[-1]
     assert last_hypothesis.measurement is detection3
     assert last_hypothesis.distance > hypothesiser.missed_distance
+
+
+def test_multi_distance(predictor, updater):
+    measurement_models = [
+        LinearGaussian(ndim_state=4, mapping=(0, 2), noise_covar=np.eye(2)),
+        CartesianToBearingRange(ndim_state=4, mapping=(0, 2),
+                                noise_covar=np.diag([np.radians(1) ** 2, 10 ** 2]))
+    ]
+
+    predictor = KalmanPredictor(CombinedLinearGaussianTransitionModel(2 * [ConstantVelocity(0.1)]))
+
+    hypothesisers = [
+        DistanceHypothesiser(predictor,
+                             updater=ExtendedKalmanUpdater(),
+                             measure=Euclidean((0, 1)),  # consider all elements of linear Gaussian
+                             missed_distance=2,
+                             include_all=True),  # include missed detections
+        DistanceHypothesiser(predictor,
+                             updater=ExtendedKalmanUpdater(),
+                             measure=Euclidean(0),  # consider bearing element of bearing-range
+                             missed_distance=np.radians(30),
+                             include_all=False)  # don't include missed detections
+    ]
+
+    timestamp = datetime.datetime.now()
+    track = Track([GaussianState(np.array([[1, 0, 1, 0]]), np.eye(4), timestamp)])
+
+    detection1 = Detection(np.array([[1, 1]]), measurement_model=measurement_models[0],
+                           timestamp=timestamp)
+    detection2 = Detection(np.array([[3, 3]]), measurement_model=measurement_models[0],
+                           timestamp=timestamp)
+    detection3 = Detection(np.array([[np.radians(45)]]), measurement_model=measurement_models[1],
+                           timestamp=timestamp)
+    detection4 = Detection(np.array([[np.radians(120)]]), measurement_model=measurement_models[1],
+                           timestamp=timestamp)
+    detection5 = Detection(np.array([8, 8]),
+                           measurement_model=LinearGaussian(ndim_state=4,
+                                                            mapping=(0, 1),
+                                                            noise_covar=np.eye(1)),
+                           timestamp=timestamp)
+
+    detections = [detection1, detection2, detection3, detection4, detection5]
+
+    # Test mismatch sequence length error
+    with pytest.raises(ValueError, match="Number of hypothesisers must equal number of "
+                                         "measurement models in MultiDistanceHypothesiser"):
+        MultiDistanceHypothesiser(hypothesisers[1:], measurement_models)
+
+    hypothesiser = MultiDistanceHypothesiser(hypothesisers, measurement_models)
+
+    with pytest.warns(UserWarning, match="Defaulting to first hypothesiser"):
+        hypotheses = hypothesiser.hypothesise(track, detections, timestamp)
+
+    # There are 4 hypotheses - Detections and Missed Detection but not for detection4
+    assert len(hypotheses) == 5
+
+    for i, detection in enumerate(detections, 1):
+        detection_hypothesis = [hypothesis
+                                for hypothesis in hypotheses
+                                if hypothesis.measurement is detection]
+        # Test all detections except for detection4 are accounted for
+        if i == 4:
+            assert len(detection_hypothesis) == 0
+            continue
+        assert len(detection_hypothesis) == 1
+
+        detection_hypothesis = detection_hypothesis.pop()
+
+        if i == 1:
+            # detection1 within hypothesiser1 missed distance
+            assert detection_hypothesis.distance < hypothesisers[0].missed_distance
+        elif i in (2, 5):
+            # detection2 outside of hypothesiser1 missed distance
+            assert detection_hypothesis.distance > hypothesisers[0].missed_distance
+        else:
+            # detection3 within hypothesiser2 missed distance
+            assert detection_hypothesis.distance < hypothesisers[1].missed_distance


### PR DESCRIPTION
The standard DistanceHypothesiser only allows a fixed measure to be used.  If one has incoming detections of BearingRange type, and some of Cartesian type, clearly the distance should be calculated differently.
The usual way around the issue would be to use a Mahalanobis measure and entirely avoid the units of measurement in the measurement space.
This PR adds a hypothesiser that allows the user to have multiple "distance" measures available, dependent on what the incoming detections' measurement models are.

I'll leave this PR as a discussion in the instance where this PR is redundant and there are better ways to go around this problem.