### PR TITLE
Prevent track from birth component w/o detection

### DIFF
--- a/docs/tutorials/11_GMPHDTutorial.py
+++ b/docs/tutorials/11_GMPHDTutorial.py
@@ -332,7 +332,7 @@ for truth in start_truths:
             state_vector=truth.state_vector,
             covar=covar**2,
             weight=0.25,
-            tag='birth',
+            tag=TaggedWeightedGaussianState.BIRTH,
             timestamp=start_time)
     tracks.add(Track(new_track))
 

--- a/stonesoup/hypothesiser/gaussianmixture.py
+++ b/stonesoup/hypothesiser/gaussianmixture.py
@@ -62,10 +62,10 @@ class GaussianMixtureHypothesiser(Hypothesiser):
                 if isinstance(component, TaggedWeightedGaussianState):
                     # Ensure that a birth component without a measurement retains
                     # the birth tag. This will prevent a track from being made
-                    if component.tag == 'birth' and \
+                    if component.tag == component.BIRTH and \
                             isinstance(hypothesis.measurement, MissedDetection):
-                        tag = 'birth'
-                    elif component.tag == 'birth':
+                        tag = component.BIRTH
+                    elif component.tag == component.BIRTH:
                         tag = None  # a new tag will be made
                     else:
                         tag = component.tag

--- a/stonesoup/hypothesiser/gaussianmixture.py
+++ b/stonesoup/hypothesiser/gaussianmixture.py
@@ -59,10 +59,17 @@ class GaussianMixtureHypothesiser(Hypothesiser):
                                                                  **kwargs)
             for hypothesis in component_hypotheses:
                 if isinstance(component, TaggedWeightedGaussianState):
+                    # Ensure that a birth component without a measurement retains
+                    # the birth tag. This will prevent a track from being made
+                    if component.tag == 'birth' and isinstance(hypothesis.measurement, MissedDetection):
+                        tag = 'birth'
+                    elif component.tag == 'birth':
+                        tag = None # a new tag will be made
+                    else:
+                        tag = component.tag
                     hypothesis.prediction = \
                         TaggedWeightedGaussianStatePrediction(
-                            tag=component.tag if component.tag != "birth"
-                            else None,
+                            tag=tag,
                             weight=component.weight,
                             state_vector=hypothesis.prediction.state_vector,
                             covar=hypothesis.prediction.covar,

--- a/stonesoup/hypothesiser/gaussianmixture.py
+++ b/stonesoup/hypothesiser/gaussianmixture.py
@@ -5,6 +5,7 @@ from ..types.multihypothesis import MultipleHypothesis
 from ..types.prediction import (TaggedWeightedGaussianStatePrediction,
                                 WeightedGaussianStatePrediction)
 from ..types.state import TaggedWeightedGaussianState
+from ..types.detection import MissedDetection
 
 
 class GaussianMixtureHypothesiser(Hypothesiser):
@@ -61,10 +62,11 @@ class GaussianMixtureHypothesiser(Hypothesiser):
                 if isinstance(component, TaggedWeightedGaussianState):
                     # Ensure that a birth component without a measurement retains
                     # the birth tag. This will prevent a track from being made
-                    if component.tag == 'birth' and isinstance(hypothesis.measurement, MissedDetection):
+                    if component.tag == 'birth' and \
+                            isinstance(hypothesis.measurement, MissedDetection):
                         tag = 'birth'
                     elif component.tag == 'birth':
-                        tag = None # a new tag will be made
+                        tag = None  # a new tag will be made
                     else:
                         tag = component.tag
                     hypothesis.prediction = \

--- a/stonesoup/tracker/pointprocess.py
+++ b/stonesoup/tracker/pointprocess.py
@@ -64,8 +64,7 @@ class PointProcessMultiTargetTracker(Tracker):
         """
         for component in self.gaussian_mixture:
             tag = component.tag
-            if tag != 0:
-                # Sanity check for birth component
+            if tag != 'birth':  # Sanity check for birth component
                 if tag in self.target_tracks:
                     # Track found, so update it
                     track = self.target_tracks[tag]

--- a/stonesoup/tracker/pointprocess.py
+++ b/stonesoup/tracker/pointprocess.py
@@ -31,7 +31,9 @@ class PointProcessMultiTargetTracker(Tracker):
         default=None,
         doc="The birth component. The weight should be "
             "equal to the mean of the expected number of "
-            "births per timestep (Poission distributed)")
+            "births per timestep (Poission distributed). "
+            "The tag should be "
+            ":attr:`TaggedWeightedGaussianState.BIRTH`")
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -64,7 +66,7 @@ class PointProcessMultiTargetTracker(Tracker):
         """
         for component in self.gaussian_mixture:
             tag = component.tag
-            if tag != 'birth':  # Sanity check for birth component
+            if tag != component.BIRTH:  # Sanity check for birth component
                 if tag in self.target_tracks:
                     # Track found, so update it
                     track = self.target_tracks[tag]

--- a/stonesoup/tracker/tests/test_pointprocess.py
+++ b/stonesoup/tracker/tests/test_pointprocess.py
@@ -23,7 +23,7 @@ def test_point_process_multi_target_tracker_cycle(detector, predictor):
         birth_mean,
         birth_covar,
         weight=0.3,
-        tag="birth",
+        tag=TaggedWeightedGaussianState.BIRTH,
         timestamp=timestamp)
 
     # Initialise a Kalman Updater

--- a/stonesoup/types/state.py
+++ b/stonesoup/types/state.py
@@ -420,6 +420,8 @@ class TaggedWeightedGaussianState(WeightedGaussianState):
     """
     tag: str = Property(default=None, doc="Unique tag of the Gaussian State.")
 
+    BIRTH = 'birth'
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         if self.tag is None:

--- a/stonesoup/types/state.py
+++ b/stonesoup/types/state.py
@@ -421,6 +421,7 @@ class TaggedWeightedGaussianState(WeightedGaussianState):
     tag: str = Property(default=None, doc="Unique tag of the Gaussian State.")
 
     BIRTH = 'birth'
+    '''Tag value used to signify birth component'''
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)


### PR DESCRIPTION
Problem: In Gaussian-mixture based trackers, tracks can currently be made from the birth component without a detection. 

The `GaussianMixtureHypothesiser` creates prediction-detection pairs as hypotheses. Each prediction is paired with each `TrueDetection` and also with a `MissedDetection`. If the prediction is from the birth component, the hypothesis will get assigned a new tag. Otherwise, the hypothesis will carry the tag from the predicted component. But if the hypothesis is from the birth component with a `MissedDetection`, then it should not get a new tag. It should keep the "birth" tag because it does not correspond to any real data. This problem is realized later, when the `PointProcessMultiTargetTracker` checks the tag of each component. If a component does not have the 'birth' tag, then it will try to make a track or add to an existing one. For this if-statement to be effective, we need the birth component to keep its birth tag.

To fix this, I added a new conditional when assigning tags to hypotheses.

---

Also, pointprocess.py use '0' as the tag of the birth component, , while these other files use 'birth':
https://github.com/dstl/Stone-Soup/blob/d38a196fa91dc7015355903f3cfcf5d68792d782/stonesoup/tracker/tests/test_pointprocess.py#L26

https://github.com/dstl/Stone-Soup/blob/d38a196fa91dc7015355903f3cfcf5d68792d782/stonesoup/hypothesiser/gaussianmixture.py#L64
I changed pointprocess.py to also use 'birth'.

It may be good to explicitly say that the birth component must have tag 'birth' in the docstring of the `birth_component`, and/or to check for it in the constructor and raise an error otherwise. Thoughts?