### PR TITLE
Fix a bug in Tutorial 09

### DIFF
--- a/docs/tutorials/09_Initiators_&_Deleters.py
+++ b/docs/tutorials/09_Initiators_&_Deleters.py
@@ -98,14 +98,14 @@ for k in range(20):
                                               timestamp=truth_state.timestamp,
                                               measurement_model=measurement_model))
 
-            # Generate clutter at this time-step
-            truth_x = truth_state.state_vector[0]
-            truth_y = truth_state.state_vector[2]
-            for _ in range(np.random.randint(2)):
-                x = uniform.rvs(truth_x - 10, 20)
-                y = uniform.rvs(truth_y - 10, 20)
-                measurement_set.add(Clutter(np.array([[x], [y]]), timestamp=timestamp,
-                                            measurement_model=measurement_model))
+        # Generate clutter at this time-step
+        truth_x = truth_state.state_vector[0]
+        truth_y = truth_state.state_vector[2]
+        for _ in range(np.random.randint(2)):
+            x = uniform.rvs(truth_x - 10, 20)
+            y = uniform.rvs(truth_y - 10, 20)
+            measurement_set.add(Clutter(np.array([[x], [y]]), timestamp=timestamp,
+                                        measurement_model=measurement_model))
     all_measurements.append(measurement_set)
 
 # Plot true detections and clutter.


### PR DESCRIPTION
This PR fixes an issue with Tutorial 09 on Initiators and Deleters, pointed out in Issue #591, which resulted in clutter being generated only when a TrueDetection was generated for a given truth.  