### PR TITLE
Add option to specify number of targets in MultiTargetGroundTruthSimulator

### DIFF
--- a/stonesoup/simulator/simple.py
+++ b/stonesoup/simulator/simple.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from typing import Optional
 import datetime
-from typing import Sequence, Tuple
+from typing import Sequence, Collection
 
 import numpy as np
 from ordered_set import OrderedSet
@@ -14,6 +14,7 @@ from ..types.detection import TrueDetection, Clutter
 from ..types.groundtruth import GroundTruthPath, GroundTruthState
 from ..types.numeric import Probability
 from ..types.state import GaussianState, State
+from ..types.array import StateVector
 from .base import DetectionSimulator, GroundTruthSimulator
 from stonesoup.buffered_generator import BufferedGenerator
 
@@ -92,9 +93,9 @@ class MultiTargetGroundTruthSimulator(SingleTargetGroundTruthSimulator):
         default=0.1, doc="Probability of track dying in each time step. Default 0.1.")
     seed: Optional[int] = Property(default=None, doc="Seed for random number generation."
                                                      " Default None")
-    preexisting_states: Tuple = Property(
-        default=tuple(), doc="State vectors at time 0 for "
-                             "groundtruths which should exist at the start of simulation.")
+    preexisting_states: Collection[StateVector] = Property(
+        default=list(), doc="State vectors at time 0 for "
+                            "groundtruths which should exist at the start of simulation.")
     initial_number_targets: int = Property(
         default=0, doc="Initial number of targets to be "
                        "simulated. These simulated targets will be made in addition to those "

--- a/stonesoup/simulator/simple.py
+++ b/stonesoup/simulator/simple.py
@@ -92,11 +92,13 @@ class MultiTargetGroundTruthSimulator(SingleTargetGroundTruthSimulator):
         default=0.1, doc="Probability of track dying in each time step. Default 0.1.")
     seed: Optional[int] = Property(default=None, doc="Seed for random number generation."
                                                      " Default None")
-    preexisting_states: Tuple = Property(default=tuple(), doc="State vectors at time 0 for "
-                        "groundtruths which should exist at the start of simulation.")
-    initial_number_targets: int = Property(default=0, doc="Initial number of targets to be "
-                        "simulated. These simulated targets will be made in addition to those "
-                        "defined by :attr:`preexisting_states`.")
+    preexisting_states: Tuple = Property(
+        default=tuple(), doc="State vectors at time 0 for "
+                             "groundtruths which should exist at the start of simulation.")
+    initial_number_targets: int = Property(
+        default=0, doc="Initial number of targets to be "
+                       "simulated. These simulated targets will be made in addition to those "
+                       "defined by :attr:`preexisting_states`.")
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -107,11 +109,11 @@ class MultiTargetGroundTruthSimulator(SingleTargetGroundTruthSimulator):
             self.initial_state.state_vector + \
             self.initial_state.covar @ \
             random_state.randn(self.initial_state.ndim, 1)
-        
+
         gttrack = GroundTruthPath()
         gttrack.append(GroundTruthState(
             state_vector=vector,
-            timestamp=time, 
+            timestamp=time,
             metadata={"index": self.index})
         )
         return gttrack
@@ -125,7 +127,7 @@ class MultiTargetGroundTruthSimulator(SingleTargetGroundTruthSimulator):
         if self.preexisting_states or self.initial_number_targets:
             # Use preexisting_states to make some groundtruth paths
             preexisting_paths = OrderedSet(
-                self._new_target(time, random_state, state) for state in self.preexisting_states) 
+                self._new_target(time, random_state, state) for state in self.preexisting_states)
 
             # Simulate more groundtruth paths for the number of initial_simulated_states
             initial_simulated_paths = OrderedSet(


### PR DESCRIPTION
I added two parameters to the MultiTargetGroundTruthSimulator class. Together, these parameters give the user more control over the number of targets, and their locations, that exist in the simulation. Previously, the number of targets could only be controlled using the birth rate and death probability.

`preexisting_states` is a list of state vectors where the user wants a target to start. These targets will all be initiated at time 0 and will last at least 1 time step (they will not die at time 0). After that, their survival is random according to the death probability.

`initial_number_targets` is an integer dictating the number of targets that the user wants to be randomly created at time 0. This makes it possible to start the simulation with, for example, 10 targets randomly spread in the state space. Previously, the number of targets existing at time 0 varied randomly according to the birth rate. Like the `preexisting_states` targets, these simulated states will not die at time 0. 

**Note:** I tried to make the docstrings clear that `initial_number_targets` is not simply the length of `preexisting states`. Please feel free to make suggestions if this needs clarification. Alternatively, make suggestions if the names of the parameters is not clear.

Thanks to @sdhiscocks for his suggestions and edits about this!

I made this in response to my discussion https://github.com/dstl/Stone-Soup/discussions/630#discussion-4054726.
