### PR TITLE
Fix ActionGenerator so resolution of actions available is not hard coded

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -122,7 +122,7 @@ version = release = get_distribution('stonesoup').version
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:

--- a/stonesoup/sensor/action/__init__.py
+++ b/stonesoup/sensor/action/__init__.py
@@ -52,6 +52,7 @@ class ActionGenerator(Base):
     attribute: str = Property(doc="The name of the attribute to be modified.")
     start_time: datetime.datetime = Property(doc="Start time of action.")
     end_time: datetime.datetime = Property(doc="End time of action.")
+    resolution: float = Property(default=None, doc="Resolution of action space")
 
     @abstractmethod
     def __contains__(self, item):

--- a/stonesoup/sensor/action/dwell_action.py
+++ b/stonesoup/sensor/action/dwell_action.py
@@ -69,10 +69,10 @@ class DwellActionsGenerator(RealNumberActionGenerator):
 
     owner: object = Property(doc="Object with `timestamp`, `rpm` (revolutions per minute) and "
                                  "dwell-centre attributes")
+    resolution: Angle = Property(default=np.radians(1), doc="Resolution of action space")
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.resolution = Angle(np.radians(1))
         self.epsilon = Angle(np.radians(1e-6))
 
     @property


### PR DESCRIPTION
Changes made so that the resolution of an ActionGenerator can be set manually when setting up an actionable sensor (rather than fixed at 1 degree for dwell_centre for example).