### PR TITLE
Move contract reference from LICENSE file to documentation

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -5,10 +5,6 @@ MIT License
 © Copyright 2018-2022 University of Liverpool UK
 © Copyright 2020-2022 John Hiles
 
-Portions of this work were created while John Hiles was employed by Wright
-State University under Contract No. FA8650-18-2-1645 to the Air Force Research
-Laboratory, and the University has released its rights to this Student work.
-
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
 in the Software without restriction, including without limitation the rights

--- a/docs/source/copyright.rst
+++ b/docs/source/copyright.rst
@@ -6,3 +6,7 @@ holders listed:
 
 .. literalinclude:: ../../LICENSE
     :language: none
+
+Portions of this work were created while John Hiles was employed by Wright
+State University under Contract No. FA8650-18-2-1645 to the Air Force Research
+Laboratory, and the University has released its rights to this Student work.


### PR DESCRIPTION
This is required to ensure GitHub correctly identifies the license of the project.