### PR TITLE
Fix time steps based deleter 

### DIFF
--- a/stonesoup/deleter/time.py
+++ b/stonesoup/deleter/time.py
@@ -30,8 +30,17 @@ class UpdateTimeStepsDeleter(Deleter):
             `False` if track has an :class:`~.Update` with measurements within
             time steps; `True` otherwise.
         """
-        return not any(isinstance(state, Update) and state.hypothesis
-                       for state in track[-self.time_steps_since_update:])
+        timestamps_set = set()
+
+        for state in track[::-1]:
+            timestamps_set.add(state.timestamp)
+            if len(timestamps_set) > self.time_steps_since_update:
+                return True
+
+            if isinstance(state, Update) and state.hypothesis:
+                return False
+
+        return False
 
 
 class UpdateTimeDeleter(Deleter):

--- a/stonesoup/deleter/time.py
+++ b/stonesoup/deleter/time.py
@@ -27,8 +27,8 @@ class UpdateTimeStepsDeleter(Deleter):
         Returns
         -------
         bool
-            `True` if track has an :class:`~.Update` with measurements within
-            time steps; `False` otherwise.
+            `False` if track has an :class:`~.Update` with measurements within
+            time steps; `True` otherwise.
         """
         return not any(isinstance(state, Update) and state.hypothesis
                        for state in track[-self.time_steps_since_update:])
@@ -57,8 +57,8 @@ class UpdateTimeDeleter(Deleter):
         Returns
         -------
         bool
-            `True` if track has an :class:`~.Update` with measurements within
-            time; `False` otherwise.
+            `False` if track has an :class:`~.Update` with measurements within
+            time; `True` otherwise.
         """
         if timestamp is None:
             timestamp = track.timestamp


### PR DESCRIPTION
This pull request is intended to resolve the issue #610.

As discussed in #610, the **_UpdateTimeStepsDeleter_** does not correctly consider the situation when multiple states are appended to a track at a given timestamp.

The new proposed **_check_for_deletion_** method will instead run through the past n timestamps, where n is the specified **_time_steps_since_update_,** checking if any states appended in that window are of type **_Update_**.

This PR also fixes some minor documentation errors to correctly reflect when a track will be deleted.