### PR TITLE
Cast correction term to float in LCCUpdater

### DIFF
--- a/stonesoup/updater/pointprocess.py
+++ b/stonesoup/updater/pointprocess.py
@@ -2,6 +2,7 @@
 from abc import abstractmethod
 
 from scipy.stats import multivariate_normal
+import numpy as np
 
 from ..base import Base, Property
 from .kalman import KalmanUpdater
@@ -195,7 +196,7 @@ class LCCUpdater(PointProcessUpdater):
         misdetected_c2 = (misdetected_weight_sum**2)*l2
         self.second_order_cumulant = misdetected_c2 - detected_c2
         # Return the l1 correction factor for miss detected weight update
-        return l1
+        return np.float64(l1)
 
     @property
     def second_order_false_alarm_cumulant(self):


### PR DESCRIPTION
**TLDR:** Gaussian components updated using the `LCCUpdater` have weights which are `Probability` objects. This in turn causes some component state vectors to be made of Probabilities instead of floats. To fix this, we can cast the l1 correction term from a Probability to a float.

**Problem:** 
When using the GM-LCC filter, sometimes an updated component's state vector is filled with Probability types, instead of floats. For example, an updated component may have state vector 
`[Probability(15.0), Probability(0.5), 8.0, Probability(0.3)]`
On its own, this is not a big problem. But it isn't the proper use of a Probability object and none of the other filters behave this way.

**Cause:**
I traced the problem back and found that it was caused by two things:

The LCCUpdater calculates an l1 correction factor. As seen in the code below, that correction factor will be a Probability object (I have checked this). 

https://github.com/dstl/Stone-Soup/blob/d38a196fa91dc7015355903f3cfcf5d68792d782/stonesoup/updater/pointprocess.py#L164-L187

Later, the correction factor is used as a factor in the weight calculation for updated components. Thus, the calculated weight will be a Probability. This means that updated components in a GM-LCC (other than the birth component) will have Probability weights.

https://github.com/dstl/Stone-Soup/blob/d38a196fa91dc7015355903f3cfcf5d68792d782/stonesoup/updater/pointprocess.py#L99-L112

This Probability weight causes problems further down the line in the GaussianMixtureReducer. When merging two components, the state vector of each original component is multiplied by its weight. If that weight is a Probability, it will make the merged component mean have Probability elements. It is also true that a Probability weight will perpetuate the problem in the next timesteps even if the component is not merged with another.

**Proposed Solution:**
In the LCCUpdater function `_calculate_update_terms()`, simply cast l1 as a numpy float64 before returning it. Note that it is cast as a numpy 64 float so that the weights are also numpy64, thus matching the result from a PHDUpdater.