### PR TITLE
Modify EnsembleState to use StateVectors

### DIFF
--- a/stonesoup/predictor/ensemble.py
+++ b/stonesoup/predictor/ensemble.py
@@ -1,8 +1,6 @@
 from .base import Property
 from ..models.transition import TransitionModel
 from .kalman import KalmanPredictor
-from ..types.array import StateVector, StateVectors
-from ..types.state import State
 from ..types.prediction import Prediction
 
 
@@ -43,10 +41,8 @@ class EnsemblePredictor(KalmanPredictor):
         # Compute time_interval
         time_interval = self._predict_over_interval(prior, timestamp)
         # This block of code propagates each column through the transition model.
-        pred_ensemble = StateVectors(
-            [self.transition_model.function(State(state_vector=StateVector(ensemble_member)),
-                                            noise=True, time_interval=time_interval)
-             for ensemble_member in prior.ensemble.T])
+        pred_ensemble = self.transition_model.function(
+            prior, noise=True, time_interval=time_interval)
 
         return Prediction.from_state(prior, pred_ensemble, timestamp=timestamp,
                                      transition_model=self.transition_model)

--- a/stonesoup/predictor/tests/test_ensemble.py
+++ b/stonesoup/predictor/tests/test_ensemble.py
@@ -25,7 +25,7 @@ def test_ensemble():
     gaussian_state = GaussianState(mean, covar, timestamp)
     num_vectors = 50
     prior_state = EnsembleState.from_gaussian_state(gaussian_state, num_vectors)
-    prior_ensemble = prior_state.ensemble
+    prior_ensemble = prior_state.state_vector
 
     # Create Predictor object, run prediction
     predictor = EnsemblePredictor(transition_model)
@@ -39,6 +39,6 @@ def test_ensemble():
 
     # Compare evaluated mean and covariance with predictor results
     assert np.allclose(prediction.mean, eval_mean)
-    assert np.allclose(prediction.ensemble, eval_ensemble)
+    assert np.allclose(prediction.state_vector, eval_ensemble)
     assert np.allclose(prediction.covar, eval_cov)
     assert prediction.timestamp == new_timestamp

--- a/stonesoup/types/state.py
+++ b/stonesoup/types/state.py
@@ -532,9 +532,8 @@ class EnsembleState(Type):
 
     """
 
-    ensemble: StateVectors = Property(doc='''An ensemble of state vectors which represent
-                                the state''')
-
+    state_vector: StateVectors = Property(doc="An ensemble of state vectors which represent the "
+                                              "state")
     timestamp: datetime.datetime = Property(
         default=None, doc="Timestamp of the state. Default None.")
 
@@ -559,7 +558,7 @@ class EnsembleState(Type):
         covar = gaussian_state.covar
         timestamp = gaussian_state.timestamp
 
-        return EnsembleState(ensemble=self.generate_ensemble(mean, covar, num_vectors),
+        return EnsembleState(state_vector=self.generate_ensemble(mean, covar, num_vectors),
                              timestamp=timestamp)
 
     @classmethod
@@ -603,34 +602,29 @@ class EnsembleState(Type):
     @property
     def ndim(self):
         """Number of dimensions in state vectors"""
-        return np.shape(self.ensemble)[0]
+        return np.shape(self.state_vector)[0]
 
     @property
     def num_vectors(self):
         """Number of columns in state ensemble"""
-        return np.shape(self.ensemble)[1]
+        return np.shape(self.state_vector)[1]
 
     @property
     def mean(self):
         """The state mean, numerically equivalent to state vector"""
-        return np.average(self.ensemble, axis=1)
-
-    @property
-    def state_vector(self):
-        """State mean in StateVector wrapper."""
-        return StateVector(self.mean)
+        return np.average(self.state_vector, axis=1)
 
     @property
     def covar(self):
         """Sample covariance matrix for ensemble"""
-        return np.cov(self.ensemble)
+        return np.cov(self.state_vector)
 
     @property
     def sqrt_covar(self):
         """sqrt of sample covariance matrix for ensemble, useful for
         some EnKF algorithms"""
-        return ((self.ensemble - np.tile(self.mean, self.num_vectors)) /
-                np.sqrt(self.num_vectors - 1))
+        return ((self.state_vector-np.tile(self.mean, self.num_vectors))
+                / np.sqrt(self.num_vectors - 1))
 
 
 State.register(EnsembleState)  # noqa: E305

--- a/stonesoup/types/tests/test_state.py
+++ b/stonesoup/types/tests/test_state.py
@@ -256,13 +256,13 @@ def test_ensemblestate():
 
     # Test state without timestamp
     state = EnsembleState(ensemble)
-    assert np.allclose(state.state_vector, StateVector([[1]]))
+    assert np.allclose(state.mean, StateVector([[1]]))
     assert np.allclose(state.covar, CovarianceMatrix([[0.5]]))
 
     # Test state with timestamp
     timestamp = datetime.datetime(2021, 2, 25, 22, 29, 2)
     state = EnsembleState(ensemble, timestamp=timestamp)
-    assert np.allclose(state.state_vector, StateVector([[1]]))
+    assert np.allclose(state.mean, StateVector([[1]]))
     assert np.allclose(state.covar, CovarianceMatrix([[0.5]]))
     assert state.timestamp == timestamp
 
@@ -272,7 +272,7 @@ def test_ensemblestate():
     ensemble = StateVectors([state_vector1, state_vector2])
 
     state = EnsembleState(ensemble)
-    assert np.allclose(state.state_vector, StateVector([[1], [1]]))
+    assert np.allclose(state.mean, StateVector([[1], [1]]))
     assert np.allclose(state.covar, CovarianceMatrix([[0.5, -0.25], [-0.25, 0.125]]))
     assert np.allclose(state.sqrt_covar @ state.sqrt_covar.T, state.covar)
 
@@ -307,8 +307,8 @@ def test_ensemblestate_gaussian_init():
     num_vectors = 50
     ensemble_state = EnsembleState.from_gaussian_state(gaussian_state, num_vectors)
 
-    assert isinstance(ensemble_state.state_vector, StateVector)
-    assert isinstance(ensemble_state.ensemble, StateVectors)
+    assert isinstance(ensemble_state.mean, StateVector)
+    assert isinstance(ensemble_state.state_vector, StateVectors)
     assert isinstance(ensemble_state.covar, CovarianceMatrix)
     assert isinstance(ensemble_state.timestamp, datetime.datetime)
     assert ensemble_state.timestamp == timestamp

--- a/stonesoup/updater/ensemble.py
+++ b/stonesoup/updater/ensemble.py
@@ -4,7 +4,6 @@ import scipy
 from .kalman import KalmanUpdater
 from ..base import Property
 from ..types.state import State
-from ..types.array import StateVector, StateVectors
 from ..types.prediction import MeasurementPrediction
 from ..types.update import Update
 from ..models.measurement import MeasurementModel
@@ -131,10 +130,7 @@ class EnsembleUpdater(KalmanUpdater):
         measurement_model = self._check_measurement_model(measurement_model)
 
         # Propagate each vector through the measurement model.
-        pred_meas_ensemble = StateVectors(
-                [measurement_model.function(State(state_vector=ensemble_member),
-                                            noise=True)
-                 for ensemble_member in predicted_state.ensemble.T])
+        pred_meas_ensemble = measurement_model.function(predicted_state, noise=True)
 
         return MeasurementPrediction.from_state(
                    predicted_state, pred_meas_ensemble)
@@ -166,33 +162,31 @@ class EnsembleUpdater(KalmanUpdater):
         pred_state = hypothesis.prediction
         meas_mean = hypothesis.measurement.state_vector
         meas_covar = self.measurement_model.covar()
-        num_vectors = hypothesis.prediction.num_vectors
-        prior_ensemble = hypothesis.prediction.ensemble
+        num_vectors = pred_state.num_vectors
 
         # Generate an ensemble of measurements based on measurement
-        measurement_ensemble = hypothesis.prediction.generate_ensemble(
+        measurement_ensemble = pred_state.generate_ensemble(
                                    mean=meas_mean,
                                    covar=meas_covar,
                                    num_vectors=num_vectors)
 
         # Calculate Kalman Gain according to Dr. Jan Mandel's EnKF formalism.
-        innovation_ensemble = hypothesis.prediction.ensemble - hypothesis.prediction.mean
+        innovation_ensemble = pred_state.state_vector - pred_state.mean
 
-        meas_innovation = StateVectors(
-            [self.measurement_model.function(State(state_vector=StateVector(col)))
-             - self.measurement_model.function(State(state_vector=hypothesis.prediction.mean))
-             for col in prior_ensemble.T])
+        meas_innovation = (
+            self.measurement_model.function(pred_state)
+            - self.measurement_model.function(State(pred_state.mean)))
 
         # Calculate Kalman Gain
         kalman_gain = 1/(num_vectors-1) * innovation_ensemble @ meas_innovation.T @ \
             scipy.linalg.inv(1/(num_vectors-1) * meas_innovation @ meas_innovation.T + meas_covar)
 
         # Calculate Posterior Ensemble
-        posterior_ensemble = pred_state.ensemble + \
-            kalman_gain @ (measurement_ensemble -
-                           hypothesis.measurement_prediction.ensemble)
+        posterior_ensemble = (
+            pred_state.state_vector
+            + kalman_gain@(measurement_ensemble - hypothesis.measurement_prediction.state_vector))
 
-        return Update.from_state(hypothesis.prediction,
+        return Update.from_state(pred_state,
                                  posterior_ensemble,
                                  timestamp=hypothesis.measurement.timestamp,
                                  hypothesis=hypothesis)


### PR DESCRIPTION
Similar to change in #581, this uses `StateVectors` as the `EnsembleState` state vector. As well as being more consistent, this also enables use of the vectorised models.