### PR TITLE
Add additional functionality into Plotter class.

### DIFF
--- a/stonesoup/plotter.py
+++ b/stonesoup/plotter.py
@@ -1,6 +1,5 @@
 import warnings
 from itertools import chain
-from typing import Optional
 
 import numpy as np
 from matplotlib import pyplot as plt
@@ -10,7 +9,6 @@ from matplotlib.legend_handler import HandlerPatch
 
 from .types import detection
 from .models.base import LinearModel, Model
-from .base import Property
 
 from enum import Enum
 
@@ -56,14 +54,16 @@ class Plotter:
         and labels as str
     """
 
-    def __init__(self, dimension=Dimension.TWO, figsize=(10, 6)):
+    def __init__(self, dimension=Dimension.TWO, **kwargs):
+        figure_kwargs = {"figsize": (10, 6)}
+        figure_kwargs.update(kwargs)
         if isinstance(dimension, type(Dimension.TWO)):
             self.dimension = dimension
         else:
             raise TypeError("""%s is an unsupported type for \'dimension\';
                             expected type %s""" % (type(dimension), type(Dimension.TWO)))
         # Generate plot axes
-        self.fig = plt.figure(figsize=figsize)
+        self.fig = plt.figure(**figure_kwargs)
         if self.dimension is Dimension.TWO:  # 2D axes
             self.ax = self.fig.add_subplot(1, 1, 1)
             self.ax.axis('equal')

--- a/stonesoup/plotter.py
+++ b/stonesoup/plotter.py
@@ -42,8 +42,9 @@ class Plotter:
     ----------
     dimension: enum \'Dimension\'
         Optional parameter to specify 2D or 3D plotting. Default is 2D plotting.
-    figsize: tuple
-        Optional parameter to specify the size of the figure. Default is (10, 6).
+    \\*\\*kwargs: dict
+        Additional arguments to be passed to plot function. For example, figsize (Default is
+        (10, 6)).
 
     Attributes
     ----------

--- a/stonesoup/plotter.py
+++ b/stonesoup/plotter.py
@@ -193,7 +193,7 @@ class Plotter:
 
         if plot_detections:
             detection_array = np.array(plot_detections)
-            # *detection_array.T unpacks detection_array by coloumns
+            # *detection_array.T unpacks detection_array by columns
             # (same as passing in detection_array[:,0], detection_array[:,1], etc...)
             self.ax.scatter(*detection_array.T, **measurement_kwargs)
             measurements_handle = Line2D([], [], linestyle='', **measurement_kwargs)
@@ -218,9 +218,9 @@ class Plotter:
         """Plots track(s)
 
         Plots each track generated, generating a legend automatically. If ``uncertainty=True``
-        and is being plotted in 2D, error elipses are plotted. If being plotted in
+        and is being plotted in 2D, error ellipses are plotted. If being plotted in
         3D, uncertainty bars are plotted every :attr:`err_freq` measurement, default
-        plots unceratinty bars at every track step. Tracks are plotted as solid
+        plots uncertainty bars at every track step. Tracks are plotted as solid
         lines with point markers and default colors. Uncertainty bars are plotted
         with a default color which is the same for all tracks.
 

--- a/stonesoup/plotter.py
+++ b/stonesoup/plotter.py
@@ -43,7 +43,7 @@ class Plotter:
     dimension: enum \'Dimension\'
         Optional parameter to specify 2D or 3D plotting. Default is 2D plotting.
     figsize: tuple
-        Optional parameter to specify the size of the figure.
+        Optional parameter to specify the size of the figure. Default is (10, 6).
 
     Attributes
     ----------

--- a/stonesoup/plotter.py
+++ b/stonesoup/plotter.py
@@ -1,5 +1,6 @@
 import warnings
 from itertools import chain
+from typing import Optional
 
 import numpy as np
 from matplotlib import pyplot as plt
@@ -9,6 +10,7 @@ from matplotlib.legend_handler import HandlerPatch
 
 from .types import detection
 from .models.base import LinearModel, Model
+from .base import Property
 
 from enum import Enum
 
@@ -40,6 +42,8 @@ class Plotter:
     ----------
     dimension: enum \'Dimension\'
         Optional parameter to specify 2D or 3D plotting. Default is 2D plotting.
+    figsize: tuple
+        Optional parameter to specify the size of the figure.
 
     Attributes
     ----------
@@ -52,14 +56,14 @@ class Plotter:
         and labels as str
     """
 
-    def __init__(self, dimension=Dimension.TWO):
+    def __init__(self, dimension=Dimension.TWO, figsize=(10, 6)):
         if isinstance(dimension, type(Dimension.TWO)):
             self.dimension = dimension
         else:
             raise TypeError("""%s is an unsupported type for \'dimension\';
                             expected type %s""" % (type(dimension), type(Dimension.TWO)))
         # Generate plot axes
-        self.fig = plt.figure(figsize=(10, 6))
+        self.fig = plt.figure(figsize=figsize)
         if self.dimension is Dimension.TWO:  # 2D axes
             self.ax = self.fig.add_subplot(1, 1, 1)
             self.ax.axis('equal')

--- a/stonesoup/tests/test_plotter.py
+++ b/stonesoup/tests/test_plotter.py
@@ -106,3 +106,12 @@ def test_particle_3d():  # warning should arise if particle is attempted in 3d m
     plotter3 = Plotter(dimension=Dimension.THREE)
     with pytest.raises(NotImplementedError):
         plotter3.plot_tracks(track, [0, 1, 2], particle=True, uncertainty=False)
+
+
+def test_figsize():
+    plotter_figsize_default = Plotter()
+    plotter_figsize_different = Plotter(figsize=(20, 15))
+    assert plotter_figsize_default.fig.get_figwidth() == 10
+    assert plotter_figsize_default.fig.get_figheight() == 6
+    assert plotter_figsize_different.fig.get_figwidth() == 20
+    assert plotter_figsize_different.fig.get_figheight() == 15

--- a/stonesoup/tests/test_plotter.py
+++ b/stonesoup/tests/test_plotter.py
@@ -22,7 +22,7 @@ from stonesoup.hypothesiser.distance import DistanceHypothesiser
 from stonesoup.measures import Mahalanobis
 
 from stonesoup.dataassociator.neighbour import NearestNeighbour
-from stonesoup.types.state import GaussianState
+from stonesoup.types.state import GaussianState, State
 
 from stonesoup.types.track import Track
 
@@ -115,3 +115,30 @@ def test_figsize():
     assert plotter_figsize_default.fig.get_figheight() == 6
     assert plotter_figsize_different.fig.get_figwidth() == 20
     assert plotter_figsize_different.fig.get_figheight() == 15
+
+
+def test_equal_3daxis():
+    plotter_default = Plotter(dimension=Dimension.THREE)
+    plotter_xy_default = Plotter(dimension=Dimension.THREE)
+    plotter_xy = Plotter(dimension=Dimension.THREE)
+    plotter_xyz = Plotter(dimension=Dimension.THREE)
+    truths = GroundTruthPath(states=[State(state_vector=[-1000, -20, -3]),
+                                     State(state_vector=[1000, 20, 3])])
+    plotter_default.plot_ground_truths(truths, mapping=[0, 1, 2])
+    plotter_xy_default.plot_ground_truths(truths, mapping=[0, 1, 2])
+    plotter_xy.plot_ground_truths(truths, mapping=[0, 1, 2])
+    plotter_xyz.plot_ground_truths(truths, mapping=[0, 1, 2])
+    plotter_xy_default.set_equal_3daxis()
+    plotter_xy.set_equal_3daxis([0, 1])
+    plotter_xyz.set_equal_3daxis([0, 1, 2])
+    plotters = [plotter_default, plotter_xy_default, plotter_xy, plotter_xyz]
+    lengths = [3, 2, 2, 1]
+    for plotter, l in zip(plotters, lengths):
+        min_xyz = [0, 0, 0]
+        max_xyz = [0, 0, 0]
+        for i in range(3):
+            for line in plotter.ax.lines:
+                min_xyz[n] = np.min([min_xyz[i], *line.get_data_3d()[i]])
+                max_xyz[n] = np.max([max_xyz[i], *line.get_data_3d()[i]])
+        assert len(set(min_xyz)) == l
+        assert len(set(max_xyz)) == l

--- a/stonesoup/tests/test_plotter.py
+++ b/stonesoup/tests/test_plotter.py
@@ -142,3 +142,11 @@ def test_equal_3daxis():
                 max_xyz[n] = np.max([max_xyz[i], *line.get_data_3d()[i]])
         assert len(set(min_xyz)) == l
         assert len(set(max_xyz)) == l
+
+
+def test_equal_3daxis_2d():
+    plotter = Plotter(dimension=Dimension.TWO)
+    truths = GroundTruthPath(states=[State(state_vector=[-1000, -20, -3]),
+                                     State(state_vector=[1000, 20, 3])])
+    plotter.plot_ground_truths(truths, mapping=[0, 1])
+    plotter.set_equal_3daxis()

--- a/stonesoup/tests/test_plotter.py
+++ b/stonesoup/tests/test_plotter.py
@@ -138,8 +138,8 @@ def test_equal_3daxis():
         max_xyz = [0, 0, 0]
         for i in range(3):
             for line in plotter.ax.lines:
-                min_xyz[n] = np.min([min_xyz[i], *line.get_data_3d()[i]])
-                max_xyz[n] = np.max([max_xyz[i], *line.get_data_3d()[i]])
+                min_xyz[i] = np.min([min_xyz[i], *line.get_data_3d()[i]])
+                max_xyz[i] = np.max([max_xyz[i], *line.get_data_3d()[i]])
         assert len(set(min_xyz)) == l
         assert len(set(max_xyz)) == l
 


### PR DESCRIPTION
This PR adds the ability to pass custom arguments to figure initialisation as highlighted in #655. For example, `figsize` can be passed to Plotter in initialisation to change the figure size. 
Additionally, the method to set equal axes in 3d plots. This uses the data in the figure to set the axes.