### PR TITLE
Add max range to simple Radars

### DIFF
--- a/stonesoup/sensor/radar/radar.py
+++ b/stonesoup/sensor/radar/radar.py
@@ -210,7 +210,7 @@ class RadarElevationBearingRange(RadarBearingRange):
         detections = set()
         for truth in ground_truths:
             # Initially no noise is added to the measurement vector
-            measurement_vector = measurement_model.function(truth, noise=noise, **kwargs)
+            measurement_vector = measurement_model.function(truth, noise=False, **kwargs)
 
             if noise is True:
                 measurement_noise = measurement_model.rvs()

--- a/stonesoup/sensor/radar/radar.py
+++ b/stonesoup/sensor/radar/radar.py
@@ -189,7 +189,9 @@ class RadarElevationBearingRange(RadarBearingRange):
         doc="The sensor noise covariance matrix. This is utilised by "
             "(and follow in format) the underlying "
             ":class:`~.CartesianToElevationBearingRange` model")
-    max_range: float = Property(doc="The maximum detection range of the radar (in meters)")
+    max_range: float = Property(
+        default=np.inf,
+        doc="The maximum detection range of the radar (in meters)")
 
     @property
     def measurement_model(self):

--- a/stonesoup/sensor/radar/radar.py
+++ b/stonesoup/sensor/radar/radar.py
@@ -119,11 +119,14 @@ class RadarRotatingBearingRange(RadarBearingRange):
             "sensor frame/orientation. The angle is positive if the rotation is in the "
             "counter-clockwise direction when viewed by an observer looking down the z-axis of "
             "the sensor frame, towards the origin. Angle units are in radians",
-        generator_cls=DwellActionsGenerator
-    )
-    rpm: float = Property(doc="The number of antenna rotations per minute (RPM)")
-    max_range: float = Property(doc="The maximum detection range of the radar (in meters)")
-    fov_angle: float = Property(doc="The radar field of view (FOV) angle (in radians).")
+        generator_cls=DwellActionsGenerator)
+    rpm: float = Property(
+        doc="The number of antenna rotations per minute (RPM)")
+    max_range: float = Property(
+        default=np.inf,
+        doc="The maximum detection range of the radar (in meters)")
+    fov_angle: float = Property(
+        doc="The radar field of view (FOV) angle (in radians).")
 
     @property
     def measurement_model(self):

--- a/stonesoup/sensor/radar/tests/test_radar.py
+++ b/stonesoup/sensor/radar/tests/test_radar.py
@@ -60,7 +60,7 @@ def h3d(state, pos_map, translation_offset, rotation_offset):
 
 
 @pytest.mark.parametrize(
-    "h, sensorclass, ndim_state, pos_mapping, noise_covar, position, target",
+    "h, sensorclass, ndim_state, pos_mapping, noise_covar, position, target, max_range",
     [
         (
                 h2d,  # h

--- a/stonesoup/sensor/radar/tests/test_radar.py
+++ b/stonesoup/sensor/radar/tests/test_radar.py
@@ -88,7 +88,8 @@ def h3d(state, pos_map, translation_offset, rotation_offset):
     ],
     ids=["RadarBearingRange", "RadarElevationBearingRange"]
 )
-def test_simple_radar(h, sensorclass, ndim_state, pos_mapping, noise_covar, position, target, max_range):
+def test_simple_radar(h, sensorclass, ndim_state, pos_mapping, noise_covar, position, target,
+                      max_range):
     # Instantiate the simple radar
     radar = sensorclass(ndim_state=ndim_state,
                         position_mapping=pos_mapping,

--- a/stonesoup/sensor/radar/tests/test_radar.py
+++ b/stonesoup/sensor/radar/tests/test_radar.py
@@ -70,7 +70,8 @@ def h3d(state, pos_map, translation_offset, rotation_offset):
                 np.array([[0.015, 0],
                           [0, 0.1]]),  # noise_covar
                 StateVector([[1], [1]]),  # position
-                np.array([[200], [10]])  # target
+                np.array([[200], [10]]),  # target
+                1000  # max_range
         ),
         (
                 h3d,  # h
@@ -81,17 +82,19 @@ def h3d(state, pos_map, translation_offset, rotation_offset):
                           [0, 0.015, 0],
                           [0, 0, 0.1]]),  # noise_covar
                 StateVector([[1], [1], [0]]),  # position
-                np.array([[200], [10], [10]])  # target
+                np.array([[200], [10], [10]]),  # target
+                1000  # max_range
         )
     ],
     ids=["RadarBearingRange", "RadarElevationBearingRange"]
 )
-def test_simple_radar(h, sensorclass, ndim_state, pos_mapping, noise_covar, position, target):
-    # Instantiate the rotating radar
+def test_simple_radar(h, sensorclass, ndim_state, pos_mapping, noise_covar, position, target, max_range):
+    # Instantiate the simple radar
     radar = sensorclass(ndim_state=ndim_state,
                         position_mapping=pos_mapping,
                         noise_covar=noise_covar,
-                        position=position)
+                        position=position,
+                        max_range=max_range)
 
     assert (np.equal(radar.position, position).all())
 
@@ -131,6 +134,17 @@ def test_simple_radar(h, sensorclass, ndim_state, pos_mapping, noise_covar, posi
     for measurement in measurements:
         assert measurement.groundtruth_path in truth
         assert isinstance(measurement.groundtruth_path, GroundTruthPath)
+
+    # Assert that no detection is made when target is out of range
+    target3 = np.array([[2_000], [20], [20]])
+    target3_state = GroundTruthState(target3, timestamp=datetime.datetime.now())
+    target3_truth = GroundTruthPath([target3_state])
+
+    # Don't want any noise since we're range testing
+    measurement3 = radar.measure(target3_truth, noise=False)
+
+    # Check no detection have been made when target is out of range
+    assert (len(measurement3) == 0)
 
 
 def h2d_rr(state, pos_map, vel_map, translation_offset, rotation_offset, velocity):


### PR DESCRIPTION
Currently the _RadarBearingRange_ and _RadarElevationBearingRange_ have no attribute to set its max range.

This PR adds a max_range, and adds in logic to only produce detections for states that lie within the sensor's FOV (similar to how _RadarRotatingBearingRange_ does it).