### PR TITLE
Add options to track to track association algorithm

### DIFF
--- a/stonesoup/dataassociator/tests/test_tracktotrack.py
+++ b/stonesoup/dataassociator/tests/test_tracktotrack.py
@@ -65,7 +65,6 @@ def test_euclidiantracktotrack(tracks):
         association_threshold=10,
         consec_pairs_confirm=3,
         consec_misses_end=2,
-        mapping=[0, 1],
         use_positional_only=False)
     start_time = datetime.datetime(2019, 1, 1, 14, 0, 0)
 
@@ -76,7 +75,7 @@ def test_euclidiantracktotrack(tracks):
         association_threshold=10,
         consec_pairs_confirm=3,
         consec_misses_end=2,
-        mapping=[0],
+        pos_map=[0],
         use_positional_only=True)
 
     association_set_2 = positional_associator.associate_tracks({tracks[0], tracks[2]},
@@ -87,7 +86,7 @@ def test_euclidiantracktotrack(tracks):
         association_threshold=10,
         consec_pairs_confirm=3,
         consec_misses_end=2,
-        mapping=[0],
+        pos_map=[0],
         use_positional_only=False,
         position_weighting=0.999)
 

--- a/stonesoup/dataassociator/tests/test_tracktotrack.py
+++ b/stonesoup/dataassociator/tests/test_tracktotrack.py
@@ -46,6 +46,17 @@ def tracks():
               timestamp=start_time + datetime.timedelta(seconds=i))
         for i in range(10)]))
 
+    # 6th should match with 1st from the 2nd timestamp to the 7th, but continues after this point
+    tracks.append(Track(states=[
+        State(state_vector=[[20], [20]],
+              timestamp=start_time)]
+        + [State(state_vector=[[i + 2], [i + 2]],
+                 timestamp=start_time + datetime.timedelta(seconds=i))
+            for i in range(1, 7)]
+        + [State(state_vector=[[i + 1000], [i + 1000]],
+                 timestamp=start_time + datetime.timedelta(seconds=i))
+           for i in range(7, 10)]))
+
     return tracks
 
 
@@ -83,6 +94,8 @@ def test_euclidiantracktotrack(tracks):
     association_set_3 = heavily_weighted_associator.associate_tracks(
                             {tracks[0], tracks[2]}, {tracks[1], tracks[3], tracks[4]})
 
+    association_set_4 = complete_associator.associate_tracks({tracks[0]}, {tracks[5]})
+
     assert len(association_set_1.associations) == 1
     assoc1 = list(association_set_1.associations)[0]
     assert set(assoc1.objects) == {tracks[0], tracks[1]}
@@ -95,13 +108,20 @@ def test_euclidiantracktotrack(tracks):
     assoc20 = list(association_set_2.associations)[0]
     assoc21 = list(association_set_2.associations)[1]
     assert set(assoc20.objects) == {tracks[0], tracks[4]} or \
-           set(assoc21.objects) == {tracks[0], tracks[4]}
+        set(assoc21.objects) == {tracks[0], tracks[4]}
 
     assert len(association_set_3.associations) == 2
     assoc30 = list(association_set_3.associations)[0]
     assoc31 = list(association_set_3.associations)[1]
     assert set(assoc30.objects) == {tracks[0], tracks[4]} or \
-           set(assoc31.objects) == {tracks[0], tracks[4]}
+        set(assoc31.objects) == {tracks[0], tracks[4]}
+
+    assert len(association_set_4) == 1
+    assoc4 = list(association_set_4)[0]
+    assert assoc4.time_range.start_timestamp \
+        == start_time + datetime.timedelta(seconds=1)
+    assert assoc4.time_range.end_timestamp \
+        == start_time + datetime.timedelta(seconds=7)
 
 
 def test_euclidiantracktotruth(tracks):

--- a/stonesoup/dataassociator/tracktotrack.py
+++ b/stonesoup/dataassociator/tracktotrack.py
@@ -21,11 +21,17 @@ class TrackToTrackCounting(TrackToTrackAssociator):
     each time at which the two :class:`~.State` within the :class:`~.tracks`
     are assessed to be associated.
 
-    Uses an algorithm called the Counting Technique [1]_.  Sagild et al, 2021.
+    Uses an algorithm called the Counting Technique [1]_.
     Associations are triggered by track states being within a threshold
     distance for a given number of timestamps. Associations are terminated when
     either the two :class:`~.tracks` end or the two :class:`~.State` are
     separated by a distance greater than the threshold at the next time step.
+
+    References
+        ----------
+        .. [1] J. Å. Sagild, A. Gullikstad Hem and E. F. Brekke, \
+        "Counting Technique versus Single-Time Test for Track-to-Track Association," \
+        2021 IEEE 24th International Conference on Information Fusion (FUSION), 2021, pp. 1-7
 
     Note
     ----
@@ -36,12 +42,6 @@ class TrackToTrackCounting(TrackToTrackAssociator):
     combinations.
 
     ----
-
-    References
-        ----------
-        .. [1] J. Å. Sagild, A. Gullikstad Hem and E. F. Brekke,
-        "Counting Technique versus Single-Time Test for Track-to-Track Association,"
-        2021 IEEE 24th International Conference on Information Fusion (FUSION), 2021, pp. 1-7
 
     """
 

--- a/stonesoup/dataassociator/tracktotrack.py
+++ b/stonesoup/dataassociator/tracktotrack.py
@@ -40,7 +40,7 @@ class TrackToTrackCounting(TrackToTrackAssociator):
     :class:`~.Association` object will be return for all possible association
     combinations.
 
-    ----
+    
 
     """
 

--- a/stonesoup/dataassociator/tracktotrack.py
+++ b/stonesoup/dataassociator/tracktotrack.py
@@ -28,11 +28,10 @@ class TrackToTrackCounting(TrackToTrackAssociator):
     separated by a distance greater than the threshold at the next time step.
 
     References
-        ----------
-        .. [1] J. Å. Sagild, A. Gullikstad Hem and E. F. Brekke, \
-        "Counting Technique versus Single-Time Test for Track-to-Track Association," \
-        2021 IEEE 24th International Conference on Information Fusion (FUSION), 2021, pp. 1-7
-
+    ----------
+    .. [1] J. Å. Sagild, A. Gullikstad Hem and E. F. Brekke,
+           "Counting Technique versus Single-Time Test for Track-to-Track Association,"
+           2021 IEEE 24th International Conference on Information Fusion (FUSION), 2021, pp. 1-7
     Note
     ----
     Association is not prioritised based on historic associations or distance.

--- a/stonesoup/dataassociator/tracktotrack.py
+++ b/stonesoup/dataassociator/tracktotrack.py
@@ -14,13 +14,14 @@ from ..types.time import TimeRange
 
 
 class TrackToTrackCounting(TrackToTrackAssociator):
-    """Track to track associator based on the Counting Technique [1]_.  Sagild et al, 2021.
+    """Track to track associator based on the Counting Technique
 
     Compares two sets of :class:`~.tracks`, each formed of a sequence of
     :class:`~.State` objects and returns an :class:`~.Association` object for
-    each time at which a the two :class:`~.State` within the :class:`~.tracks`
+    each time at which the two :class:`~.State` within the :class:`~.tracks`
     are assessed to be associated.
 
+    Uses an algorithm called the Counting Technique [1]_.  Sagild et al, 2021.
     Associations are triggered by track states being within a threshold
     distance for a given number of timestamps. Associations are terminated when
     either the two :class:`~.tracks` end or the two :class:`~.State` are
@@ -32,7 +33,9 @@ class TrackToTrackCounting(TrackToTrackAssociator):
     If, at a specific time step, the :class:`~.State` of one of the
     :class:`~.tracks` is assessed as close to more than one track then an
     :class:`~.Association` object will be return for all possible association
-    combinations
+    combinations.
+
+    ----
 
     References
         ----------
@@ -59,14 +62,14 @@ class TrackToTrackCounting(TrackToTrackAssociator):
         default=EuclideanWeighted([0]),
         doc="Distance measure to use. Must use :class:`~.measures.EuclideanWeighted()` if "
             "`use_positional_only` set to True.  Default :class:`~.measures.EuclideanWeighted()` "
-            "(using equal weights unless use_positional_only is set to True)")
+            "(using equal weights unless :attr:`use_positional_only` is set to `True`)")
     mapping: list = Property(
         doc="List of items specifying the mapping of the position components "
             "of the state space")
     use_positional_only: bool = Property(
         default=True,
-        doc="If True, the differences in velocity/acceleration values for each state are ignored "
-            "in the calculation for the association threshold.  Default is True"
+        doc="If `True`, the differences in velocity/acceleration values for each state are "
+            "ignored in the calculation for the association threshold.  Default is `True`"
     )
     position_weighting: float = Property(
         default=0.6,

--- a/stonesoup/dataassociator/tracktotrack.py
+++ b/stonesoup/dataassociator/tracktotrack.py
@@ -40,7 +40,6 @@ class TrackToTrackCounting(TrackToTrackAssociator):
     :class:`~.Association` object will be return for all possible association
     combinations.
 
-    
 
     """
 

--- a/stonesoup/hypothesiser/tests/test_gaussianmixture.py
+++ b/stonesoup/hypothesiser/tests/test_gaussianmixture.py
@@ -89,7 +89,7 @@ def test_gm_ordered_by_component(predictor, updater):
     assert all(isinstance(hyp, SingleHypothesis)
                for multi_hyp in hypotheses for hyp in multi_hyp)
     assert len(hypotheses) == 2
-    # Last element in each array isthe miss detected component
+    # Last element in each array is the miss detected component
     assert len(hypotheses[0]) == 3
     assert len(hypotheses[1]) == 3
 

--- a/stonesoup/measures.py
+++ b/stonesoup/measures.py
@@ -11,7 +11,7 @@ from .types.state import State
 class Measure(Base):
     """Measure base type
 
-    A measure provides a means to assess the seperation between two
+    A measure provides a means to assess the separation between two
     :class:`~.State` objects state1 and state2.
     """
     mapping: np.ndarray = Property(


### PR DESCRIPTION
I've made some improvements to the track to track association algorithm.  The main difference is extra parameters allowing the user to specify whether the entire `StateVector` should be used, or rather just positional elements given in the `mapping` parameter.  The class was also renamed in anticipation of new T2TA algorithms in Stone Soup