### PR TITLE
Fix bugs when dealing with Gaussian mixtures

### DIFF
--- a/stonesoup/mixturereducer/gaussianmixture.py
+++ b/stonesoup/mixturereducer/gaussianmixture.py
@@ -51,7 +51,7 @@ class GaussianMixtureReducer(MixtureReducer):
         if len(components_list) > 0:
             if self.pruning:
                 components_list = self.prune(components_list)
-            if len(components_list) > 1 & self.merging:
+            if len(components_list) > 1 and self.merging:
                 components_list = self.merge(components_list)
         return components_list
 
@@ -78,7 +78,7 @@ class GaussianMixtureReducer(MixtureReducer):
                 pruned_weight_sum += component.weight
 
         remaining_components = [component for component in components_list
-                                if component.weight > self.prune_threshold]
+                                if component.weight >= self.prune_threshold]
         # Distribute pruned weights across remaining components
         for component in remaining_components:
             component.weight += \

--- a/stonesoup/updater/pointprocess.py
+++ b/stonesoup/updater/pointprocess.py
@@ -111,7 +111,7 @@ class PointProcessUpdater(Base):
                     covar=missed_detected_hypotheses.prediction.covar,
                     timestamp=missed_detected_hypotheses.prediction.timestamp)
                 updated_components.append(component)
-        
+
         # Ensure that no component has a weight of 0. This avoids divide
         # by 0 bugs in the GaussianMixtureReducer
         for component in updated_components:

--- a/stonesoup/updater/pointprocess.py
+++ b/stonesoup/updater/pointprocess.py
@@ -111,6 +111,13 @@ class PointProcessUpdater(Base):
                     covar=missed_detected_hypotheses.prediction.covar,
                     timestamp=missed_detected_hypotheses.prediction.timestamp)
                 updated_components.append(component)
+        
+        # Ensure that no component has a weight of 0. This avoids divide
+        # by 0 bugs in the GaussianMixtureReducer
+        for component in updated_components:
+            if component.weight == 0:
+                component.weight = np.finfo(float).eps
+
         # Return updated components
         return GaussianMixtureUpdate(hypothesis=hypotheses,
                                      components=updated_components)


### PR DESCRIPTION
This pull request fixes a few small bugs that are caused when dealing with Gaussian mixtures. Thanks to @sdhiscocks for your advice on this! I've described the fixes by filename:

**gaussianmixture.py:**
These are simple fixes - changing the and from a bitwise to a logical operator, and making the pruning threshold inclusive.

**pointprocess.py:**
Sometimes, a component will have a weight of 0. If the user has pruning off, the component can stay in the mixture. If this component then gets merged with another one, the merging process can result in a state whose mean and covariance are filled with NaN values. This problem is not immediately obvious, and only causes an error in the next time step in the hypothesiser. To be clear, it is fairly rare that this bug will actually cause a problem, but when it does, it is hard to diagnose because the error is raised in the next time step in a different class. To fix this, any weights that are 0 can be replaced by a weight of `np.finfo(float).eps`, the smallest number recognizable by numpy larger than 0.

Any feedback or suggestions are appreciated, thank you!
