### PR TITLE
Restructure forward algorithm (in context of hidden Markov model)

### DIFF
--- a/docs/examples/Classifying_Using_HMM.py
+++ b/docs/examples/Classifying_Using_HMM.py
@@ -4,63 +4,67 @@
 """
 Classification Using Hidden Markov Model
 ========================================
-This is a demonstration using the implemented Hidden Markov model to classify multiple targets.
+This is a demonstration using the implemented forward algorithm in the context of a hidden Markov
+model to classify multiple targets.
 
 We will attempt to classify 3 targets in an undefined region.
-Our sensor will be all-seeing, and provide us with indirect observations of the targets such that,
-using the implemented Hidden Markov Model (HMM), we should hopefully successfully classify exactly
-3 targets correctly.
 """
 
 # %%
 # All Stone Soup imports will be given in order of usage.
 
 from datetime import datetime, timedelta
+
 import numpy as np
+
+from stonesoup.models.transition.categorical import MarkovianTransitionModel
+from stonesoup.types.groundtruth import CategoricalGroundTruthState
+from stonesoup.types.groundtruth import GroundTruthPath
 
 # %%
 # Ground Truth
 # ^^^^^^^^^^^^
-# The targets may take one of three discrete hidden classes: 'bike', 'car' and 'bus'.
-# It will be assumed that the targets cannot transition from one class to another, hence an
-# identity transition matrix is given to the :class:`~.CategoricalTransitionModel`.
+# The targets may take one of two discrete hidden classes: 'bike', and 'car'.
+# A target may be able to transition from one class to another (this could be considered as a
+# person switching from riding a bike to driving a car and vice versa).
+# This behaviour will be modelled in the transition matrix of the
+# :class:`~.MarkovianTransitionModel`. This transition matrix is a Markov process matrix, whereby
+# it is assumed that the state of a target is wholly dependent on its previous state, and nothing
+# else.
 #
 # A :class:`~.CategoricalState` class is used to store information on the classification/category
-# of the targets. The state vector will define a categorical distribution over the 3 possible
+# of the targets. The state vector will define a categorical distribution over the 2 possible
 # classes, whereby each component defines the probability that a target is of the corresponding
-# class. For example, the state vector (0.2, 0.3, 0.5), with category names ('bike', 'car', 'bus')
-# indicates that a target has a 20% probability of being class 'bike', a 30% probability of being
-# class 'car' etc.
+# class. For example, the state vector (0.2, 0.8), with category names ('bike', 'car')
+# indicates that a target has a 20% probability of being class 'bike' and an 80% probability of
+# being class 'car' etc.
 # It does not make sense to have a true target being a distribution over the possible classes, and
 # therefore the true categorical states will have binary state vectors indicating a specific class
-# (i.e. a '1' at one state vector index, and '0's elsewhere).
+# (i.e. a '1' at one state vector index, and '0's elsewhere). This can be considered as stating
+# there is a 100% probability that the target is of a particular class. We specify that there
+# should be noise when functioning our transition model in order to sample the resultant
+# distribution and receive this binary vector.
 # The :class:`~.CategoricalGroundTruthState` class inherits directly from the base
 # :class:`~.CategoricalState` class.
 #
-# While the category will remain the same, a :class:`~.CategoricalTransitionModel` is used here
-# for the sake of demonstration.
-#
 # The category and timings for one of the ground truth paths will be printed.
 
-from stonesoup.models.transition.categorical import CategoricalTransitionModel
-from stonesoup.types.groundtruth import CategoricalGroundTruthState
-from stonesoup.types.groundtruth import GroundTruthPath
-
-category_transition = CategoricalTransitionModel(transition_matrix=np.eye(3),
-                                                 transition_covariance=0.1 * np.eye(3))
+transition_matrix = np.array([[0.8, 0.2],  # P(bike | bike), P(bike | car)
+                              [0.4, 0.6]])  # P(car | bike), P(car | car)
+category_transition = MarkovianTransitionModel(transition_matrix=transition_matrix)
 
 start = datetime.now()
 
-hidden_classes = ['bike', 'car', 'bus']
+hidden_classes = ['bike', 'car']
 
 # Generating ground truth
 ground_truths = list()
-for i in range(1, 4):
-    state_vector = np.zeros(3)  # create a vector with 3 zeroes
-    state_vector[np.random.choice(3, 1, p=[1/3, 1/3, 1/3])] = 1  # pick a random class out of the 3
+for i in range(1, 4):  # 4 targets
+    state_vector = np.zeros(2)  # create a vector with 2 zeroes
+    state_vector[np.random.choice(2, 1, p=[1 / 2, 1 / 2])] = 1  # pick a random class out of the 2
     ground_truth_state = CategoricalGroundTruthState(state_vector,
                                                      timestamp=start,
-                                                     category_names=hidden_classes)
+                                                     categories=hidden_classes)
 
     ground_truth = GroundTruthPath([ground_truth_state], id=f"GT{i}")
 
@@ -71,7 +75,7 @@ for i in range(1, 4):
         new_state = CategoricalGroundTruthState(
             new_vector,
             timestamp=ground_truth[-1].timestamp + timedelta(seconds=1),
-            category_names=hidden_classes
+            categories=hidden_classes
         )
 
         ground_truth.append(new_state)
@@ -86,29 +90,26 @@ for states in np.vstack(ground_truths).T:
 # %%
 # Measurement
 # ^^^^^^^^^^^
-# Using a Hidden markov model, it is assumed the hidden class of a target cannot be directly
-# observed, and instead indirect observations are taken. In this instance, observations of the
-# targets' sizes are taken ('small' or 'large'), which have direct implications as to the targets'
-# hidden classes, and this relationship is modelled by the `emission matrix` of the
-# :class:`~.CategoricalMeasurementModel`, which is used by the :class:`~.CategoricalSensor` to
+# Using a Hidden markov model, it is assumed the true class of a target cannot be directly
+# observed (hence 'hidden'), and instead observations that are dependent on this class are taken.
+# In this instance, observations of the targets' sizes are taken ('small', 'medium' or 'large').
+# The relationship between true class and observed size is modelled by the `emission matrix` of the
+# :class:`~.MarkovianMeasurementModel`, which is used by the :class:`~.HMMSensor` to
 # provide :class:`~.CategoricalDetection` types.
 # We will model this such that a 'bike' has a very small chance of being observed as a 'big'
-# target. Similarly, a 'bus' will tend to appear as 'large'. Whereas, a 'car' has equal chance of
-# being observed as either.
+# target etc.
 
-from stonesoup.models.measurement.categorical import CategoricalMeasurementModel
-from stonesoup.sensor.categorical import CategoricalSensor
+from stonesoup.models.measurement.categorical import MarkovianMeasurementModel
+from stonesoup.sensor.categorical import HMMSensor
 
-E = np.array([[0.99, 0.01],  # P(small | bike)  P(large | bike)
-              [0.5, 0.5],
-              [0.01, 0.99]])
-model = CategoricalMeasurementModel(ndim_state=3,
-                                    emission_matrix=E,
-                                    emission_covariance=0.1 * np.eye(2),
-                                    mapping=[0, 1, 2])
+E = np.array([[0.8, 0.1],  # P(small | bike), P(small | car)
+              [0.19, 0.3],  # P(medium | bike), P(medium | car)
+              [0.01, 0.6]])  # P(large | bike), P(large | car)
 
-eo = CategoricalSensor(measurement_model=model,
-                       category_names=['small', 'large'])
+model = MarkovianMeasurementModel(emission_matrix=E)
+
+eo = HMMSensor(measurement_model=model,
+               measurement_categories=['small', 'medium', 'large'])
 
 # Generating measurements
 measurements = list()
@@ -133,6 +134,11 @@ for index, states in enumerate(np.vstack(ground_truths).T):
 # predict.
 from stonesoup.predictor.categorical import HMMPredictor
 
+# It would be cheating to use the same transition model as in ground truth generation!
+transition_matrix = np.array([[0.81, 0.19],  # P(bike | bike), P(bike | car)
+                              [0.39, 0.61]])  # P(car | bike), P(car | car)
+category_transition = MarkovianTransitionModel(transition_matrix=transition_matrix)
+
 predictor = HMMPredictor(category_transition)
 
 # %%
@@ -145,13 +151,13 @@ updater = HMMUpdater()
 # %%
 # Hypothesiser
 # ------------
-# A :class:`~.CategoricalHypothesiser` is used for calculating categorical hypotheses.
+# A :class:`~.HMMHypothesiser` is used for calculating categorical hypotheses.
 # It utilises the :class:`~.ObservationAccuracy` measure: a multi-dimensional extension of an
 # 'accuracy' score, essentially providing a measure of the similarity between two categorical
 # distributions.
-from stonesoup.hypothesiser.categorical import CategoricalHypothesiser
+from stonesoup.hypothesiser.categorical import HMMHypothesiser
 
-hypothesiser = CategoricalHypothesiser(predictor=predictor, updater=updater)
+hypothesiser = HMMHypothesiser(predictor=predictor, updater=updater)
 
 # %%
 # Data Associator
@@ -169,16 +175,17 @@ data_associator = GNNWith2DAssignment(hypothesiser)
 # might take (the category names are also provided here).
 from stonesoup.types.state import CategoricalState
 
-prior = CategoricalState([1 / 3, 1 / 3, 1 / 3], category_names=hidden_classes)
+prior = CategoricalState([1 / 2, 1 / 2], categories=hidden_classes)
 
 # %%
 # Initiator
 # ---------
 # For each unassociated detection, a new track will be initiated. In this instance we use a
-# :class:`~.SimpleCategoricalInitiator`, which specifically handles categorical state priors.
-from stonesoup.initiator.categorical import SimpleCategoricalInitiator
+# :class:`~.SimpleCategoricalMeasurementInitiator`, which specifically handles categorical state
+# priors.
+from stonesoup.initiator.categorical import SimpleCategoricalMeasurementInitiator
 
-initiator = SimpleCategoricalInitiator(prior_state=prior, measurement_model=None)
+initiator = SimpleCategoricalMeasurementInitiator(prior_state=prior, updater=updater)
 
 # %%
 # Deleter
@@ -247,3 +254,26 @@ for true_classification in true_classifications:
 
 print(f"Excess tracks: {excess_tracks}")
 print(f"No. correct classifications: {num_correct_classifications}")
+
+# %%
+# Plotting
+# ^^^^^^^^
+# Plotting the probability that each one of our targets and tracks is a 'bike' will help to
+# visualise this 2-hidden class problem.
+
+import matplotlib.pyplot as plt
+
+
+def plot(path, style):
+    times = list()
+    probs = list()
+    for state in path:
+        times.append(state.timestamp)
+        probs.append(state.state_vector[0])
+    plt.plot(times, probs, linestyle=style)
+
+
+for truth in ground_truths:
+    plot(truth, '-')
+for track in tracks:
+    plot(track, '--')

--- a/stonesoup/hypothesiser/categorical.py
+++ b/stonesoup/hypothesiser/categorical.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+
 from .base import Hypothesiser
 from ..base import Property
 from ..measures import ObservationAccuracy
@@ -10,7 +11,7 @@ from ..types.numeric import Probability
 from ..updater.categorical import HMMUpdater
 
 
-class CategoricalHypothesiser(Hypothesiser):
+class HMMHypothesiser(Hypothesiser):
     r"""Hypothesiser based on categorical distribution accuracy.
 
     This hypothesiser generates track predictions at detection times and scores each hypothesised
@@ -20,12 +21,11 @@ class CategoricalHypothesiser(Hypothesiser):
 
     predictor: HMMPredictor = Property(doc="Predictor used to predict tracks to detection times")
     updater: HMMUpdater = Property(doc="Updater used to get measurement prediction")
-    prob_detect: Probability = Property(
-        default=Probability(0.85),
-        doc="Target Detection Probability")
-    prob_gate: Probability = Property(
-        default=Probability(0.95),
-        doc="Gate Probability - prob. gate contains true measurement if detected")
+    prob_detect: Probability = Property(default=Probability(0.99),
+                                        doc="Target Detection Probability")
+    prob_gate: Probability = Property(default=Probability(0.95),
+                                      doc="Gate Probability - prob. gate contains true "
+                                          "measurement if detected")
 
     def hypothesise(self, track, detections, timestamp):
         """ Evaluate and return all track association hypotheses.
@@ -56,7 +56,9 @@ class CategoricalHypothesiser(Hypothesiser):
         hypotheses = list()
 
         prediction = self.predictor.predict(track, timestamp=timestamp)
+
         probability = Probability(1 - self.prob_detect * self.prob_gate)
+
         hypotheses.append(
             SingleProbabilityHypothesis(
                 prediction,
@@ -65,11 +67,14 @@ class CategoricalHypothesiser(Hypothesiser):
             ))
 
         for detection in detections:
-            prediction = self.predictor.predict(
-                track, timestamp=detection.timestamp)
+            prediction = self.predictor.predict(track, timestamp=detection.timestamp)
 
             measurement_prediction = self.updater.predict_measurement(
-                prediction, detection.measurement_model, noise=False)
+                predicted_state=prediction,
+                measurement_model=detection.measurement_model,
+                noise=False,
+                measurement=detection
+            )
 
             probability = self.measure(measurement_prediction, detection)
             probability = probability * self.prob_detect
@@ -82,6 +87,7 @@ class CategoricalHypothesiser(Hypothesiser):
                     detection,
                     probability,
                     measurement_prediction))
+
         return MultipleHypothesis(hypotheses, normalise=False, total_weight=1)
 
     @property

--- a/stonesoup/hypothesiser/tests/conftest.py
+++ b/stonesoup/hypothesiser/tests/conftest.py
@@ -52,11 +52,11 @@ def dummy_category_updater():
         def measurement_model(self):
             pass
 
-        def predict_measurement(self, state_prediction, measurement_model=None, **kwargs):
+        def predict_measurement(self, predicted_state, measurement_model=None, **kwargs):
             """Return the first two state vector elements, normalised."""
-            vector = state_prediction.state_vector[:2]
+            vector = predicted_state.state_vector[:2]
             vector = vector / np.sum(vector)
             return CategoricalMeasurementPrediction(vector,
-                                                    timestamp=state_prediction.timestamp)
+                                                    timestamp=predicted_state.timestamp)
 
     return DummyCategoricalUpdater()

--- a/stonesoup/hypothesiser/tests/test_categorical.py
+++ b/stonesoup/hypothesiser/tests/test_categorical.py
@@ -1,36 +1,45 @@
 # -*- coding: utf-8 -*-
+
 from datetime import datetime
 
-from ..categorical import CategoricalHypothesiser
+from ..categorical import HMMHypothesiser
+from ...types.array import StateVector
 from ...types.detection import CategoricalDetection
+from ...types.multihypothesis import MultipleHypothesis
 from ...types.state import CategoricalState
 from ...types.track import Track
 
 
-def test_categorical(dummy_category_predictor, dummy_category_updater):
-    timestamp = datetime.now()
+def test_hmm_hypothesiser(dummy_category_predictor, dummy_category_updater):
+    now = datetime.now()
 
-    track = Track([CategoricalState(state_vector=[0.5, 0.3, 0.2], timestamp=timestamp)])
+    track = Track([CategoricalState(state_vector=[80, 10, 10], timestamp=now)])
 
-    detection1 = CategoricalDetection(state_vector=[0.6, 0.4], timestamp=timestamp)
-    detection2 = CategoricalDetection(state_vector=[0.5, 0.5], timestamp=timestamp)
-    detection3 = CategoricalDetection(state_vector=[0.1, 0.9], timestamp=timestamp)
+    measurement_categories = ['red', 'green', 'blue', 'yellow']
+    detection1 = CategoricalDetection(StateVector([10, 20, 30, 40]),
+                                      timestamp=now,
+                                      categories=measurement_categories)
+    detection2 = CategoricalDetection(StateVector([40, 30, 20, 10]),
+                                      timestamp=now,
+                                      categories=measurement_categories)
+    detection3 = CategoricalDetection(StateVector([10, 40, 40, 10]),
+                                      timestamp=now,
+                                      categories=measurement_categories)
     detections = {detection1, detection2, detection3}
 
-    hypothesiser = CategoricalHypothesiser(dummy_category_predictor, dummy_category_updater)
+    hypothesiser = HMMHypothesiser(dummy_category_predictor, dummy_category_updater)
 
-    hypotheses = hypothesiser.hypothesise(track, detections, timestamp)
+    hypotheses = hypothesiser.hypothesise(track, detections, now)
+
+    assert isinstance(hypotheses, MultipleHypothesis)
 
     # 4 hypotheses: detections 1, 2 and 3, and missed detection
     assert len(hypotheses) == 4
 
-    hypothesis_detections = {hypothesis.measurement for hypothesis in hypotheses}
-
-    # All detections have a hypothesis
-    assert all(detection in hypothesis_detections for detection in detections)
-
-    # There is a missed detection hypothesis
-    assert any(not hypothesis.measurement for hypothesis in hypotheses)
-
-    # Each hypothesis has a probability attribute
-    assert all(hypothesis.probability >= 0 for hypothesis in hypotheses)
+    for hypothesis in hypotheses:
+        if hypothesis.measurement:
+            assert hypothesis
+            assert hypothesis.measurement in detections
+        else:
+            assert not hypothesis
+        assert hypothesis.probability >= 0

--- a/stonesoup/initiator/categorical.py
+++ b/stonesoup/initiator/categorical.py
@@ -1,50 +1,34 @@
 # -*- coding: utf-8 -*-
-import numpy as np
 
 from .base import Initiator
 from ..base import Property
-from ..models.measurement.categorical import CategoricalMeasurementModel
 from ..types.hypothesis import SingleHypothesis
 from ..types.state import CategoricalState
 from ..types.track import Track
-from ..types.update import CategoricalStateUpdate
+from ..updater.categorical import HMMUpdater
 
 
-class SimpleCategoricalInitiator(Initiator):
+class SimpleCategoricalMeasurementInitiator(Initiator):
     """Initiator that creates tracks in a categorical state space.
 
-    The defined :attr:`measurement_model` or all detections' measurement models must be a
-    :class:`CategoricalMeasurementModel` type as this class utilises the models' emission matrices
-    to determine detections' state space equivalents.
-    For state space indices where a detection provides no information, the :attr:`prior_state`
-    value is used instead."""
-    prior_state: CategoricalState = Property(doc="Prior state information")
-    measurement_model: CategoricalMeasurementModel = Property(
-        default=None, doc="Measurement model (should be categorical model)")
+    Uses state updates from an :class:`HMMUpdater` to initialise new tracks.
+    Initialises a new track on every detection received.
+    """
 
-    def initiate(self, detections, timestamp, **kwargs):
+    prior_state: CategoricalState = Property(doc="Prior state information")
+    updater: HMMUpdater = Property(doc="Hidden Markov model updater")
+
+    def initiate(self, detections, *args, **kwargs):
+        """Create a new track for each detection. Updating the :attr:`prior-state` with a
+        detection to start-off a new track.
+        """
+
         tracks = set()
 
         for detection in detections:
-            if detection.measurement_model is not None:
-                measurement_model = detection.measurement_model
-            else:
-                measurement_model = self.measurement_model
+            hypothesis = SingleHypothesis(prediction=self.prior_state, measurement=detection)
 
-            state_vector = measurement_model.emission_matrix @ detection.state_vector
+            update = self.updater.update(hypothesis)
 
-            # Replace the default prior with the measurement's state-space components were possible
-            prior_state_vector = self.prior_state.state_vector.copy()
-            for index, element in zip(measurement_model.mapping, state_vector):
-                prior_state_vector[index] = element
-
-            # Normalise the prior
-            prior_state_vector = prior_state_vector / np.sum(prior_state_vector)
-
-            state = CategoricalStateUpdate(state_vector=prior_state_vector,
-                                           hypothesis=SingleHypothesis(None, detection),
-                                           timestamp=detection.timestamp,
-                                           category_names=self.prior_state.category_names)
-
-            tracks.add(Track([state]))
+            tracks.add(Track([update]))
         return tracks

--- a/stonesoup/initiator/tests/test_categorical.py
+++ b/stonesoup/initiator/tests/test_categorical.py
@@ -1,57 +1,50 @@
 # -*- coding: utf-8 -*-
+
 from datetime import datetime
 
 import numpy as np
-import pytest
 
-from ..categorical import SimpleCategoricalInitiator
-from ...models.measurement.categorical import CategoricalMeasurementModel
-from ...models.transition.tests.test_categorical import create_categorical, \
-    create_categorical_matrix
+from ..categorical import SimpleCategoricalMeasurementInitiator
+from ...models.measurement.categorical import MarkovianMeasurementModel
+from ...types.array import StateVector
 from ...types.detection import CategoricalDetection
 from ...types.state import CategoricalState
 from ...types.update import CategoricalStateUpdate
+from ...updater.categorical import HMMUpdater
 
 
-@pytest.mark.parametrize(
-    'measurement_model',
-    [CategoricalMeasurementModel(ndim_state=3,
-                                 emission_matrix=create_categorical_matrix(3, 3),
-                                 emission_covariance=0.1 * np.eye(3),
-                                 mapping=[0, 1, 2]),
-     CategoricalMeasurementModel(ndim_state=3,
-                                 emission_matrix=create_categorical_matrix(2, 2),
-                                 emission_covariance=0.1 * np.eye(3),
-                                 mapping=[0, 1]),
-     CategoricalMeasurementModel(ndim_state=3,
-                                 emission_matrix=create_categorical_matrix(2, 2),
-                                 emission_covariance=0.1 * np.eye(3),
-                                 mapping=[0, 2]),
-     CategoricalMeasurementModel(ndim_state=3,
-                                 emission_matrix=create_categorical_matrix(2, 2),
-                                 emission_covariance=0.1 * np.eye(3),
-                                 mapping=[2, 0])
-     ],
-    ids=['[0, 1, 2]', '[0, 1]', '[0, 2]', '[2, 0]'])
-def test_categorical_initiator(measurement_model):
+def test_categorical_initiator():
+    E = np.array([[30, 25, 5],
+                  [20, 25, 10],
+                  [10, 25, 80],
+                  [40, 25, 5]])
+    measurement_model = MarkovianMeasurementModel(E)
+
+    updater = HMMUpdater(measurement_model)
+
     now = datetime.now()
 
     # Prior state information
-    prior_state = CategoricalState([1 / 3, 1 / 3, 1 / 3], category_names=['red', 'green', 'blue'])
+    prior_state = CategoricalState([80, 10, 10], timestamp=now)
 
-    ndim_meas = measurement_model.ndim_meas
+    measurement_categories = ['red', 'green', 'blue', 'yellow']
+    detection1 = CategoricalDetection(StateVector([10, 20, 30, 40]),
+                                      timestamp=now,
+                                      categories=measurement_categories)
+    detection2 = CategoricalDetection(StateVector([40, 30, 20, 10]),
+                                      timestamp=now,
+                                      categories=measurement_categories)
+    detection3 = CategoricalDetection(StateVector([10, 40, 40, 10]),
+                                      timestamp=now,
+                                      categories=measurement_categories)
+    detections = {detection1, detection2, detection3}
 
-    measurements = [CategoricalDetection(create_categorical(ndim_meas), timestamp=now,
-                                         measurement_model=measurement_model),
-                    CategoricalDetection(create_categorical(ndim_meas), timestamp=now)]
+    initiator = SimpleCategoricalMeasurementInitiator(prior_state=prior_state, updater=updater)
 
-    initiator = SimpleCategoricalInitiator(prior_state, measurement_model=measurement_model)
+    tracks = initiator.initiate(detections)
 
-    tracks = initiator.initiate(measurements, now)
-
-    assert len(tracks) == 2
+    assert len(tracks) == 3
     for track in tracks:
         assert len(track) == 1
         assert isinstance(track.state, CategoricalStateUpdate)
-
-    assert set(measurements) == set(track.state.hypothesis.measurement for track in tracks)
+        assert track.state.hypothesis.measurement in detections

--- a/stonesoup/models/measurement/categorical.py
+++ b/stonesoup/models/measurement/categorical.py
@@ -1,118 +1,84 @@
 # -*- coding: utf-8 -*-
-from typing import Union, Sequence
 
 import numpy as np
-from scipy.stats import multinomial
 
-from .base import MeasurementModel
+from ..measurement import MeasurementModel
 from ...base import Property
-from ...types.array import Matrix, StateVector, StateVectors, CovarianceMatrix
+from ...types.array import Matrix, StateVector
 
 
-class CategoricalMeasurementModel(MeasurementModel):
-    r"""Measurement model which returns a category.
-    This is a time invariant model for simple observations of a state.
-    A measurement can take one of a finite number of observation categories
-    :math:`Y = \{y_k|k\in Z_{\gt0}\}` and a measurement vector :math:`(z_k)_i = P(y_i, k)` will
-    define a categorical distribution over these categories. Measurements are generated via random
-    sampling.
+class MarkovianMeasurementModel(MeasurementModel):
+    r"""The measurement model for categorical states
+
+    This is a time invariant, measurement model of a hidden Markov process.
+
+    A measurement can take one of a finite number of observable categories
+    :math:`Z = \{\zeta^n|n\in \mathbf{N}, n\le N\} (for some finite :math:`N`). A measurement
+    vector represents a categorical distribution over :math:`Z`.
+
+    .. math::
+        \mathbf{y}_t^i = P(\zeta_t^i)
+
+    A state space vector takes the form :math:`\alpha_t^i = P(\phi_t^i)`, representing a
+    categorical distribution over a discrete, finite set of possible categories
+    :math:`\Phi = \{\phi^m|m\in \mathbf{N}, m\le M\}` (for some finite :math:`M`).
+
+    It is assumed that a measurement is independent of everything but the true state of a target.
 
     Intended to be used in conjunction with the :class:`~.CategoricalState` type.
     """
     emission_matrix: Matrix = Property(
-        doc=r"The emission matrix defining emission probability "
-            r":math:`(E_k)_{ij} = P(z_{j}, k | \phi_{i}, k)` (the probability of receiving an "
-            r"observation :math:`z` from state :math:`x_{k_j} = P(\phi_j, k)`. "
-            r"Rows of the matrix must sum to 1.")
-    emission_covariance: CovarianceMatrix = Property(doc="Emission covariance.")
-    mapping: Sequence[int] = Property(default=None,
-                                      doc="Mapping between measurement and state dims.")
+        doc=r"Matrix of emission/output probabilities "
+            r":math:`E_t^{ij} = E^{ij} = P(\zeta_t^i | \phi_t^j)`, determining the conditional "
+            r"probability that a measurement is category :math:`\zeta^i` at 'time' :math:`t` "
+            r"given that the true state category is :math:`\phi^j` at 'time' :math:`t`. "
+            r"Columns will be normalised.")
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        for i, row in enumerate(self.emission_matrix):
-            if not np.isclose(np.sum(row), 1):
-                raise ValueError(f"Row {i} of emission matrix does not sum to 1")
+        # Normalise matrix columns
+        self.emission_matrix = self.emission_matrix / np.sum(self.emission_matrix, axis=0)
 
-        if self.mapping is None:
-            self.mapping = np.arange(self.ndim_state)
-        elif len(self.mapping) != np.shape(self.emission_matrix)[0]:
-            raise ValueError(f"Emission matrix maps from {np.shape(self.emission_matrix)[0]} "
-                             f"elements of the state space, but the mapping is length "
-                             f"{len(self.mapping)}")
+    def function(self, state, **kwargs):
+        r"""Applies the linear transformation:
 
-    @property
-    def ndim_meas(self):
-        """Number of observation dimensions/categories."""
-        return self.emission_matrix.shape[1]
+        .. math::
+            E^{ij}\alpha_{t-1}^j = P(\zeta_t^i|\phi_t^j)P(\phi_t^j)
 
-    def _cond_prob_emission(self, state, noise=False, **kwargs):
-        """This function returns the probability of each observation category conditioned on the
-        input state, :math:`(p(z_j|x_i) p(x_i)` (this should come out normalised).
-        Noise is additive, and used by transforming resultant vectors using a logit function."""
-
-        if type(noise) is bool and noise:
-            noise = self.rvs()
-        elif not noise:
-            noise = 0
-        else:
-            raise ValueError("Noise is generated via random sampling, and defined noise is not "
-                             "implemented")
-
-        hp = self.emission_matrix.T @ state.state_vector[self.mapping]
-
-        with np.errstate(divide='ignore', over='ignore', under='ignore'):
-            if any(hp == 1):
-                y = hp.astype(float)
-                y[hp == 1] = np.finfo(np.float64).max
-                y[hp == 0] = np.finfo(np.float64).min
-            else:
-                y = np.log(hp / (1 - hp))
-
-            y += noise
-
-            p = 1 / (1 + np.exp(-y))
-            return p / np.sum(p)
-
-    def function(self, state, noise=False, **kwargs):
-        r"""Observation function
+        The resultant vector is normalised.
 
         Parameters
         ----------
         state: :class:`~.CategoricalState`
-            An input (hidden class) state, where the state vector defines a categorical
-            distribution over the set of possible hidden states
-            :math:`\Phi = \{\phi_m|m\in Z_{\gt0}\}`.
-        noise: bool
-            If 'True', additive noise (generated via random sampling) will be included. Noise
-            vectors cannot be defined beforehand. Only a boolean value is valid.
+            The state to be measured.
 
         Returns
         -------
         state_vector: :class:`stonesoup.types.array.StateVector`
             of shape (:py:attr:`~ndim_meas, 1`). The resultant measurement vector.
-            The resultant vector represents a categorical distribution over the set of possible
-            measurement categories. A definitive measurement category is chosen, hence the vector
-            will be binary.
         """
-        cond_prob_emission = self._cond_prob_emission(state, noise=noise, **kwargs)
-        rv = multinomial(n=1, p=cond_prob_emission.flatten())
-        if noise:
-            return StateVector(rv.rvs(size=1, random_state=None))
-        else:
-            return StateVector(cond_prob_emission)
 
-    def rvs(self, num_samples=1, **kwargs) -> Union[StateVector, StateVectors]:
-        """Additive noise."""
-        omega = np.random.multivariate_normal(np.zeros(self.ndim),
-                                              self.emission_covariance,
-                                              size=num_samples)
-        return StateVectors(omega).T
+        meas_vector = self.emission_matrix @ state.state_vector
+        meas_vector = meas_vector / np.sum(meas_vector)  # normalise
 
-    def pdf(self, state1, state2, **kwargs):
-        """Assumes that state 1 is a binary measurement state (i.e. one vector element is 1 and
-        the rest are zeroes).
-        Returns the probability that the emission of state 2 is state 1."""
-        Hx = self._cond_prob_emission(state2)
-        return Hx.T @ state1.state_vector
+        return StateVector(meas_vector)
+
+    @property
+    def ndim_state(self):
+        return self.emission_matrix.shape[1]
+
+    @property
+    def ndim_meas(self):
+        return self.emission_matrix.shape[0]
+
+    @property
+    def mapping(self):
+        """Assumes that all elements of the state space are considered."""
+        return np.arange(self.ndim_state)
+
+    def rvs(self):
+        raise NotImplementedError
+
+    def pdf(self):
+        raise NotImplementedError

--- a/stonesoup/models/measurement/tests/test_categorical.py
+++ b/stonesoup/models/measurement/tests/test_categorical.py
@@ -1,99 +1,39 @@
 # -*- coding: utf-8 -*-
 
 import numpy as np
-import pytest
 
-from ...transition.tests.test_categorical import create_categorical, create_categorical_matrix
-from ....models.measurement.categorical import CategoricalMeasurementModel
-from ....types.array import Matrix, CovarianceMatrix, StateVectors
+from ....models.measurement.categorical import MarkovianMeasurementModel
+from ....types.array import StateVector
 from ....types.state import CategoricalState
 
 
 def test_categorical_measurement_model():
-    # test emission matrix error
-    with pytest.raises(ValueError, match="Row 0 of emission matrix does not sum to 1"):
-        CategoricalMeasurementModel(ndim_state=2,
-                                    emission_matrix=Matrix([[1, 1],
-                                                            [0, 0]]),
-                                    emission_covariance=np.eye(2))
+    # 3 hidden categories, 4 measurement categories
+    E = np.array([[30, 25, 5],
+                  [20, 25, 10],
+                  [10, 25, 80],
+                  [40, 25, 5]])
 
-    # test mapping error
-    with pytest.raises(ValueError, match="Emission matrix maps from 2 elements of the state "
-                                         "space, but the mapping is length 3"):
-        CategoricalMeasurementModel(ndim_state=2,
-                                    emission_matrix=np.eye(2),
-                                    emission_covariance=np.eye(2),
-                                    mapping=[0, 2, 4])
+    model = MarkovianMeasurementModel(E)
 
-    # 3 measurement categories, 2 hidden categories
-    E = create_categorical_matrix(2, 3)
-    Ecov = CovarianceMatrix(np.diag([0.1, 0.1, 0.1]))
-    mapping = [0, 2]
+    # Test normalised
+    expected_array = np.array([[3 / 10, 1 / 4, 1 / 20],
+                               [2 / 10, 1 / 4, 2 / 20],
+                               [1 / 10, 1 / 4, 16 / 20],
+                               [4 / 10, 1 / 4, 1 / 20]])
+    assert np.allclose(model.emission_matrix, expected_array)
 
-    model = CategoricalMeasurementModel(ndim_state=2,
-                                        emission_matrix=E,
-                                        emission_covariance=Ecov,
-                                        mapping=mapping)
+    # Test ndim
+    assert model.ndim_state == 3
+    assert model.ndim_meas == 4
 
-    # test ndim meas
-    assert model.ndim_meas == 3
+    state = CategoricalState([80, 10, 10])
 
-    # test conditional probability emission
-    for _ in range(3):
-        state = CategoricalState(create_categorical(4))
-        # testing noiseless as noise generation uses random sampling
-        exp_hp = E.T @ state.state_vector[mapping]
-        exp_y = np.log(exp_hp / (1 - exp_hp))
-        exp_p = 1 / (1 + np.exp(-exp_y))
-        exp_p = exp_p / np.sum(exp_p)
-        actual_p = model._cond_prob_emission(state)
-        assert np.array_equal(exp_p, actual_p)
-        assert np.isclose(np.sum(actual_p), 1)
+    # Test function
+    new_vector = model.function(state, noise=False)
+    assert isinstance(new_vector, StateVector)
+    assert new_vector.shape[0] == 4
+    assert np.isclose(np.sum(new_vector), 1)
 
-    with pytest.raises(ValueError, match="Noise is generated via random sampling, and defined "
-                                         "noise is not implemented"):
-        model._cond_prob_emission(CategoricalState(create_categorical(4)), noise=[1, 2, 3])
-
-    states = [CategoricalState(create_categorical(4)) for _ in range(5)]
-
-    for state in states:
-        # test function with noise (random sampling at end)
-        measurement = model.function(state, noise=True)
-        assert len(np.where(measurement == 0)[0]) == 2
-        assert len(np.where(measurement == 1)[1]) == 1
-        assert len(measurement) == 3
-        assert np.isclose(np.sum(measurement), 1)
-
-        # test function without noise (no random sampling at end)
-        measurement = model.function(state, noise=False)
-        assert len(measurement) == 3
-        assert np.isclose(np.sum(measurement), 1)
-
-        # test pdf
-        meas = CategoricalState(create_categorical(3))  # measurement vector
-        exp_Hx = E.T @ state.state_vector[mapping]
-        exp_Hx = exp_Hx / np.sum(exp_Hx)
-        exp_value = exp_Hx.T @ meas.state_vector
-        actual_value = model.pdf(meas, state)
-        assert np.allclose(actual_value, exp_value)
-
-    # test rvs
-    for i in range(1, 4):
-        rvs = model.rvs(num_samples=i)
-        assert isinstance(rvs, StateVectors)
-        assert len(rvs.T) == i
-        for elem in rvs.T:
-            assert len(elem) == 3  # same as model ndim meas
-
-    # Test edge case
-    state = CategoricalState([1, 0])
-    E = np.eye(2)
-    Ecov = 0.1 * np.eye(2)
-    model = CategoricalMeasurementModel(ndim_state=2,
-                                        emission_matrix=E,
-                                        emission_covariance=Ecov)
-    measurement = model.function(state, noise=True)
-    assert len(np.where(measurement == 0)[0]) == 1
-    assert len(np.where(measurement == 1)[1]) == 1
-    assert len(measurement) == 2
-    assert np.isclose(np.sum(measurement), 1)
+    # Test mapping
+    assert np.array_equal(model.mapping, [0, 1, 2])

--- a/stonesoup/models/transition/tests/test_categorical.py
+++ b/stonesoup/models/transition/tests/test_categorical.py
@@ -1,116 +1,50 @@
 # coding: utf-8
 
+from datetime import datetime, timedelta
+
 import numpy as np
-import pytest
 
-from ..categorical import CategoricalTransitionModel
-from ....types.array import StateVectors, CovarianceMatrix
-from ....types.state import State, CategoricalState
-
-
-def create_categorical(ndim):
-    """Create a state with random state vector representing a categorical distribution across
-    `ndim` possible categories."""
-    total = 0
-    sv = list()
-    for i in range(ndim - 1):
-        x = np.random.uniform(0, 1 - total)
-        sv.append(x)
-        total += x
-    sv.append(1 - total)  # add probability that is left
-    sv = np.array(sv)
-    np.random.shuffle(sv)  # shuffle state vector
-    return sv
+from ..categorical import MarkovianTransitionModel
+from ....types.array import StateVector
+from ....types.state import CategoricalState
 
 
-def create_categorical_matrix(num_rows, num_cols):
-    """Create a matrix with normalised rows"""
-    matrix = list()
-    for i in range(num_rows):
-        matrix.append(create_categorical(num_cols))
-    return np.array(matrix)
+def test_categorical_transition_model():
+    # 3 categories
+    F = np.array([[50, 5, 30],
+                  [25, 90, 30],
+                  [25, 5, 30]])
 
+    model = MarkovianTransitionModel(F)
 
-@pytest.mark.parametrize('ndim', (2, 3, 4))
-def test_categorical_transition_model(ndim):
-    # test invalid matrix
-    with pytest.raises(ValueError, match="Column 0 of transition matrix does not sum to 1"):
-        CategoricalTransitionModel(2 * np.eye(2))
+    # Test normalised
+    expected_array = np.array([[2 / 4, 1 / 20, 1 / 3],
+                               [1 / 4, 18 / 20, 1 / 3],
+                               [1 / 4, 1 / 20, 1 / 3]])
+    assert np.allclose(model.transition_matrix, expected_array)
 
-    # ndim possible categories
-    F = create_categorical_matrix(ndim, ndim).T  # normalised columns
-    Q = CovarianceMatrix(np.eye(ndim))
+    # Test ndim
+    assert model.ndim == 3
+    assert model.ndim_state == 3
 
-    model = CategoricalTransitionModel(F, Q)
+    state = CategoricalState([80, 10, 10], timestamp=datetime.now())
 
-    # test ndim state
-    assert model.ndim == F.shape[0]
-    assert model.ndim_state == F.shape[0]
+    # Test function (noiseless)
+    new_vector = model.function(state, time_interval=timedelta(seconds=1), noise=False)
+    assert isinstance(new_vector, StateVector)
+    assert new_vector.shape[0] == 3
+    assert np.isclose(np.sum(new_vector), 1)
 
-    # test function noise error
-    with pytest.raises(ValueError, match="Noise is generated via random sampling, and defined "
-                                         "noise is not implemented"):
-        prior = CategoricalState(create_categorical(2))
-        model.function(prior, noise=ndim * [0.5])
+    # Test function (noisy)
+    new_vector = model.function(state, time_interval=timedelta(seconds=1), noise=True)
+    assert isinstance(new_vector, StateVector)
+    assert new_vector.shape[0] == 3
+    assert np.count_nonzero(new_vector) == 1  # basis vector
 
-    states = [CategoricalState(create_categorical(ndim)) for _ in range(5)]
+    # Test 0 time-interval function
+    new_vector = model.function(state, time_interval=timedelta(seconds=0))
+    assert np.allclose(new_vector, state.state_vector)
 
-    # Test function
-    for state in states:
-
-        fp = F @ state.state_vector
-
-        # Test noiseless
-
-        if any(fp == 1):
-            exp_noiseless = fp * 1.0
-            exp_noiseless[fp == 1] = np.finfo(np.float64).max
-            exp_noiseless[fp == 0] = np.finfo(np.float64).min
-        else:
-            exp_noiseless = np.log(fp / (1 - fp)) + 0
-
-        exp_noiseless = 1 / (1 + np.exp(-exp_noiseless))
-        exp_noiseless = exp_noiseless / np.sum(exp_noiseless)
-
-        actual_noiseless = model.function(state, noise=False)
-
-        assert len(actual_noiseless) == ndim
-        assert np.isclose(sum(actual_noiseless), 1)  # test normalised
-        assert np.array_equal(exp_noiseless, actual_noiseless)  # test is expected
-
-        # Test noisy
-        noisy = model.function(state, noise=True)
-        assert len(noisy) == ndim
-        assert np.isclose(sum(noisy), 1)  # test normalised
-
-        # Test pdf
-        other_state = CategoricalState(create_categorical(ndim))
-        exp_value = (F @ other_state.state_vector).T @ state.state_vector
-        actual_value = model.pdf(state, other_state)
-        assert np.array_equal(actual_value, exp_value)
-
-    # Test edge case
-    id_model = CategoricalTransitionModel(np.eye(ndim), Q)
-    state = State(np.eye(ndim)[0])  # vector looks like (1, 0, ..., 0) - ndim elements
-    fp = np.eye(ndim) @ state.state_vector
-
-    exp_noiseless = fp * 1.0
-    exp_noiseless[fp == 1] = np.finfo(np.float64).max
-    exp_noiseless[fp == 0] = np.finfo(np.float64).min
-
-    exp_noiseless = 1 / (1 + np.exp(-exp_noiseless))
-    exp_noiseless = exp_noiseless / np.sum(exp_noiseless)
-
-    actual_noiseless = id_model.function(state, noise=False)
-
-    assert len(actual_noiseless) == ndim
-    assert np.isclose(sum(actual_noiseless), 1)  # test normalised
-    assert np.array_equal(exp_noiseless, actual_noiseless)  # test is expected
-
-    # test rvs
-    for i in range(1, 4):
-        rvs = model.rvs(num_samples=i)
-        assert isinstance(rvs, StateVectors)
-        assert len(rvs.T) == i
-        for elem in rvs.T:
-            assert len(elem) == ndim
+    # Test no time-interval
+    new_vector = model.function(state)
+    assert np.allclose(new_vector, state.state_vector)

--- a/stonesoup/predictor/categorical.py
+++ b/stonesoup/predictor/categorical.py
@@ -1,28 +1,62 @@
 # -*- coding: utf-8 -*-
+
 from ..base import Property
-from ..models.transition.categorical import CategoricalTransitionModel
+from ..models.transition.categorical import MarkovianTransitionModel
 from ..predictor import Predictor
 from ..predictor._utils import predict_lru_cache
 from ..types.prediction import Prediction
-from ..types.state import CategoricalState
 
 
 class HMMPredictor(Predictor):
-    r"""Models the prediction step of a Hidden Markov Model"""
+    r"""Hidden Markov model predictor
 
-    transition_model: CategoricalTransitionModel = Property(doc="The transition model to be used.")
+    Assumes transition model is time-invariant, and therefore care should be taken when predicting
+    forward to the same time."""
 
-    def _transition_function(self, prior, **kwargs):
-        return self.transition_model.function(prior, **kwargs)
+    transition_model: MarkovianTransitionModel = Property(
+        doc="The transition model used to predict states forward in `time`."
+    )
+
+    @predict_lru_cache()
+    def predict(self, prior, timestamp=None, **kwargs):
+        r"""Predicts a :class:`~.CategoricalState` forward using the :attr:`transition_model`.
+
+        Parameters
+        ----------
+        prior : :class:`~.CategoricalState`
+            :math:`\alpha_{t-1}`
+        timestamp : :class:`datetime.datetime`, optional
+            :math:`t`
+        **kwargs :
+            These are passed to the :meth:`transition_model.function` method.
+
+        Returns
+        -------
+        : :class:`~.CategoricalStatePrediction`
+            The predicted state.
+
+        Notes
+        -----
+        The Markovian transition model is time-invariant and the evaluated `time_interval` can be
+        `None`.
+        """
+
+        predict_over_interval = self._predict_over_interval(prior, timestamp)
+
+        prediction_vector = self.transition_model.function(prior,
+                                                           time_interval=predict_over_interval,
+                                                           **kwargs)
+
+        return Prediction.from_state(prior, prediction_vector, timestamp=timestamp,
+                                     transition_model=self.transition_model)
 
     def _predict_over_interval(self, prior, timestamp):
-        """Private function to get the prediction interval (or None)
+        """Private method to get the prediction interval (or None)
 
         Parameters
         ----------
         prior : :class:`~.State`
             The prior state
-
         timestamp : :class:`datetime.datetime`, optional
             The (current) timestamp
 
@@ -30,7 +64,6 @@ class HMMPredictor(Predictor):
         -------
         : :class:`datetime.timedelta`
             time interval to predict over
-
         """
 
         # Deal with undefined timestamps
@@ -40,45 +73,3 @@ class HMMPredictor(Predictor):
             predict_over_interval = timestamp - prior.timestamp
 
         return predict_over_interval
-
-    @predict_lru_cache()
-    def predict(self, prior, timestamp=None, **kwargs):
-        r"""A simple matrix multiplication. The Chapman-Kolmogorov equation is:
-
-        .. math::
-            p(x_k|z_{1:k-1}) &= \Sigma_{x_{k-1}} p(x_k|x_{k-1}) p(x_{k-1}|z_{1:k-1})\\
-                             &= F_k p(x_{k-1}|z_{1:k-1})
-
-        where :math:`F_k` is the category-transition matrix and :math:`p(x)` is encoded in the
-        state vector
-
-        Parameters
-        ----------
-        prior : :class:`~.CategoricalState`
-            :math:`\mathbf{x}_{k-1}`
-        timestamp : :class:`datetime.datetime`, optional
-            :math:`k + 1`
-        **kwargs :
-            These are passed to the :meth:`transition_model.function` method.
-
-        Returns
-        -------
-        : :class:`~.CategoricalStatePrediction`
-            :math:`\mathbf{x}_{t + \Delta t|t}`, the predicted state.
-
-        Notes
-        -----
-        The categorical transition model is time-invariant and the evaluated `time_interval` can be
-        `None`.
-        """
-
-        if not isinstance(prior, CategoricalState):
-            raise ValueError("Prior must be a categorical state type")
-
-        predict_over_interval = self._predict_over_interval(prior, timestamp)
-
-        prediction = self._transition_function(prior, time_interval=predict_over_interval,
-                                               **kwargs)
-
-        return Prediction.from_state(prior, prediction, timestamp=timestamp,
-                                     transition_model=self.transition_model)

--- a/stonesoup/sensor/categorical.py
+++ b/stonesoup/sensor/categorical.py
@@ -1,19 +1,29 @@
 # -*- coding: utf-8 -*-
-from typing import Set, Sequence
+
+from typing import Sequence
+
+from scipy.stats import multinomial
 
 from ..base import Property
-from ..models.measurement.categorical import CategoricalMeasurementModel
+from ..models.measurement.categorical import MarkovianMeasurementModel
 from ..sensor.sensor import Sensor
-from ..types.detection import TrueDetection, TrueCategoricalDetection
-from ..types.groundtruth import GroundTruthState, GroundTruthPath
-from ..types.state import CategoricalState
+from ..types.array import StateVector
+from ..types.detection import TrueCategoricalDetection
 
 
-class CategoricalSensor(Sensor):
-    measurement_model: CategoricalMeasurementModel = Property(
-        doc="Categorical measurement model used in generating measurements.")
-    category_names: Sequence[str] = Property(default=None,
-                                             doc="Measurement category names.")
+class HMMSensor(Sensor):
+    r"""Sensor model that observes a categorical state space and returns categorical measurements.
+
+    Measurements are categorical distributions over a finite set of categories
+    :math:`Z = \{\zeta^n|n\in \mathbf{N}, n\le N\} (for some finite :math:`N`).
+    """
+
+    measurement_model: MarkovianMeasurementModel = Property(
+        doc="Measurement model to generate detection vectors from"
+    )
+    measurement_categories: Sequence[str] = Property(doc="Sequence of measurement category names. "
+                                                         "Defaults to a list of integers",
+                                                     default=None)
 
     @property
     def ndim_state(self):
@@ -26,17 +36,29 @@ class CategoricalSensor(Sensor):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        if self.category_names and len(self.category_names) != self.ndim_meas:
-            raise ValueError(f"{len(self.category_names)} category names were given for a sensor "
-                             f"which returns vectors of length {self.ndim_meas}")
+        if self.measurement_categories is None:
+            self.measurement_categories = list(map(str, range(self.ndim_meas)))
 
-    def measure(self, ground_truths: Set[GroundTruthState], **kwargs) -> Set[TrueDetection]:
-        """Generate a categorical measurement for a given categorical state.
+        if len(self.measurement_categories) != self.ndim_meas:
+            raise ValueError(
+                f"ndim_meas of {self.ndim_meas} does not match number of measurement categories "
+                f"{len(self.measurement_categories)}"
+            )
+
+    def measure(self, ground_truths, noise: bool = True, **kwargs):
+        r"""Generate a categorical measurement for a given set of true categorical state.
 
         Parameters
         ----------
-        ground_truths : Set[:class:`~.CategoricalGroundTruthState`]
-            A set of :class:`~.CategoricalGroundTruthState`
+        ground_truths: Set[:class:`~.CategoricalGroundTruthState`]
+            A set of :class:`~.CategoricalGroundTruthState`.
+        noise: bool
+            Indicates whether measurement vectors are sampled from and the resultant measurement
+            categories returned instead. These are discrete categories instead of a distribution
+            over the measurement space. They are represented by N-tuples, with all components
+            equal to 0, except at an index corresponding to the relevant category.
+            For example :math:`e^k` indicates that the measurement category is :math:`\zeta^k`.
+            If `False`, the resultant distribution is returned.
 
         Returns
         -------
@@ -48,24 +70,21 @@ class CategoricalSensor(Sensor):
         """
 
         detections = set()
+
         for truth in ground_truths:
+            timestamp = truth.timestamp
+            detection_vector = self.measurement_model.function(truth, noise=noise, **kwargs)
 
-            wrong_type = False
-            if isinstance(truth, GroundTruthPath):
-                if not isinstance(truth[-1], CategoricalState):
-                    wrong_type = True
-            elif not isinstance(truth, CategoricalState):
-                wrong_type = True
+            if noise:
+                # Sample from resultant distribution
+                rv = multinomial(n=1, p=detection_vector.flatten())
+                detection_vector = StateVector(rv.rvs(size=1, random_state=None))
 
-            if wrong_type:
-                raise ValueError("Categorical sensor can only observe categorical states")
-
-            measurement_vector = self.measurement_model.function(truth, **kwargs)
-            detection = TrueCategoricalDetection(state_vector=measurement_vector,
-                                                 timestamp=truth.timestamp,
+            detection = TrueCategoricalDetection(state_vector=detection_vector,
+                                                 timestamp=timestamp,
+                                                 categories=self.measurement_categories,
                                                  measurement_model=self.measurement_model,
-                                                 groundtruth_path=truth,
-                                                 category_names=self.category_names)
+                                                 groundtruth_path=truth)
             detections.add(detection)
 
         return detections

--- a/stonesoup/sensor/tests/test_categorical.py
+++ b/stonesoup/sensor/tests/test_categorical.py
@@ -1,70 +1,62 @@
 # -*- coding: utf-8 -*-
-import datetime
+
+from datetime import datetime
 
 import numpy as np
 import pytest
 
-from ..categorical import CategoricalSensor
-from ...models.measurement.categorical import CategoricalMeasurementModel
-from ...models.transition.tests.test_categorical import create_categorical_matrix
-from ...types.array import CovarianceMatrix
+from ..categorical import HMMSensor
+from ...models.measurement.categorical import MarkovianMeasurementModel
 from ...types.detection import TrueCategoricalDetection
-from ...types.groundtruth import GroundTruthState, CategoricalGroundTruthState, \
-    GroundTruthPath
+from ...types.groundtruth import CategoricalGroundTruthState, GroundTruthPath
 
 
-@pytest.mark.parametrize('category_names', (['red', 'green', 'blue', 'yellow'], None))
-def test_categorical_sensor(category_names):
-    # 4 measurement categories, 2 hidden categories
-    E = create_categorical_matrix(2, 4)
-    Ecov = CovarianceMatrix(np.eye(4))
-    mapping = [0, 2]
+def test_hmm_sensor():
+    # 3 hidden categories, 4 measurement categories
+    E = np.array([[30, 25, 5],
+                  [20, 25, 10],
+                  [10, 25, 80],
+                  [40, 25, 5]])
 
-    model = CategoricalMeasurementModel(ndim_state=2,
-                                        emission_matrix=E,
-                                        emission_covariance=Ecov,
-                                        mapping=mapping)
+    model = MarkovianMeasurementModel(E)
 
-    # Test category names error
-    with pytest.raises(ValueError, match="3 category names were given for a sensor which returns "
-                                         "vectors of length 4"):
-        CategoricalSensor(measurement_model=model, category_names=['red', 'green', 'blue'])
+    # Test mismatched number of category names
+    with pytest.raises(ValueError, match="ndim_meas of 4 does not match number of measurement "
+                                         "categories 2"):
+        HMMSensor(measurement_model=model, measurement_categories=['red', 'blue'])
 
-    sensor = CategoricalSensor(measurement_model=model,
-                               category_names=category_names)
+    sensor = HMMSensor(measurement_model=model)
 
-    now = datetime.datetime.now()
+    # Test default category names
+    assert sensor.measurement_categories == ['0', '1', '2', '3']
 
     # Test ndim state
-    assert sensor.ndim_state == 2
+    assert sensor.ndim_state == 3
 
     # Test ndim meas
     assert sensor.ndim_meas == 4
 
-    # Test measuring non-categorical error
-    with pytest.raises(ValueError, match="Categorical sensor can only observe categorical states"):
-        sensor.measure({GroundTruthState([1, 2, 3], timestamp=now)})
-    with pytest.raises(ValueError, match="Categorical sensor can only observe categorical states"):
-        sensor.measure({GroundTruthPath(GroundTruthState([1, 2, 3], timestamp=now))})
-
     # Test measure
+    now = datetime.now()
     truth1 = GroundTruthPath([CategoricalGroundTruthState([0.1, 0.4, 0.5], timestamp=now)])
     truth2 = GroundTruthPath([CategoricalGroundTruthState([0.6, 0.1, 0.3], timestamp=now)])
     truth3 = CategoricalGroundTruthState([0.1, 0.1, 0.8], timestamp=now)
     ground_truths = {truth1, truth2, truth3}
 
-    detections = sensor.measure(ground_truths)
+    for noise in (True, False):
 
-    assert len(detections) == len(ground_truths)
+        detections = sensor.measure(ground_truths, noise=noise)
 
-    for detection in detections:
-        assert isinstance(detection, TrueCategoricalDetection)
-        assert len(detection.state_vector) == 4
-        assert np.isclose(np.sum(detection.state_vector), 1)  # is normalised
-        assert detection.groundtruth_path in ground_truths
-        assert detection.timestamp == now
-        assert detection.measurement_model == model
-        if category_names:
-            assert detection.category_names == category_names
-        else:
-            assert detection.category_names == [0, 1, 2, 3]  # default category names
+        assert len(detections) == 3
+
+        for detection in detections:
+            assert isinstance(detection, TrueCategoricalDetection)
+            assert len(detection.state_vector) == 4
+            assert np.isclose(np.sum(detection.state_vector), 1)  # is normalised
+            assert detection.groundtruth_path in ground_truths
+            assert detection.timestamp == now
+            assert detection.measurement_model == model
+            assert detection.categories == ['0', '1', '2', '3']
+
+            if noise:
+                assert np.count_nonzero(detection.state_vector) == 1  # basis vector

--- a/stonesoup/types/state.py
+++ b/stonesoup/types/state.py
@@ -478,41 +478,33 @@ class CategoricalState(State):
     r"""CategoricalState type.
 
     State object representing an object in a categorical state space. A state vector
-    :math:`\mathbf{x}_i = P(\phi_i)` defines a categorical distribution over a finite set of
-    discrete categories :math:`\Phi = \{\phi_m|m\in Z_{\ge0}\}`."""
+    :math:`\mathbf{\alpha}_t^i = P(\phi_t^i)` defines a categorical distribution over a finite set
+    of discrete categories :math:`\Phi = \{\phi^m|m\in \mathbf{N}, m\le M\}` for some finite
+    :math:`M`."""
 
-    category_names: Sequence[str] = Property(
-        default=None,
-        doc="Sequence of category names corresponding to each state vector component. Defaults to "
-            "a list of integers."
-    )
+    categories: Sequence[float] = Property(doc="Category names. Defaults to a list of integers.",
+                                           default=None)
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        # Check there is a category name for each state vector component
-        if self.category_names and len(self.category_names) != self.ndim:
-            raise ValueError(f"{len(self.category_names)} category names were given for a state "
-                             f"vector with {self.ndim} elements")
+        self.state_vector = self.state_vector / np.sum(self.state_vector)  # normalise state vector
 
-        # Build default list of integers if no category names given
-        if self.category_names is None:
-            self.category_names = list(range(self.ndim))
+        if self.categories is None:
+            self.categories = list(map(str, range(self.ndim)))
 
-        # Check all vector elements are valid probabilities
-        if any(p < 0 or p > 1 for p in self.state_vector):
-            raise ValueError("Category probabilities must lie in the closed interval [0, 1]")
-
-        # Check vector is normalised
-        if not np.isclose(np.sum(self.state_vector), 1):
-            raise ValueError("Category probabilities must sum to 1")
+        if len(self.categories) != self.ndim:
+            raise ValueError(
+                f"ndim of {self.ndim} does not match number of categories {len(self.categories)}"
+            )
 
     def __str__(self):
         strings = [f"P({category}) = {p}"
-                   for category, p in zip(self.category_names, self.state_vector)]
-        return f"({', '.join(strings)})"
+                   for category, p in zip(self.categories, self.state_vector)]
+        string = ',\n'.join(strings)
+        return string
 
     @property
     def category(self):
-        """Return the name of the most likely category"""
-        return self.category_names[np.argmax(self.state_vector)]
+        """Return the name of the most likely category."""
+        return self.categories[np.argmax(self.state_vector)]

--- a/stonesoup/types/tests/test_state.py
+++ b/stonesoup/types/tests/test_state.py
@@ -435,27 +435,21 @@ def test_creatable_from_state_multi_base_error():
 
 def test_categorical_state():
 
-    # Test instantiation errors
-    with pytest.raises(ValueError, match="2 category names were given for a state vector with 3 "
-                                         "elements"):
-        CategoricalState(state_vector=StateVector([0.1, 0.4, 0.5]), category_names=['1', '2'])
-    with pytest.raises(ValueError, match=r"Category probabilities must lie in the closed interval "
-                                         r"\[0, 1\]"):
-        CategoricalState(state_vector=StateVector([1.1, 0.4, 0.5]))
-    with pytest.raises(ValueError, match="Category probabilities must sum to 1"):
-        CategoricalState(state_vector=StateVector([0.6, 0.7, 0.7]))
-    with pytest.raises(ValueError, match="Category probabilities must sum to 1"):
-        CategoricalState(state_vector=StateVector([0.2, 0.2, 0.3]))
+    # Test mismatched number of category names
+    with pytest.raises(ValueError, match="ndim of 3 does not match number of categories 4"):
+        CategoricalState(state_vector=StateVector([50, 60, 90]),
+                         categories=['red', 'green', 'blue', 'yellow'])
 
-    # Test defaults
-    state = CategoricalState(state_vector=StateVector([0.1, 0.4, 0.5]))
-    assert state.category_names == [0, 1, 2]
+    state = CategoricalState(state_vector=StateVector([50, 60, 90]))
 
-    # Test str
-    state = CategoricalState(state_vector=StateVector([0.1, 0.4, 0.5]),
-                             timestamp=datetime.datetime.now(),
-                             category_names=['red', 'blue', 'yellow'])
-    assert str(state) == "(P(red) = 0.1, P(blue) = 0.4, P(yellow) = 0.5)"
+    # Test normalised
+    state.state_vector == [0.25, 0.3, 0.45]
+
+    # Test default category names
+    assert state.categories == ['0', '1', '2']
+
+    # Test string
+    assert str(state) == "P(0) = 0.25,\nP(1) = 0.3,\nP(2) = 0.45"
 
     # Test category
-    assert state.category == 'yellow'
+    assert state.category == '2'

--- a/stonesoup/updater/categorical.py
+++ b/stonesoup/updater/categorical.py
@@ -1,96 +1,41 @@
 # -*- coding: utf-8 -*-
+
 import numpy as np
 
 from ..base import Property
-from ..models.measurement.categorical import CategoricalMeasurementModel
+from ..models.measurement.categorical import MarkovianMeasurementModel
 from ..types.prediction import MeasurementPrediction
-from ..types.state import CategoricalState
 from ..types.update import Update
 from ..updater import Updater
 
 
 class HMMUpdater(Updater):
-    r"""Models the update step of a hidden Markov model"""
+    r"""Hidden Markov model updater"""
 
-    measurement_model: CategoricalMeasurementModel = Property(
+    measurement_model: MarkovianMeasurementModel = Property(
         default=None,
-        doc="An observation-based measurement model. Measurements are assumed to be as defined "
-            "above. This model need not be defined if a measurement model is provided in the "
-            "measurement. If no model specified on construction, or in the measurement, then an "
-            "error will be thrown.")
-
-    def _check_measurement_model(self, measurement_model):
-        """Check that the measurement model passed actually exists. If not attach the one in the
-        updater. If that one's not specified, return an error.
-
-        Parameters
-        ----------
-        measurement_model : :class`~.MeasurementModel`
-            A measurement model to be checked
-
-        Returns
-        -------
-        : :class`~.MeasurementModel`
-            The measurement model to be used
-        """
-
-        if measurement_model is None:
-            if self.measurement_model is None:
-                raise ValueError("No measurement model specified")
-            else:
-                measurement_model = self.measurement_model
-
-        try:
-            measurement_model.emission_matrix
-        except AttributeError:
-            raise ValueError("Measurement model must be categorical. I.E. it must have an "
-                             "Emission matrix property for the HMMUpdater")
-
-        return measurement_model
-
-    def _get_emission_matrix(self, hypothesis):
-
-        measurement_model = self._check_measurement_model(hypothesis.measurement.measurement_model)
-
-        return measurement_model.emission_matrix
-
-    def predict_measurement(self, predicted_state, measurement_model=None, category_names=None,
-                            **kwargs):
-        r"""Predict the measurement implied by the predicted state mean
-
-        Parameters
-        ----------
-        predicted_state : :class:`~.State`
-            The predicted state :math:`X_{k|k-1}`.
-        measurement_model : :class:`~.MeasurementModel`
-            The measurement model. If omitted, the model in the updater object is used.
-        category_names : :class:`list`
-            List of :class:`str` measurement category names.
-        **kwargs : various
-            These are passed to :meth:`~.MeasurementModel.function` and
-            :meth:`~.MeasurementModel.matrix`.
-
-        Returns
-        -------
-        : :class:`~.MeasurementPrediction`
-            The measurement prediction, :math:`Y_{k|k-1}`
-        """
-
-        measurement_model = self._check_measurement_model(measurement_model)
-
-        pred_meas = measurement_model.function(predicted_state, **kwargs)
-
-        return MeasurementPrediction.from_state(predicted_state, pred_meas,
-                                                category_names=category_names)
+        doc="The measurement model used to predict measurement vectors. If no model is specified "
+            "on construction, or in a measurement, then an error will be thrown.")
 
     def update(self, hypothesis, **kwargs):
         r"""The update method. Given a hypothesised association between a predicted state or
         predicted measurement and an actual measurement, calculate the posterior state.
 
-        Bayes' rule: :math:`p(x_k|z_{1:k}) \propto p(z_k|x_k) p(x_k|z_{1:k-1})`. The likelihood is
-        calculated as an Nx1 vector of :math:`p(z_k|x_{k|k-1})` for the :math:`z_k` actually
-        observed.
-        This is element-wise multiplied by the prior and normalised.
+        .. math::
+            \alpha_t^i = E^{ki}(F\alpha_{t-1})^i
+
+        Measurements are assumed to be discrete categories from a finite set of measurement
+        categories :math:`Z = \{\zeta^n|n\in \mathbf{N}, n\le N\} (for some finite :math:`N`).
+        A measurement should be equivalent to a basis vector :math:`e^k`, (the N-tuple with all
+        components equal to 0, except the k-th (indices starting at 0), which is 1). This
+        indicates that the measured category is :math:`\zeta^k`.
+
+        The equation above can be simplified to:
+
+        .. math::
+            \alpha_t = E^Ty_t \circ F\alpha_{t-1}
+
+        where :math:`\circ` denotes element-wise (Hadamard) product.
 
         Parameters
         ----------
@@ -99,37 +44,87 @@ class HMMUpdater(Updater):
             predicted measurement, or a predicted state. In the latter case a predicted
             measurement will be calculated.
         **kwargs : various
-            These are passed to :meth:`predict_measurement`
+            These are passed to :meth:`predict_measurement`.
 
         Returns
         -------
         : :class:`~.CategoricalStateUpdate`
-            The posterior categorical state
+            The posterior categorical state.
         """
 
         prediction = hypothesis.prediction
-
-        if not isinstance(prediction, CategoricalState):
-            raise ValueError("Prediction must be a categorical state type")
-
-        # category names to be passed to measurement prediction
-        measurement_category_names = hypothesis.measurement.category_names
+        measurement = hypothesis.measurement
+        measurement_model = hypothesis.measurement.measurement_model
+        measurement_model = self._check_measurement_model(measurement_model)
 
         if hypothesis.measurement_prediction is None:
-            measurement_model = hypothesis.measurement.measurement_model
-            measurement_model = self._check_measurement_model(measurement_model)
-
             # Attach the measurement prediction to the hypothesis
             hypothesis.measurement_prediction = self.predict_measurement(
-                prediction, measurement_model=measurement_model,
-                category_names=measurement_category_names, **kwargs)
+                predicted_state=prediction,
+                measurement_model=measurement_model,
+                measurement=measurement,
+                **kwargs
+            )
 
-        emission_matrix = self._get_emission_matrix(hypothesis)
-        likelihood = emission_matrix @ hypothesis.measurement.state_vector
+        emission_matrix = measurement_model.emission_matrix
+        likelihood = emission_matrix.T @ measurement.state_vector
 
-        # Bayes rule
         posterior = np.multiply(likelihood, hypothesis.prediction.state_vector)
         posterior = posterior / np.sum(posterior)
 
         return Update.from_state(hypothesis.prediction, posterior,
                                  timestamp=hypothesis.measurement.timestamp, hypothesis=hypothesis)
+
+    def _check_measurement_model(self, measurement_model):
+        """Check that the measurement model passed actually exists. If not attach the one in the
+        updater. If that one is not specified, raise an error.
+
+        Parameters
+        ----------
+        measurement_model : :class`~.MeasurementModel`
+            A measurement model to be checked.
+
+        Returns
+        -------
+        : :class`~.MeasurementModel`
+            The measurement model to be used.
+        """
+
+        if measurement_model is None:
+            if self.measurement_model is None:
+                raise ValueError("No measurement model specified")
+            else:
+                measurement_model = self.measurement_model
+
+        if not isinstance(measurement_model, MarkovianMeasurementModel):
+            raise ValueError(
+                "HMMUpdater must be used in conjuction with HiddenMarkovianMeasurementModel types"
+            )
+
+        return measurement_model
+
+    def predict_measurement(self, predicted_state, measurement_model, measurement, **kwargs):
+        r"""Predict the measurement implied by the predicted state.
+
+        Parameters
+        ----------
+        predicted_state : :class:`~.CategoricalState`
+            The predicted state..
+        measurement_model : :class:`~.MeasurementModel`
+            The measurement model. If omitted, the model in the updater object is used.
+        measurement : :class:`~.CategoricalState`.
+            The measurement.
+        **kwargs : various
+            These are passed to :meth:`~.MeasurementModel.function`.
+
+        Returns
+        -------
+        : :class:`~.CategoricalMeasurementPrediction`
+            The measurement prediction.
+        """
+
+        measurement_model = self._check_measurement_model(measurement_model)
+
+        pred_meas = measurement_model.function(predicted_state, **kwargs)
+
+        return MeasurementPrediction.from_state(measurement, state_vector=pred_meas)

--- a/stonesoup/updater/tests/test_categorical.py
+++ b/stonesoup/updater/tests/test_categorical.py
@@ -1,98 +1,74 @@
 # coding: utf-8
+
 import datetime
 
 import numpy as np
 import pytest
 
-from ...models.measurement.categorical import CategoricalMeasurementModel
+from ...models.measurement.categorical import MarkovianMeasurementModel
 from ...models.measurement.linear import LinearGaussian
-from ...models.transition.tests.test_categorical import create_categorical, \
-    create_categorical_matrix
+from ...types.array import StateVector
 from ...types.detection import CategoricalDetection
 from ...types.hypothesis import SingleHypothesis
-from ...types.prediction import CategoricalMeasurementPrediction
-from ...types.state import CategoricalState, GaussianState
+from ...types.prediction import CategoricalMeasurementPrediction, CategoricalStatePrediction
 from ...types.update import CategoricalStateUpdate
 from ...updater.categorical import HMMUpdater
 
 
-@pytest.mark.parametrize('ndim_state', (2, 3, 4))
-@pytest.mark.parametrize('ndim_meas', (2, 3, 4))
-def test_classification_updater(ndim_state, ndim_meas):
-    now = datetime.datetime.now()
-    future = now + datetime.timedelta(seconds=5)
-
-    E = create_categorical_matrix(ndim_state, ndim_meas)
-    Ecov = 0.1 * np.eye(ndim_meas)
-    measurement_model = CategoricalMeasurementModel(ndim_state=ndim_state,
-                                                    emission_matrix=E,
-                                                    emission_covariance=Ecov)
-
-    prediction = CategoricalState(create_categorical(ndim_state))
-    prediction.timestamp = future
+def test_hmm_updater():
+    E = np.array([[30, 25, 5],
+                  [20, 25, 10],
+                  [10, 25, 80],
+                  [40, 25, 5]])
+    measurement_model = MarkovianMeasurementModel(E)
 
     updater = HMMUpdater(measurement_model)
-    empty_updater = HMMUpdater()
-    wrong_updater = HMMUpdater(LinearGaussian(ndim_state=ndim_state,
-                                              mapping=[0, 1],
-                                              noise_covar=np.eye(ndim_state)))
+
+    now = datetime.datetime.now()
+
+    prediction = CategoricalStatePrediction([80, 10, 10], timestamp=now)
+
+    # Test check measurement model
+    assert updater._check_measurement_model(measurement_model) == measurement_model
+    assert updater._check_measurement_model(None) == measurement_model
+    updater.measurement_model = None
+    with pytest.raises(ValueError, match="No measurement model specified"):
+        updater._check_measurement_model(None)
+    updater.measurement_model = measurement_model
+    with pytest.raises(ValueError, match="HMMUpdater must be used in conjuction with "
+                                         "HiddenMarkovianMeasurementModel types"):
+        updater._check_measurement_model(LinearGaussian(np.eye(3),
+                                                        mapping=(0, 1, 2),
+                                                        noise_covar=np.eye(3)))
+
+    measurement_categories = ['red', 'green', 'blue', 'yellow']
+    measurement = CategoricalDetection(StateVector([10, 20, 30, 40]),
+                                       timestamp=now,
+                                       measurement_model=measurement_model,
+                                       categories=measurement_categories)
 
     # Test measurement prediction
-    eval_measurement_prediction = measurement_model.function(prediction)
-    measurement_prediction = updater.predict_measurement(prediction)
+    measurement_prediction = updater.predict_measurement(prediction,
+                                                         measurement_model,
+                                                         measurement)
+    exp_measurement_prediction_vector = measurement_model.function(prediction, noise=False)
     assert isinstance(measurement_prediction, CategoricalMeasurementPrediction)
-    assert (np.allclose(measurement_prediction.state_vector,
-                        eval_measurement_prediction,
-                        0,
-                        atol=1.e-14))
+    assert np.allclose(measurement_prediction.state_vector, exp_measurement_prediction_vector)
+    assert measurement_prediction.categories == measurement_categories
 
-    E = measurement_model.emission_matrix
-    measurement = measurement_model.function(CategoricalState(create_categorical(E.shape[0])))
-    hypothesis = SingleHypothesis(
-        prediction=prediction,
-        measurement=CategoricalDetection(measurement, timestamp=future,
-                                         measurement_model=measurement_model)
-    )
+    # Test update (with/without measurement prediction)
 
-    # Test get emission matrix
-    assert (updater._get_emission_matrix(hypothesis) == E).all()
+    for hypothesis in [SingleHypothesis(prediction=prediction,
+                                        measurement=measurement),
+                       SingleHypothesis(prediction=prediction,
+                                        measurement=measurement,
+                                        measurement_prediction=measurement_prediction)]:
+        update = updater.update(hypothesis)
 
-    # Test update with and without measurement prediction
-    for meas_pred in [None, measurement_prediction]:
-        hypothesis.measurement_prediction = meas_pred
-        eval_posterior = np.multiply(prediction.state_vector, E @ measurement)
-        eval_posterior = eval_posterior / np.sum(eval_posterior)
-        posterior = updater.update(hypothesis)
+        measurement_prediction = hypothesis.measurement_prediction
+        assert isinstance(measurement_prediction, CategoricalMeasurementPrediction)
+        assert np.allclose(measurement_prediction.state_vector, exp_measurement_prediction_vector)
 
-        assert isinstance(posterior, CategoricalStateUpdate)
-        assert posterior.category_names == prediction.category_names
-        assert (np.allclose(posterior.state_vector, eval_posterior, 0, atol=1.e-14))
-        assert posterior.timestamp == prediction.timestamp
-
-        # Assert presence of measurement
-        assert hasattr(posterior, 'hypothesis')
-        assert posterior.hypothesis == hypothesis
-
-    # Test measurement model error
-    empty_hypothesis = SingleHypothesis(
-        prediction=prediction,
-        measurement=CategoricalDetection(measurement, timestamp=future)
-    )
-
-    with pytest.raises(ValueError,
-                       match="No measurement model specified"):
-        empty_updater.update(empty_hypothesis)
-    with pytest.raises(ValueError,
-                       match="Measurement model must be categorical. I.E. it must have an "
-                             "Emission matrix property for the HMMUpdater"):
-        wrong_updater.update(empty_hypothesis)
-
-    # Test non-categorical prediction
-
-    bad_hypothesis = SingleHypothesis(
-        prediction=GaussianState(create_categorical(ndim_state), np.eye(ndim_state)),
-        measurement=CategoricalDetection(measurement, timestamp=future)
-    )
-
-    with pytest.raises(ValueError, match="Prediction must be a categorical state type"):
-        updater.update(bad_hypothesis)
+        assert isinstance(update, CategoricalStateUpdate)
+        assert update.hypothesis == hypothesis
+        assert update.state_vector.shape[0] == 3


### PR DESCRIPTION
The most important change here is the use of the "emission matrix". Which has been correctly defined now as the matrix modelling conditional probabilities of receiving measurement classes given a particular hidden class.

Models now do not have additive noise (this was originally done to make the models interface similarly to other Stone Soup models, but was not necessary).

Some renaming also carried-out.