### PR TITLE
Fix typo in MultiTargetGroundTruthSimulator

### DIFF
--- a/stonesoup/simulator/simple.py
+++ b/stonesoup/simulator/simple.py
@@ -144,7 +144,7 @@ class MultiTargetGroundTruthSimulator(SingleTargetGroundTruthSimulator):
 
             number_steps_remaining -= 1
             yield time, groundtruth_paths
-            self.time += self.timestep
+            time += self.timestep
 
         else:
             groundtruth_paths = OrderedSet()


### PR DESCRIPTION
Apologies for missing this in my PR when I added this functionality to the MultiTargetGroundTruthSimulator. Small typo.