### PR TITLE
Add Nonparametric PDA and gate out non valid measurements

### DIFF
--- a/stonesoup/dataassociator/tests/conftest.py
+++ b/stonesoup/dataassociator/tests/conftest.py
@@ -33,7 +33,8 @@ def updater(measurement_model):
 def probability_hypothesiser(predictor, updater):
     return PDAHypothesiser(predictor, updater,
                            clutter_spatial_density=1.2e-2,
-                           prob_detect=0.9, prob_gate=0.99)
+                           prob_detect=0.9, prob_gate=0.99,
+                           include_all=True)
 
 
 @pytest.fixture()

--- a/stonesoup/gater/tests/test_distance.py
+++ b/stonesoup/gater/tests/test_distance.py
@@ -41,7 +41,8 @@ def test_distance(predictor, updater, detections, gate_threshold, num_gated):
 
     timestamp = datetime.datetime.now()
 
-    hypothesiser = PDAHypothesiser(predictor, updater, clutter_spatial_density=0.000001)
+    hypothesiser = PDAHypothesiser(
+        predictor, updater, clutter_spatial_density=0.000001, include_all=True)
     gater = DistanceGater(hypothesiser, measure=measure, gate_threshold=gate_threshold)
 
     track = Track([GaussianStateUpdate(

--- a/stonesoup/hypothesiser/tests/test_composite.py
+++ b/stonesoup/hypothesiser/tests/test_composite.py
@@ -25,11 +25,11 @@ def make_categorical_measurement_model(ndim_state, ndim_meas):
 def test_composite(predictor, updater, dummy_category_predictor, dummy_category_updater):
     sub_hypothesisers = [
         PDAHypothesiser(predictor, updater, clutter_spatial_density=1.2e-2, prob_detect=0.9,
-                        prob_gate=0.99),
+                        prob_gate=0.99, include_all=True),
         HMMHypothesiser(dummy_category_predictor, dummy_category_updater,
                         prob_detect=0.7, prob_gate=0.95),
         PDAHypothesiser(predictor, updater, clutter_spatial_density=1.4e-2, prob_detect=0.5,
-                        prob_gate=0.98),
+                        prob_gate=0.98, include_all=True),
         HMMHypothesiser(dummy_category_predictor, dummy_category_updater,
                         prob_detect=0.8, prob_gate=0.97)
     ]

--- a/stonesoup/hypothesiser/tests/test_probability.py
+++ b/stonesoup/hypothesiser/tests/test_probability.py
@@ -1,6 +1,7 @@
 import datetime
 
 import numpy as np
+import pytest
 
 from ..probability import PDAHypothesiser
 from ...types.detection import Detection, MissedDetection
@@ -24,20 +25,60 @@ def test_pda(predictor, updater):
     mulltihypothesis = \
         hypothesiser.hypothesise(track, detections, timestamp)
 
-    # There are 3 weighted hypotheses - Detections 1 and 2, MissedDectection
+    # There are 2 weighted hypotheses - Detections 1 and MissedDetection
+    # Detection 2 is not a "valid measurement" and gated out
+    assert len(mulltihypothesis) == 2
+
+    # Each hypothesis has a probability/weight attribute
+    assert all(hypothesis.probability >= 0 and isinstance(hypothesis.probability, Probability)
+               for hypothesis in mulltihypothesis)
+
+    #  Detection 1 and MissedDetection are present
+    assert detection1 in {hypothesis.measurement for hypothesis in mulltihypothesis}
+    assert any(isinstance(hypothesis.measurement, MissedDetection)
+               for hypothesis in mulltihypothesis)
+
+    hypothesiser = PDAHypothesiser(predictor, updater,
+                                   clutter_spatial_density=1.2e-2,
+                                   prob_detect=0.9, prob_gate=0.99,
+                                   include_all=True)
+
+    mulltihypothesis = \
+        hypothesiser.hypothesise(track, detections, timestamp)
+
+    # There are 3 weighted hypotheses - Detections 1 and 2, MissedDetection
     assert len(mulltihypothesis) == 3
 
     # Each hypothesis has a probability/weight attribute
-    assert all(hypothesis.probability >= 0 and
-               isinstance(hypothesis.probability, Probability)
-               for hypothesis in
-               mulltihypothesis)
+    assert all(hypothesis.probability >= 0 and isinstance(hypothesis.probability, Probability)
+               for hypothesis in mulltihypothesis)
 
     #  Detection 1, 2 and MissedDetection are present
-    assert any(hypothesis.measurement is detection1 for hypothesis in
-               mulltihypothesis)
-    assert any(hypothesis.measurement is detection2 for hypothesis in
-               mulltihypothesis)
+    assert {detection1, detection2} < {hypothesis.measurement for hypothesis in mulltihypothesis}
     assert any(isinstance(hypothesis.measurement, MissedDetection)
-               for hypothesis in
-               mulltihypothesis)
+               for hypothesis in mulltihypothesis)
+
+    hypothesiser = PDAHypothesiser(predictor, updater,
+                                   prob_detect=0.9, prob_gate=0.99)
+
+    mulltihypothesis = \
+        hypothesiser.hypothesise(track, detections, timestamp)
+
+    # There are 2 weighted hypotheses - Detections 1 and MissedDetection
+    # Detection 2 is not a "valid measurement" and gated out
+    assert len(mulltihypothesis) == 2
+
+    # Each hypothesis has a probability/weight attribute
+    assert all(hypothesis.probability >= 0 and isinstance(hypothesis.probability, Probability)
+               for hypothesis in mulltihypothesis)
+
+    #  Detection 1 and MissedDetection are present
+    assert detection1 in {hypothesis.measurement for hypothesis in mulltihypothesis}
+    assert any(isinstance(hypothesis.measurement, MissedDetection)
+               for hypothesis in mulltihypothesis)
+
+
+def test_invalid_pda_arguments(predictor, updater):
+    with pytest.raises(ValueError):
+        PDAHypothesiser(predictor, updater,
+                        prob_detect=0.9, prob_gate=0.99, include_all=True)


### PR DESCRIPTION
This adds the ability to use nonparametric PDA for clutter spatial density, where it is estimated based on assumption that measurements within a defined validation region represent the clutter level.

This change also gates out non valid measurements by default, similar to the behaviour in the `DistanceHypothesier`, and per description in original PDA paper.