### PR TITLE
One to one Assignment for Association

### DIFF
--- a/stonesoup/dataassociator/_assignment.py
+++ b/stonesoup/dataassociator/_assignment.py
@@ -317,3 +317,35 @@ def assign2DBasic(C):
 # SOFTWARE AND ANY RELATED MATERIALS, AND AGREES TO INDEMNIFY THE NAVAL
 # RESEARCH LABORATORY FOR ALL THIRD-PARTY CLAIMS RESULTING FROM THE ACTIONS
 # OF RECIPIENT IN THE USE OF THE SOFTWARE.
+
+
+def multidimensional_deconfliction(association_set):
+    """Solves the Multidimensional Assignment Problem (MAP)
+
+    The assignment problem becomes more complex when time is added as a dimension.
+    This basic solution finds all the conflicts in an association set and then creates a
+    matrix of sums of conflicts in seconds, which is then passed to assign2D to solve as a
+    simple 2D assignment problem.  Therefore, each object will only ever be assigned to one other,
+    throughout the relevant time range.
+
+    Parameters
+    ----------
+    association_set: The :class:`AssociationSet` to de-conflict
+
+    Returns
+    -------
+    : :class:`AssociationSet`
+        The association set without contradictory associations
+    """
+    objects = list(association_set.object_set)
+    length = len(objects)
+    conflict_totals = numpy.zeros((length,length))
+    association_on = numpy.full((length, length), False)
+    key_times = association_set.key_times
+    for obj in objects:
+        obj_ass_set = association_set.associations_including_objects(obj)
+        for time in key_times:
+            time_ass_set = association_set.associations_at_timestamp
+
+
+

--- a/stonesoup/dataassociator/_assignment.py
+++ b/stonesoup/dataassociator/_assignment.py
@@ -399,7 +399,7 @@ def multidimensional_deconfliction(association_set):
 def conflicts(assoc1, assoc2):
     if hasattr(assoc1, 'time_range') and hasattr(assoc2, 'time_range') and \
             len(assoc1.objects.intersection(assoc2.objects)) > 0 and \
-            len(assoc1.time_range & assoc2.time_range)) > 0:
+            len(assoc1.time_range & assoc2.time_range) > 0:
         return True
     else:
         return False

--- a/stonesoup/dataassociator/_assignment.py
+++ b/stonesoup/dataassociator/_assignment.py
@@ -399,7 +399,7 @@ def multidimensional_deconfliction(association_set):
 def conflicts(assoc1, assoc2):
     if hasattr(assoc1, 'time_range') and hasattr(assoc2, 'time_range') and \
             len(assoc1.objects.intersection(assoc2.objects)) > 0 and \
-            len(assoc1.time_range.intersection(assoc2.time_range)) > 0:
+            len(assoc1.time_range & assoc2.time_range)) > 0:
         return True
     else:
         return False

--- a/stonesoup/dataassociator/_assignment.py
+++ b/stonesoup/dataassociator/_assignment.py
@@ -1,7 +1,5 @@
 import numpy
-import datetime
 from ..types.association import AssociationSet
-import warnings
 
 
 def assign2D(C, maximize=False):
@@ -348,7 +346,6 @@ def multidimensional_deconfliction(association_set):
         The association set without contradictory associations
     """
     # Check if there are any conflicts
-    nonecheck(2,association_set)
     no_conflicts = True
     for assoc1 in association_set:
         for assoc2 in association_set:
@@ -356,7 +353,6 @@ def multidimensional_deconfliction(association_set):
                 no_conflicts = False
     if no_conflicts:
         return association_set
-    nonecheck(1,association_set)
     objects = list(association_set.object_set)
     length = len(objects)
     totals = numpy.zeros((length, length))  # Time objects i and j are associated for in total
@@ -368,7 +364,6 @@ def multidimensional_deconfliction(association_set):
                        objects.index(list(association.objects)[1])]
         totals[obj_indices[0], obj_indices[1]] = association.time_range.duration.total_seconds()
         make_symmetric(totals)
-    nonecheck(2, association_set)
 
     totals = numpy.rint(totals).astype(int)
     numpy.fill_diagonal(totals, 0)  # Don't want to count associations of an object with itself
@@ -379,7 +374,6 @@ def multidimensional_deconfliction(association_set):
         if i != solved_2d[i]:
             winning_indices.append([i, solved_2d[i]])
     cleaned_set = AssociationSet()
-    nonecheck(3, association_set)
     if len(winning_indices) == 0:
         raise ValueError("Problem unsolvable using this method")
     for winner in winning_indices:
@@ -387,7 +381,6 @@ def multidimensional_deconfliction(association_set):
                                                                 objects[winner[1]]})
         cleaned_set.add(assoc)
         association_set.remove(assoc)
-    nonecheck(4, association_set)
 
     # Recursive step
     runners_up = set()
@@ -395,7 +388,6 @@ def multidimensional_deconfliction(association_set):
         for assoc2 in association_set.associations:
             if conflicts(assoc1, assoc2):
                 runners_up = multidimensional_deconfliction(association_set).associations
-    nonecheck(5, association_set)
 
     # At this point, none of association_set should conflict with one another
     for runner_up in runners_up:
@@ -406,7 +398,6 @@ def multidimensional_deconfliction(association_set):
             cleaned_set.add(runner_up)
         else:
             runners_up.remove(runner_up)
-    nonecheck(6, association_set)
 
     return cleaned_set
 
@@ -432,8 +423,3 @@ def make_symmetric(matrix):
                 matrix[j, i] = matrix[i, j]
             else:
                 matrix[i, j] = matrix[j, i]
-
-def nonecheck(flag, association_set):
-    for assoc in association_set.associations:
-        if assoc.time_range is None:
-            print(f"NONETYPE AT {flag}")

--- a/stonesoup/dataassociator/_assignment.py
+++ b/stonesoup/dataassociator/_assignment.py
@@ -346,7 +346,6 @@ def multidimensional_deconfliction(association_set):
     : :class:`AssociationSet`
         The association set without contradictory associations
     """
-    # Check if there are any conflicts.  If none we can simply return the input
     if check_if_no_conflicts(association_set):
         return copy.copy(association_set)
 

--- a/stonesoup/dataassociator/_assignment.py
+++ b/stonesoup/dataassociator/_assignment.py
@@ -399,7 +399,7 @@ def multidimensional_deconfliction(association_set):
 def conflicts(assoc1, assoc2):
     if hasattr(assoc1, 'time_range') and hasattr(assoc2, 'time_range') and \
             len(assoc1.objects.intersection(assoc2.objects)) > 0 and \
-            len(assoc1.time_range & assoc2.time_range) > 0:
+            (assoc1.time_range & assoc2.time_range).duration.total_seconds() > 0:
         return True
     else:
         return False

--- a/stonesoup/dataassociator/_assignment.py
+++ b/stonesoup/dataassociator/_assignment.py
@@ -377,7 +377,7 @@ def multidimensional_deconfliction(association_set):
     if len(cleaned_set) == 0:
         raise ValueError("Problem unsolvable using this method")
 
-    if check_if_no_conflicts(cleaned_set) and len(association_set) == 0:
+    if check_if_no_conflicts(cleaned_set) and len(association_set_reduced) == 0:
         # If no conflicts after this iteration and all objects return
         return cleaned_set
     else:
@@ -397,29 +397,22 @@ def multidimensional_deconfliction(association_set):
 
 
 def conflicts(assoc1, assoc2):
-    if getattr(assoc1, 'time_range', None) is None or getattr(assoc2, 'time_range', None) is None:
-        return False
-    if assoc1.time_range & assoc2.time_range and assoc1 != assoc2 \
-            and len(assoc1.objects.intersection(assoc2.objects)) > 0:
+    if hasattr(assoc1, 'time_range') and hasattr(assoc2, 'time_range') and \
+            len(assoc1.objects.intersection(assoc2.objects)) > 0 and \
+            len(assoc1.time_range.intersection(assoc2.time_range)) > 0:
         return True
     else:
         return False
 
 
 def check_if_no_conflicts(association_set):
-    for assoc1 in association_set:
-        for assoc2 in association_set:
-            if conflicts(assoc1, assoc2):
+    for assoc1 in range(0, len(association_set)):
+        for assoc2 in range(assoc1, len(association_set)):
+            if conflicts(list(association_set)[assoc1], list(association_set)[assoc2]):
                 return False
     return True
 
 
 def make_symmetric(matrix):
     """Matrix must be square"""
-    length = matrix.shape[0]
-    for i in range(length):
-        for j in range(length):
-            if matrix[i, j] >= matrix[j, i]:
-                matrix[j, i] = matrix[i, j]
-            else:
-                matrix[i, j] = matrix[j, i]
+    return numpy.maximum(matrix, matrix.transpose())

--- a/stonesoup/dataassociator/_assignment.py
+++ b/stonesoup/dataassociator/_assignment.py
@@ -348,7 +348,7 @@ def multidimensional_deconfliction(association_set):
     """
     # Check if there are any conflicts.  If none we can simply return the input
     if check_if_no_conflicts(association_set):
-        return association_set
+        return copy.copy(association_set)
 
     objects = list(association_set.object_set)
     length = len(objects)
@@ -371,8 +371,8 @@ def multidimensional_deconfliction(association_set):
         if i == j:
             # Can't associate with self
             continue
-        assoc = association_set.associations_including_objects({objects[i], objects[j]})
-        cleaned_set.add(assoc)
+        assoc = association_set_reduced.associations_including_objects({objects[i], objects[j]})
+        cleaned_set.add(copy.copy(assoc))
         association_set_reduced.remove(assoc)
     if len(cleaned_set) == 0:
         raise ValueError("Problem unsolvable using this method")
@@ -388,9 +388,9 @@ def multidimensional_deconfliction(association_set):
         runner_up_remaining_time = runner_up.time_range
         for winner in cleaned_set:
             if conflicts(runner_up, winner):
-                runner_up_remaining_time = runner_up_remaining_time - winner.time_range
+                runner_up_remaining_time -= winner.time_range
         if runner_up_remaining_time and runner_up_remaining_time.duration.total_seconds() > 0:
-            runner_up_copy = runner_up
+            runner_up_copy = copy.copy(runner_up)
             runner_up_copy.time_range = runner_up_remaining_time
             cleaned_set.add(runner_up_copy)
     return cleaned_set
@@ -399,7 +399,8 @@ def multidimensional_deconfliction(association_set):
 def conflicts(assoc1, assoc2):
     if hasattr(assoc1, 'time_range') and hasattr(assoc2, 'time_range') and \
             len(assoc1.objects.intersection(assoc2.objects)) > 0 and \
-            (assoc1.time_range & assoc2.time_range).duration.total_seconds() > 0:
+            (assoc1.time_range & assoc2.time_range).duration.total_seconds() > 0 and \
+            assoc1 != assoc2:
         return True
     else:
         return False

--- a/stonesoup/dataassociator/tests/test_assignment.py
+++ b/stonesoup/dataassociator/tests/test_assignment.py
@@ -1,7 +1,7 @@
 from ...types.association import AssociationSet, TimeRangeAssociation
 from ...types.time import TimeRange, CompoundTimeRange
 from ...types.track import Track
-from .._assignment import multidimensional_deconfliction, check_if_no_conflicts
+from .._assignment import multidimensional_deconfliction
 import datetime
 import pytest
 

--- a/stonesoup/dataassociator/tests/test_assignment.py
+++ b/stonesoup/dataassociator/tests/test_assignment.py
@@ -29,7 +29,7 @@ def test_multi_deconfliction():
     assoc4 = TimeRangeAssociation({tracks[0], tracks[1]},
                                   time_range=CompoundTimeRange([ranges[1], ranges[4]]))
     a4_clone = TimeRangeAssociation({tracks[0], tracks[1]},
-                                  time_range=CompoundTimeRange([ranges[1], ranges[4]]))
+                                    time_range=CompoundTimeRange([ranges[1], ranges[4]]))
     # Will fail as there is only one track, rather than two
     assoc_fail = TimeRangeAssociation({tracks[0]}, time_range=ranges[0])
     with pytest.raises(ValueError):

--- a/stonesoup/dataassociator/tests/test_assignment.py
+++ b/stonesoup/dataassociator/tests/test_assignment.py
@@ -1,0 +1,33 @@
+from ...types.association import AssociationSet, TimeRangeAssociation
+from ...types.time import TimeRange, CompoundTimeRange
+from ...types.track import Track
+from .._assignment import multidimensional_deconfliction
+import datetime
+import pytest
+
+
+def test_multi_deconfliction():
+    test = AssociationSet()
+    tested = multidimensional_deconfliction(test)
+    assert test == tested
+    tracks = [Track(), Track(), Track(), Track()]
+    times = [datetime.datetime(year=2022, month=6, day=1, hour=0),
+             datetime.datetime(year=2022, month=6, day=1, hour=1),
+             datetime.datetime(year=2022, month=6, day=1, hour=5),
+             datetime.datetime(year=2022, month=6, day=2, hour=5),
+             datetime.datetime(year=2022, month=6, day=1, hour=9)]
+    ranges = [TimeRange(times[0], times[1]),
+              TimeRange(times[1], times[2]),
+              TimeRange(times[2], times[3]),
+              TimeRange(times[0], times[4]),
+              TimeRange(times[2], times[4])]
+
+    assoc1 = TimeRangeAssociation({tracks[0], tracks[1]}, time_range=ranges[0])
+    assoc2 = TimeRangeAssociation({tracks[2], tracks[3]}, time_range=ranges[0])
+    assoc_fail = TimeRangeAssociation({tracks[0]}, time_range=ranges[0])
+    with pytest.raises(ValueError):
+        multidimensional_deconfliction(AssociationSet({assoc_fail, assoc1, assoc2}))
+
+    # Objects do not conflict, so should do nothing
+    test2 = AssociationSet({assoc1, assoc2})
+    assert multidimensional_deconfliction(test2).associations == test2.associations

--- a/stonesoup/dataassociator/tests/test_assignment.py
+++ b/stonesoup/dataassociator/tests/test_assignment.py
@@ -28,7 +28,7 @@ def test_multi_deconfliction():
                                   time_range=CompoundTimeRange([ranges[0], ranges[4]]))
     assoc4 = TimeRangeAssociation({tracks[0], tracks[1]},
                                   time_range=CompoundTimeRange([ranges[1], ranges[4]]))
-    assoc4_again = TimeRangeAssociation({tracks[0], tracks[1]},
+    a4_clone = TimeRangeAssociation({tracks[0], tracks[1]},
                                   time_range=CompoundTimeRange([ranges[1], ranges[4]]))
     # Will fail as there is only one track, rather than two
     assoc_fail = TimeRangeAssociation({tracks[0]}, time_range=ranges[0])
@@ -58,8 +58,8 @@ def test_multi_deconfliction():
     merged = next(iter(merged.associations))
     assert merged.time_range == CompoundTimeRange([ranges[0], ranges[1], ranges[4]])
 
-    test5 = AssociationSet({assoc1, assoc2, assoc3, assoc4, assoc4_again})
-    # Very similar to above, but we add a duplicate assoc4, which should have no effect on the result.
+    test5 = AssociationSet({assoc1, assoc2, assoc3, assoc4, a4_clone})
+    # Very similar to above, but we add a duplicate assoc4 - should have no effect on the result.
     tested5 = multidimensional_deconfliction(test5)
     assert len(tested5) == 2
     assert assoc2 in tested5

--- a/stonesoup/dataassociator/tests/test_tracktotrack.py
+++ b/stonesoup/dataassociator/tests/test_tracktotrack.py
@@ -94,6 +94,16 @@ def test_euclidiantracktotrack(tracks):
 
     association_set_4 = complete_associator.associate_tracks({tracks[0]}, {tracks[5]})
 
+    complete_associator_one2one = TrackToTrackCounting(
+        association_threshold=10,
+        consec_pairs_confirm=3,
+        consec_misses_end=2,
+        use_positional_only=False)
+    start_time = datetime.datetime(2019, 1, 1, 14, 0, 0)
+
+    association_set_one2one = complete_associator_one2one.associate_tracks(
+        {tracks[0], tracks[2]}, {tracks[1], tracks[3], tracks[4]})
+
     assert len(association_set_1.associations) == 1
     assoc1 = list(association_set_1.associations)[0]
     assert set(assoc1.objects) == {tracks[0], tracks[1]}
@@ -120,6 +130,15 @@ def test_euclidiantracktotrack(tracks):
         == start_time + datetime.timedelta(seconds=1)
     assert assoc4.time_range.end_timestamp \
         == start_time + datetime.timedelta(seconds=7)
+
+    assert len(association_set_one2one) == 1
+    assoc5 = list(association_set_one2one)[0]
+    # assoc5 should be equal to assoc1
+    assert set(assoc5.objects) == {tracks[0], tracks[1]}
+    assert assoc5.time_range.start_timestamp \
+        == start_time + datetime.timedelta(seconds=1)
+    assert assoc5.time_range.end_timestamp \
+        == start_time + datetime.timedelta(seconds=6)
 
 
 def test_euclidiantracktotruth(tracks):

--- a/stonesoup/dataassociator/tracktotrack.py
+++ b/stonesoup/dataassociator/tracktotrack.py
@@ -8,6 +8,7 @@ from ..types.association import AssociationSet, TimeRangeAssociation, Associatio
 from ..types.groundtruth import GroundTruthPath
 from ..types.track import Track
 from ..types.time import TimeRange
+from ._assignment import multidimensional_deconfliction
 
 
 class TrackToTrackCounting(TrackToTrackAssociator):
@@ -186,7 +187,7 @@ class TrackToTrackCounting(TrackToTrackAssociator):
                         TimeRange(start_timestamp, end_timestamp)))
 
         if self.one_to_one:
-            return AssociationSet(associations).association_deconflicter()
+            return multidimensional_deconfliction(AssociationSet(associations))
         else:
             return AssociationSet(associations)
 

--- a/stonesoup/dataassociator/tracktotrack.py
+++ b/stonesoup/dataassociator/tracktotrack.py
@@ -77,6 +77,11 @@ class TrackToTrackCounting(TrackToTrackAssociator):
             "position components compared to others (such as velocity).  "
             "Default is 0.6"
     )
+    one_to_one: bool = Property(
+        default=False,
+        doc="If True, the Hungarian Algorithm is applied to the results so that no track is "
+            "associated with more than one other at any given time step"
+    )
 
     def associate_tracks(self, tracks_set_1: Set[Track], tracks_set_2: Set[Track]):
         """Associate two sets of tracks together.
@@ -180,7 +185,10 @@ class TrackToTrackCounting(TrackToTrackAssociator):
                         (track1, track2),
                         TimeRange(start_timestamp, end_timestamp)))
 
-        return AssociationSet(associations)
+        if self.one_to_one:
+            return AssociationSet(associations).association_deconflicter()
+        else:
+            return AssociationSet(associations)
 
 
 class TrackToTruth(TrackToTrackAssociator):

--- a/stonesoup/dataassociator/tracktotrack.py
+++ b/stonesoup/dataassociator/tracktotrack.py
@@ -79,8 +79,8 @@ class TrackToTrackCounting(TrackToTrackAssociator):
     )
     one_to_one: bool = Property(
         default=False,
-        doc="If True, the Hungarian Algorithm is applied to the results so that no track is "
-            "associated with more than one other at any given time step"
+        doc="If True, it is ensured no two associations ever contain the same track "
+            "at the same time"
     )
 
     def associate_tracks(self, tracks_set_1: Set[Track], tracks_set_2: Set[Track]):

--- a/stonesoup/metricgenerator/basicmetrics.py
+++ b/stonesoup/metricgenerator/basicmetrics.py
@@ -34,24 +34,24 @@ class BasicMetrics(MetricGenerator):
             title='Number of targets',
             value=len(manager.groundtruth_paths),
             time_range=TimeRange(
-                start_timestamp=min(timestamps),
-                end_timestamp=max(timestamps)),
+                start=min(timestamps),
+                end=max(timestamps)),
             generator=self))
 
         metrics.append(TimeRangeMetric(
             title='Number of tracks',
             value=len(manager.tracks),
             time_range=TimeRange(
-                start_timestamp=min(timestamps),
-                end_timestamp=max(timestamps)),
+                start=min(timestamps),
+                end=max(timestamps)),
             generator=self))
 
         metrics.append(TimeRangeMetric(
             title='Track-to-target ratio',
             value=len(manager.tracks) / len(manager.groundtruth_paths),
             time_range=TimeRange(
-                start_timestamp=min(timestamps),
-                end_timestamp=max(timestamps)),
+                start=min(timestamps),
+                end=max(timestamps)),
             generator=self))
 
         return metrics

--- a/stonesoup/metricgenerator/tests/test_basicmetrics.py
+++ b/stonesoup/metricgenerator/tests/test_basicmetrics.py
@@ -33,22 +33,22 @@ def test_basicmetrics():
     correct_metrics = {TimeRangeMetric(title='Number of targets',
                                        value=3,
                                        time_range=TimeRange(
-                                           start_timestamp=start_time,
-                                           end_timestamp=start_time +
+                                           start=start_time,
+                                           end=start_time +
                                            datetime.timedelta(seconds=4)),
                                        generator=generator),
                        TimeRangeMetric(title='Number of tracks',
                                        value=4,
                                        time_range=TimeRange(
-                                           start_timestamp=start_time,
-                                           end_timestamp=start_time +
+                                           start=start_time,
+                                           end=start_time +
                                            datetime.timedelta(seconds=4)),
                                        generator=generator),
                        TimeRangeMetric(title='Track-to-target ratio',
                                        value=4 / 3,
                                        time_range=TimeRange(
-                                           start_timestamp=start_time,
-                                           end_timestamp=start_time +
+                                           start=start_time,
+                                           end=start_time +
                                            datetime.timedelta(seconds=4)),
                                        generator=generator)}
     for metric_name in ["Number of targets",

--- a/stonesoup/metricgenerator/tests/test_tracktotruthmetrics.py
+++ b/stonesoup/metricgenerator/tests/test_tracktotruthmetrics.py
@@ -50,6 +50,7 @@ def test_siap(trial_manager, trial_truths, trial_tracks, trial_associations, mea
 
     # Test total_time_tracked
     assert siap_generator.total_time_tracked(trial_manager, trial_truths[0]) == 3  # seconds
+    print(trial_truths[1])
     assert siap_generator.total_time_tracked(trial_manager, trial_truths[1]) == 2
     assert siap_generator.total_time_tracked(trial_manager, trial_truths[2]) == 1
     assert siap_generator.total_time_tracked(trial_manager, GroundTruthPath()) == 0

--- a/stonesoup/metricgenerator/tests/test_tracktotruthmetrics.py
+++ b/stonesoup/metricgenerator/tests/test_tracktotruthmetrics.py
@@ -70,7 +70,9 @@ def test_siap(trial_manager, trial_truths, trial_tracks, trial_associations, mea
 
     # Test longest_track_time_on_truth
     assert siap_generator.longest_track_time_on_truth(trial_manager, trial_truths[0]) == 2
-    assert siap_generator.longest_track_time_on_truth(trial_manager, trial_truths[1]) == 1
+    # Associations 1 and 2 (starting from 0) will join together
+    # because of the AssociationSet._simplify method, so this will be 2
+    assert siap_generator.longest_track_time_on_truth(trial_manager, trial_truths[1]) == 2
     assert siap_generator.longest_track_time_on_truth(trial_manager, trial_truths[2]) == 1
 
     # Test compute_metric

--- a/stonesoup/metricgenerator/tests/test_tracktotruthmetrics.py
+++ b/stonesoup/metricgenerator/tests/test_tracktotruthmetrics.py
@@ -50,7 +50,6 @@ def test_siap(trial_manager, trial_truths, trial_tracks, trial_associations, mea
 
     # Test total_time_tracked
     assert siap_generator.total_time_tracked(trial_manager, trial_truths[0]) == 3  # seconds
-    print(trial_truths[1])
     assert siap_generator.total_time_tracked(trial_manager, trial_truths[1]) == 2
     assert siap_generator.total_time_tracked(trial_manager, trial_truths[2]) == 1
     assert siap_generator.total_time_tracked(trial_manager, GroundTruthPath()) == 0

--- a/stonesoup/metricgenerator/tests/test_tracktotruthmetrics.py
+++ b/stonesoup/metricgenerator/tests/test_tracktotruthmetrics.py
@@ -90,8 +90,8 @@ def test_siap(trial_manager, trial_truths, trial_tracks, trial_associations, mea
 
     for metric in metrics:
         assert isinstance(metric, TimeRangeMetric)
-        assert metric.time_range.start_timestamp == timestamps[0]
-        assert metric.time_range.end_timestamp == timestamps[3]
+        assert metric.time_range.start == timestamps[0]
+        assert metric.time_range.end == timestamps[3]
         assert metric.generator == siap_generator
 
         if metric.title.endswith(" at times"):
@@ -175,8 +175,8 @@ def test_id_siap(trial_manager, trial_truths, trial_tracks, trial_associations, 
 
     for metric in metrics:
         assert isinstance(metric, TimeRangeMetric)
-        assert metric.time_range.start_timestamp == timestamps[0]
-        assert metric.time_range.end_timestamp == timestamps[3]
+        assert metric.time_range.start == timestamps[0]
+        assert metric.time_range.end == timestamps[3]
         assert metric.generator == siap_generator
 
         if metric.title.endswith(" at times"):

--- a/stonesoup/metricgenerator/tracktotruthmetrics.py
+++ b/stonesoup/metricgenerator/tracktotruthmetrics.py
@@ -278,7 +278,7 @@ class SIAPMetrics(MetricGenerator):
             Number of associated tracks held by `manager` at `timestamp`.
         """
         associations = manager.association_set.associations_at_timestamp(timestamp)
-        association_objects = {thing for assoc in associations for thing in assoc.objects}
+        association_objects = associations.object_set
 
         return sum(1 for track in manager.tracks if track in association_objects)
 
@@ -355,7 +355,6 @@ class SIAPMetrics(MetricGenerator):
             return 0
 
         truth_timestamps = sorted(state.timestamp for state in truth.states)
-
         total_time = 0
         for current_time, next_time in zip(truth_timestamps[:-1], truth_timestamps[1:]):
             for assoc in assocs:
@@ -385,7 +384,7 @@ class SIAPMetrics(MetricGenerator):
             Minimum number of tracks needed to track `truth`
         """
         assocs = sorted(manager.association_set.associations_including_objects([truth]),
-                        key=attrgetter('time_range.end_timestamp'),
+                        key=attrgetter('time_range.key_times[-1]'),
                         reverse=True)
 
         if len(assocs) == 0:

--- a/stonesoup/metricgenerator/tracktotruthmetrics.py
+++ b/stonesoup/metricgenerator/tracktotruthmetrics.py
@@ -403,11 +403,7 @@ class SIAPMetrics(MetricGenerator):
             else:
                 key_times = assoc_at_time.time_range.key_times
                 # If the current time is a start of a TimeRange we need strict inequality
-                try:
-                    is_start_time = key_times.index(current_time) % 2 == 0
-                except ValueError:
-                    is_start_time = False
-                if is_start_time:
+                if current_time in key_times and key_times.index(current_time) % 2 == 0:
                     end_time = min([time for time in key_times if time > current_time])
                 else:
                     end_time = min([time for time in key_times if time >= current_time])

--- a/stonesoup/metricgenerator/tracktotruthmetrics.py
+++ b/stonesoup/metricgenerator/tracktotruthmetrics.py
@@ -384,7 +384,7 @@ class SIAPMetrics(MetricGenerator):
             Minimum number of tracks needed to track `truth`
         """
         assocs = sorted(manager.association_set.associations_including_objects([truth]),
-                        key=attrgetter('time_range.key_times[-1]'),
+                        key=attrgetter('time_range.key_times')[-1],
                         reverse=True)
 
         if len(assocs) == 0:

--- a/stonesoup/metricgenerator/tracktotruthmetrics.py
+++ b/stonesoup/metricgenerator/tracktotruthmetrics.py
@@ -358,9 +358,9 @@ class SIAPMetrics(MetricGenerator):
             time_range = TimeRange(current_time, next_time)
             for assoc in assocs:
                 # If there is some overlap between time ranges, add this to total_time
-                if time_range.overlap(assoc.time_range):
-                    total_time += time_range.overlap(assoc.time_range).duration.total_seconds()
-                    time_range = time_range.minus(time_range.overlap(assoc.time_range))
+                if time_range & assoc.time_range:
+                    total_time += (time_range & assoc.time_range).duration.total_seconds()
+                    time_range = time_range - (time_range & assoc.time_range)
                     if not time_range:
                         break
         return total_time

--- a/stonesoup/types/association.py
+++ b/stonesoup/types/association.py
@@ -88,13 +88,12 @@ class AssociationSet(Type):
 
     def _simplify(self):
         """Where multiple associations describe the same pair of objects, combine them into one.
-        Note this is only implemented for pairs with a time_range attribute- others will be skipped
+        Note this is only implemented for pairs with a time_range attribute - others will be skipped
         """
         to_remove = set()
         for (assoc1, assoc2) in combinations(self.associations, 2):
-            if not (len(assoc1.objects) == 2 and len(assoc2.objects) == 2):
-                continue
-            if not(hasattr(assoc1, 'time_range') and hasattr(assoc2, 'time_range')):
+            if not (len(assoc1.objects) == 2 and len(assoc2.objects) == 2) or \
+                    not(hasattr(assoc1, 'time_range') and hasattr(assoc2, 'time_range')):
                 continue
             if assoc1.objects == assoc2.objects:
                 if isinstance(assoc1.time_range, CompoundTimeRange):

--- a/stonesoup/types/association.py
+++ b/stonesoup/types/association.py
@@ -3,7 +3,7 @@ from typing import Set
 
 from ..base import Property
 from .base import Type
-from .time import TimeRange
+from .time import CompoundTimeRange
 
 
 class Association(Type):
@@ -48,7 +48,7 @@ class TimeRangeAssociation(Association):
     range of times
     """
 
-    time_range: TimeRange = Property(
+    time_range: CompoundTimeRange = Property(
         default=None, doc="Range of times that association exists over. Default is None")
 
 
@@ -118,6 +118,29 @@ class AssociationSet(Type):
                 for association in self.associations
                 for object_ in objects
                 if object_ in association.objects}
+
+    def get_key_times(self):
+        """Return all times at which an association from the set begins or ends
+
+        This method will return an ordered list of the times at which an association in the set
+        begins or ends.  Note that in the case of a :class:`~.CompoundTimeRange`,
+        there are potentially multiple start and end times,
+        and for :class:`~.SingleTimeAssociation` associations, the start and end time are the same
+
+        Returns
+        -------
+        : list of :class:`datetime.datetime`
+            A list of times at which an association starts or ends
+        """
+        key_times = []
+        for association in self.associations:
+            if isinstance(association, SingleTimeAssociation):
+                key_times.append(association.timestamp)
+            else:
+                key_times.extend(association.time_range.get_key_times())
+
+        return key_times
+
 
     def __contains__(self, item):
         return item in self.associations

--- a/stonesoup/types/association.py
+++ b/stonesoup/types/association.py
@@ -88,7 +88,7 @@ class AssociationSet(Type):
 
     def _simplify(self):
         """Where multiple associations describe the same pair of objects, combine them into one.
-        Note this is only implemented for pairs with a time_range attribute - others will be skipped
+        This is only implemented for pairs with a time_range attribute - others will be skipped
         """
         to_remove = set()
         for (assoc1, assoc2) in combinations(self.associations, 2):

--- a/stonesoup/types/association.py
+++ b/stonesoup/types/association.py
@@ -67,6 +67,28 @@ class AssociationSet(Type):
         if self.associations is None:
             self.associations = set()
 
+    def add(self, association):
+        if association is None:
+            return
+        elif isinstance(association, Association):
+            self.associations.add(association)
+        elif isinstance(association, AssociationSet):
+            for component in association:
+                self.add(component)
+        else:
+            raise TypeError("Supplied parameter must be an Association or AssociationSet")
+
+    def remove(self, association):
+        if association is None:
+            return
+        elif isinstance(association, Association):
+            self.associations.remove(association)
+        elif isinstance(association, AssociationSet):
+            for component in association:
+                self.remove(component)
+        else:
+            raise TypeError("Supplied parameter must be an Association or AssociationSet")
+
     @property
     def key_times(self):
         key_times = set(self.overall_time_range())

--- a/stonesoup/types/association.py
+++ b/stonesoup/types/association.py
@@ -127,7 +127,7 @@ class AssociationSet(Type):
     @property
     def key_times(self):
         """Returns all timestamps at which a component starts or ends, or where there is a
-        :class:`.~SingleTimeAssociation`"""
+        :class:`.~SingleTimeAssociation`."""
         key_times = list(self.overall_time_range.key_times)
         for association in self.associations:
             if isinstance(association, SingleTimeAssociation):
@@ -136,10 +136,10 @@ class AssociationSet(Type):
 
     @property
     def overall_time_range(self):
-        """Return a :class:`~.CompoundTimeRange` of :class:`~.TimeRange`
-        objects in this instance.
+        """Returns a :class:`~.CompoundTimeRange` covering all times at which at least
+        one association is active.
 
-        :class:`SingleTimeAssociation`s are discarded
+        Note: :class:`SingleTimeAssociation`s are not counted
         """
         overall_range = CompoundTimeRange()
         for association in self.associations:
@@ -149,8 +149,7 @@ class AssociationSet(Type):
 
     @property
     def object_set(self):
-        """Return all objects in the set
-        Returned as a set
+        """Returns a set of all objects contained by this instance.
         """
         object_set = set()
         for assoc in self.associations:

--- a/stonesoup/types/association.py
+++ b/stonesoup/types/association.py
@@ -67,14 +67,12 @@ class AssociationSet(Type):
         super().__init__(associations, *args, **kwargs)
         if self.associations is None:
             self.associations = set()
-        if not isinstance(self.associations, Set):
-            raise TypeError("Supplied parameter must be a set")
-        if not all([isinstance(member, Association) for member in self.associations]):
+        if not all(isinstance(member, Association) for member in self.associations):
             raise TypeError("Association set must contain only Association instances")
         self._simplify()
 
     def __eq__(self, other):
-        return True if self.associations == other.associations else False
+        return self.associations == other.associations
 
     def add(self, association):
         if association is None:
@@ -92,7 +90,7 @@ class AssociationSet(Type):
         """Where multiple associations describe the same pair of objects, combine them into one.
         Note this is only implemented for pairs with a time_range attribute- others will be skipped
         """
-        to_remove = []
+        to_remove = set()
         for (assoc1, assoc2) in combinations(self.associations, 2):
             if not (len(assoc1.objects) == 2 and len(assoc2.objects) == 2):
                 continue
@@ -101,13 +99,13 @@ class AssociationSet(Type):
             if assoc1.objects == assoc2.objects:
                 if isinstance(assoc1.time_range, CompoundTimeRange):
                     assoc1.time_range.add(assoc2.time_range)
-                    to_remove.append(assoc2)
+                    to_remove.add(assoc2)
                 elif isinstance(assoc2.time_range, CompoundTimeRange):
                     assoc2.time_range.add(assoc1.time_range)
-                    to_remove.append(assoc1)
+                    to_remove.add(assoc1)
                 else:
                     assoc1.time_range = CompoundTimeRange([assoc1.time_range, assoc2.time_range])
-                    to_remove.append(assoc2)
+                    to_remove.add(assoc2)
         for assoc in to_remove:
             self.remove(assoc)
 
@@ -207,8 +205,8 @@ class AssociationSet(Type):
 
         return AssociationSet({association
                               for association in self.associations
-                              if all([object_ in association.objects
-                                      for object_ in objects])})
+                              if all(object_ in association.objects
+                                     for object_ in objects)})
 
     def __contains__(self, item):
         return item in self.associations

--- a/stonesoup/types/association.py
+++ b/stonesoup/types/association.py
@@ -94,7 +94,7 @@ class AssociationSet(Type):
         """
         to_remove = []
         for (assoc1, assoc2) in combinations(self.associations, 2):
-            if not (len(assoc1.objects) == 2 and len(assoc2. objects) == 2):
+            if not (len(assoc1.objects) == 2 and len(assoc2.objects) == 2):
                 continue
             if not(hasattr(assoc1, 'time_range') and hasattr(assoc2, 'time_range')):
                 continue
@@ -102,7 +102,8 @@ class AssociationSet(Type):
                 if isinstance(assoc1.time_range, CompoundTimeRange):
                     assoc1.time_range.add(assoc2.time_range)
                 elif isinstance(assoc2.time_range, CompoundTimeRange):
-                    assoc1.time_range = assoc2.time_range.add(assoc1.time_range)
+                    assoc2.time_range.add(assoc1.time_range)
+                    assoc1.time_range = assoc2.time_range
                 else:
                     assoc1.time_range = CompoundTimeRange([assoc1.time_range, assoc2.time_range])
                 to_remove.append(assoc2)
@@ -198,7 +199,7 @@ class AssociationSet(Type):
         Returns
         -------
         : class:`~.AssociationSet`
-            A set of objects which have been associated
+            A set of associations containing every member of objects
         """
         # Ensure objects is iterable
         if not isinstance(objects, list) and not isinstance(objects, set):
@@ -206,8 +207,8 @@ class AssociationSet(Type):
 
         return AssociationSet({association
                               for association in self.associations
-                              for object_ in objects
-                              if object_ in association.objects})
+                              if all([object_ in association.objects
+                                      for object_ in objects])})
 
     def __contains__(self, item):
         return item in self.associations

--- a/stonesoup/types/association.py
+++ b/stonesoup/types/association.py
@@ -75,6 +75,9 @@ class AssociationSet(Type):
             raise TypeError("Association set must contain only Association instances")
         self._simplify()
 
+    def __eq__(self, other):
+        return self.associations == other.associations
+
     def add(self, association):
         if association is None:
             return

--- a/stonesoup/types/association.py
+++ b/stonesoup/types/association.py
@@ -139,7 +139,7 @@ class AssociationSet(Type):
         """Returns a :class:`~.CompoundTimeRange` covering all times at which at least
         one association is active.
 
-        Note: :class:`SingleTimeAssociation`s are not counted
+        Note: :class:`~.SingleTimeAssociation` are not counted
         """
         overall_range = CompoundTimeRange()
         for association in self.associations:

--- a/stonesoup/types/association.py
+++ b/stonesoup/types/association.py
@@ -52,6 +52,10 @@ class TimeRangeAssociation(Association):
     time_range: Union[CompoundTimeRange, TimeRange] = Property(
         default=None, doc="Range of times that association exists over. Default is None")
 
+    @property
+    def duration(self):
+        return self.time_range.duration.total_seconds()
+
 
 class AssociationSet(Type):
     """AssociationSet type
@@ -70,9 +74,6 @@ class AssociationSet(Type):
         if not all(isinstance(member, Association) for member in self.associations):
             raise TypeError("Association set must contain only Association instances")
         self._simplify()
-
-    def __eq__(self, other):
-        return self.associations == other.associations
 
     def add(self, association):
         if association is None:

--- a/stonesoup/types/association.py
+++ b/stonesoup/types/association.py
@@ -101,12 +101,13 @@ class AssociationSet(Type):
             if assoc1.objects == assoc2.objects:
                 if isinstance(assoc1.time_range, CompoundTimeRange):
                     assoc1.time_range.add(assoc2.time_range)
+                    to_remove.append(assoc2)
                 elif isinstance(assoc2.time_range, CompoundTimeRange):
                     assoc2.time_range.add(assoc1.time_range)
-                    assoc1.time_range = assoc2.time_range
+                    to_remove.append(assoc1)
                 else:
                     assoc1.time_range = CompoundTimeRange([assoc1.time_range, assoc2.time_range])
-                to_remove.append(assoc2)
+                    to_remove.append(assoc2)
         for assoc in to_remove:
             self.remove(assoc)
 
@@ -130,8 +131,8 @@ class AssociationSet(Type):
         key_times = list(self.overall_time_range.key_times)
         for association in self.associations:
             if isinstance(association, SingleTimeAssociation):
-                key_times.add(association.timestamp)
-        return sorted(list(key_times))
+                key_times.append(association.timestamp)
+        return sorted(key_times)
 
     @property
     def overall_time_range(self):

--- a/stonesoup/types/interval.py
+++ b/stonesoup/types/interval.py
@@ -49,9 +49,6 @@ class Interval(Type):
     def __str__(self):
         return '[{left}, {right}]'.format(left=self.start, right=self.end)
 
-    # def __repr__(self):
-    #     return 'Interval{interval}'.format(interval=str(self))
-
     def __eq__(self, other):
         return isinstance(other, Interval) and (self.start, self.end) == (other.start, other.end)
 
@@ -267,7 +264,7 @@ class Intervals(Type):
 
     def __eq__(self, other):
         if len(self) == 0:
-            return True if len(other) == 0 else False
+            return len(other) == 0
         if isinstance(other, Interval):
             other = Intervals(other)
 

--- a/stonesoup/types/interval.py
+++ b/stonesoup/types/interval.py
@@ -15,37 +15,45 @@ class Interval(Type):
     Represents a continuous, closed interval of real numbers.
     Represented by a lower and upper bound.
     """
-    left: Union[int, float] = Property(doc="Lower bound of interval")
-    right: Union[int, float] = Property(doc="Upper bound of interval")
+    start: Union[int, float] = Property(doc="Lower bound of interval")
+    end: Union[int, float] = Property(doc="Upper bound of interval")
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        if self.left >= self.right:
+        if self.start >= self.end:
             raise ValueError('Must have left < right')
 
     def __hash__(self):
-        return hash((self.left, self.right))
+        return hash((self.start, self.end))
+
+    @property
+    def left(self):
+        return self.start
+
+    @property
+    def right(self):
+        return self.end
 
     @property
     def length(self):
-        return self.right - self.left
+        return self.end - self.start
 
     def __contains__(self, item):
         if isinstance(item, Real):
-            return self.left <= item <= self.right
+            return self.start <= item <= self.end
         elif isinstance(item, Interval):
             return self & item == item
         else:
             return False
 
     def __str__(self):
-        return '[{left}, {right}]'.format(left=self.left, right=self.right)
+        return '[{left}, {right}]'.format(left=self.start, right=self.end)
 
-    def __repr__(self):
-        return 'Interval{interval}'.format(interval=str(self))
+    # def __repr__(self):
+    #     return 'Interval{interval}'.format(interval=str(self))
 
     def __eq__(self, other):
-        return isinstance(other, Interval) and (self.left, self.right) == (other.left, other.right)
+        return isinstance(other, Interval) and (self.start, self.end) == (other.start, other.end)
 
     def __and__(self, other):
         """Set-like intersection"""
@@ -54,11 +62,11 @@ class Interval(Type):
             raise ValueError("Can only intersect with Interval types")
 
         if not self.isdisjoint(other):
-            new_interval = (max(self.left, other.left), min(self.right, other.right))
+            new_interval = max(self.start, other.start), min(self.end, other.end)
             if new_interval[0] == new_interval[1]:
                 return None
             else:
-                return Interval(*new_interval)
+                return type(self)(new_interval[0], new_interval[1])
         else:
             return None
 
@@ -69,7 +77,7 @@ class Interval(Type):
             raise ValueError("Can only union with Interval types")
 
         if not self.isdisjoint(other):
-            return [Interval(min(self.left, other.left), max(self.right, other.right))]
+            return [type(self)(min(self.start, other.start), max(self.end, other.end))]
         else:
             return [copy.copy(self), copy.copy(other)]
 
@@ -82,14 +90,14 @@ class Interval(Type):
             raise ValueError("Can only subtract Interval types from Interval types")
         elif self.isdisjoint(other):
             return [copy.copy(self)]
-        elif other.left <= self.left and self.right <= other.right:
+        elif other.start <= self.start and self.end <= other.end:
             return [None]
-        elif other.left <= self.left:
-            return [Interval(other.right, self.right)]
-        elif self.right <= other.right:
-            return [Interval(self.left, other.left)]
+        elif other.start <= self.start:
+            return [Interval(other.end, self.end)]
+        elif self.end <= other.end:
+            return [Interval(self.start, other.start)]
         else:
-            return [Interval(self.left, other.left), Interval(other.right, self.right)]
+            return [Interval(self.start, other.start), Interval(other.end, self.end)]
 
     def __xor__(self, other):
         """Set-like symmetric difference"""
@@ -117,7 +125,7 @@ class Interval(Type):
         if not isinstance(other, Interval):
             raise ValueError("Can only compare Interval types to Interval types")
 
-        return other.left < self.left and self.right < other.right
+        return other.start < self.start and self.end < other.end
 
     def __ge__(self, other):
         """Superset check"""
@@ -144,12 +152,10 @@ class Interval(Type):
         if not isinstance(other, Interval):
             raise ValueError("Interval types can only overlap with Interval types")
 
-        lb = min(self.left, other.left)
-        ub = max(self.right, other.right)
+        max_start = max(self.start, other.start)
+        min_end = min(self.end, other.end)
 
-        return not ((ub - lb < self.length + other.length)
-                    or (self.right == other.left)
-                    or (other.right == self.left))
+        return max_start > min_end
 
 
 class Intervals(Type):
@@ -173,7 +179,7 @@ class Intervals(Type):
             if isinstance(self.intervals, (Interval, Tuple)):
                 self.intervals = [self.intervals]
             else:
-                raise ValueError("Must contain Interval types")
+                raise TypeError("Must contain Interval types")
         elif len(self.intervals) == 2 and all(isinstance(elem, Real) for elem in self.intervals):
             self.intervals = [self.intervals]
 
@@ -183,7 +189,7 @@ class Intervals(Type):
                 if isinstance(interval, Sequence) and len(interval) == 2:
                     self.intervals[i] = Interval(*interval)
                 else:
-                    raise ValueError("Individual intervals must be an Interval or Sequence type")
+                    raise TypeError("Individual intervals must be an Interval or Sequence type")
 
         self.intervals = self.get_merged_intervals(self.intervals)
 
@@ -209,7 +215,6 @@ class Intervals(Type):
 
         if not isinstance(other, Intervals):
             raise ValueError("Can only compare Intervals to Intervals")
-
         return all(interval.isdisjoint(other_int) for other_int in other for interval in self)
 
     @staticmethod
@@ -244,10 +249,10 @@ class Intervals(Type):
         return any(item in interval for interval in self)
 
     def __str__(self):
-        return str([[interval.left, interval.right] for interval in self])
+        return str([[interval.start, interval.end] for interval in self])
 
-    def __repr__(self):
-        return 'Intervals{intervals}'.format(intervals=str(self))
+    # def __repr__(self):
+    #     return 'Intervals{intervals}'.format(intervals=str(self))
 
     @property
     def length(self):
@@ -264,7 +269,8 @@ class Intervals(Type):
         return self._iter(reverse=True)
 
     def __eq__(self, other):
-
+        if len(self) == 0:
+            return True if len(other) == 0 else False
         if isinstance(other, Interval):
             other = Intervals(other)
 
@@ -274,6 +280,8 @@ class Intervals(Type):
     def __and__(self, other):
         """Set-like intersection"""
 
+        if other is None:
+            return False
         if not isinstance(other, (Interval, Intervals)):
             raise ValueError("Can only intersect with Intervals types")
 
@@ -287,12 +295,11 @@ class Intervals(Type):
                 if new_interval:
                     new_intervals.append(new_interval)
         new_intervals = self.get_merged_intervals(new_intervals)
-        new_intervals = Intervals(new_intervals)
+        new_intervals = type(self)(new_intervals)
         return new_intervals
 
     def __or__(self, other):
         """Set-like union"""
-
         if not isinstance(other, (Interval, Intervals)):
             raise ValueError('Can only union with Intervals types')
 
@@ -301,7 +308,7 @@ class Intervals(Type):
 
         new_intervals = self.intervals + other.intervals
         new_intervals = self.get_merged_intervals(new_intervals)
-        new_intervals = Intervals(new_intervals)
+        new_intervals = type(self)(new_intervals)
         return new_intervals
 
     def __sub__(self, other):
@@ -325,7 +332,7 @@ class Intervals(Type):
                 if diff[0] is not None:
                     temp_intervals.extend(diff)
             new_intervals = temp_intervals
-        new_intervals = Intervals(new_intervals)
+        new_intervals = type(self)(new_intervals)
         return new_intervals
 
     def __xor__(self, other):
@@ -335,7 +342,7 @@ class Intervals(Type):
             raise ValueError("Can only compare Intervals from Intervals")
 
         if isinstance(other, Interval):
-            other = Intervals(other)
+            other = type(self)(other)
 
         return (self | other) - (self & other)
 

--- a/stonesoup/types/interval.py
+++ b/stonesoup/types/interval.py
@@ -251,9 +251,6 @@ class Intervals(Type):
     def __str__(self):
         return str([[interval.start, interval.end] for interval in self])
 
-    # def __repr__(self):
-    #     return 'Intervals{intervals}'.format(intervals=str(self))
-
     @property
     def length(self):
         return sum(interval.length for interval in self)

--- a/stonesoup/types/tests/test_association.py
+++ b/stonesoup/types/tests/test_association.py
@@ -43,7 +43,6 @@ def test_associationpair():
     assert np.array_equal(assoc.objects, set(objects[:2]))
 
 
-
 def test_singletimeassociation():
     with pytest.raises(TypeError):
         SingleTimeAssociation()
@@ -189,4 +188,3 @@ def test_association_set_properties():
     assert test3.key_times == [timestamp1, timestamp2]
     assert test3.overall_time_range == com_time_range
     assert test3.object_set == set(objects)
-

--- a/stonesoup/types/tests/test_association.py
+++ b/stonesoup/types/tests/test_association.py
@@ -85,7 +85,7 @@ def test_associationset():
     timestamp2 = datetime.datetime(2018, 3, 1, 5, 8, 35)
     timestamp3 = datetime.datetime(2020, 3, 1, 1, 1, 1)
     time_range = TimeRange(start=timestamp1, end=timestamp2)
-    time_range2 = TimeRange(timestamp2, timestamp3)
+    time_range2 = TimeRange(start=timestamp2, end=timestamp3)
 
     objects_list = [Detection(np.array([[1], [2]])),
                     Detection(np.array([[3], [4]])),
@@ -96,7 +96,7 @@ def test_associationset():
 
     assoc2 = TimeRangeAssociation(objects=set(objects_list[1:]),
                                   time_range=time_range)
-    assoc_duplicate = TimeRangeAssociation(objects=set(objects_list[1:]),
+    assoc2_same_objects = TimeRangeAssociation(objects=set(objects_list[1:]),
                                            time_range=time_range2)
 
     assoc_set = AssociationSet({assoc1, assoc2})
@@ -115,7 +115,7 @@ def test_associationset():
 
     # test _simplify method
 
-    simplify_test = AssociationSet({assoc1, assoc2, assoc_duplicate})
+    simplify_test = AssociationSet({assoc1, assoc2, assoc2_same_objects})
 
     assert len(simplify_test.associations) == 2
 
@@ -148,17 +148,17 @@ def test_associationset():
 def test_association_set_add_remove():
     test = AssociationSet()
     with pytest.raises(TypeError):
-        test.add("banana")
+        test.add("a string")
     with pytest.raises(TypeError):
-        test.remove("banana")
+        test.remove("a string")
     objects = {Detection(np.array([[1], [2]])),
                Detection(np.array([[3], [4]])),
                Detection(np.array([[5], [6]]))}
 
     assoc = Association(objects)
+    assert assoc not in test.associations
     with pytest.raises(ValueError):
         test.remove(assoc)
-    assert assoc not in test.associations
     test.add(assoc)
     assert assoc in test.associations
     test.remove(assoc)

--- a/stonesoup/types/tests/test_association.py
+++ b/stonesoup/types/tests/test_association.py
@@ -67,7 +67,7 @@ def test_timerangeassociation():
                Detection(np.array([[5], [6]]))}
     timestamp1 = datetime.datetime(2018, 3, 1, 5, 3, 35)
     timestamp2 = datetime.datetime(2018, 3, 1, 5, 8, 35)
-    timerange = TimeRange(start_timestamp=timestamp1, end_timestamp=timestamp2)
+    timerange = TimeRange(start=timestamp1, end=timestamp2)
     ctimerange = CompoundTimeRange([timerange])
 
     assoc = TimeRangeAssociation(objects=objects, time_range=timerange)
@@ -84,7 +84,7 @@ def test_associationset():
     timestamp1 = datetime.datetime(2018, 3, 1, 5, 3, 35)
     timestamp2 = datetime.datetime(2018, 3, 1, 5, 8, 35)
     timestamp3 = datetime.datetime(2020, 3, 1, 1, 1, 1)
-    time_range = TimeRange(start_timestamp=timestamp1, end_timestamp=timestamp2)
+    time_range = TimeRange(start=timestamp1, end=timestamp2)
     time_range2 = TimeRange(timestamp2, timestamp3)
 
     objects_list = [Detection(np.array([[1], [2]])),
@@ -180,7 +180,7 @@ def test_association_set_properties():
     assert test2.object_set == set(objects)
     timestamp1 = datetime.datetime(2018, 3, 1, 5, 3, 35)
     timestamp2 = datetime.datetime(2018, 3, 1, 5, 8, 35)
-    time_range = TimeRange(start_timestamp=timestamp1, end_timestamp=timestamp2)
+    time_range = TimeRange(start=timestamp1, end=timestamp2)
     com_time_range = CompoundTimeRange([time_range])
     assoc2 = TimeRangeAssociation(objects=set(objects[1:]),
                                   time_range=com_time_range)

--- a/stonesoup/types/tests/test_association.py
+++ b/stonesoup/types/tests/test_association.py
@@ -97,7 +97,7 @@ def test_associationset():
     assoc2 = TimeRangeAssociation(objects=set(objects_list[1:]),
                                   time_range=time_range)
     assoc2_same_objects = TimeRangeAssociation(objects=set(objects_list[1:]),
-                                           time_range=time_range2)
+                                               time_range=time_range2)
 
     assoc_set = AssociationSet({assoc1, assoc2})
 

--- a/stonesoup/types/tests/test_association.py
+++ b/stonesoup/types/tests/test_association.py
@@ -6,7 +6,7 @@ import pytest
 from ..association import Association, AssociationPair, AssociationSet, \
     SingleTimeAssociation, TimeRangeAssociation
 from ..detection import Detection
-from ..time import TimeRange
+from ..time import TimeRange, CompoundTimeRange
 
 
 def test_association():
@@ -40,7 +40,8 @@ def test_associationpair():
 
     # 2 objects
     assoc = AssociationPair(set(objects[:2]))
-    np.array_equal(assoc.objects, set(objects[:2]))
+    assert np.array_equal(assoc.objects, set(objects[:2]))
+
 
 
 def test_singletimeassociation():
@@ -68,18 +69,24 @@ def test_timerangeassociation():
     timestamp1 = datetime.datetime(2018, 3, 1, 5, 3, 35)
     timestamp2 = datetime.datetime(2018, 3, 1, 5, 8, 35)
     timerange = TimeRange(start_timestamp=timestamp1, end_timestamp=timestamp2)
+    ctimerange = CompoundTimeRange([timerange])
 
     assoc = TimeRangeAssociation(objects=objects, time_range=timerange)
+    cassoc = TimeRangeAssociation(objects=objects, time_range=ctimerange)
 
     assert assoc.objects == objects
     assert assoc.time_range == timerange
+    assert cassoc.objects == objects
+    assert cassoc.time_range == ctimerange
 
 
 def test_associationset():
     # Set up some dummy variables
     timestamp1 = datetime.datetime(2018, 3, 1, 5, 3, 35)
     timestamp2 = datetime.datetime(2018, 3, 1, 5, 8, 35)
-    timerange = TimeRange(start_timestamp=timestamp1, end_timestamp=timestamp2)
+    timestamp3 = datetime.datetime(2020, 3, 1, 1, 1, 1)
+    time_range = TimeRange(start_timestamp=timestamp1, end_timestamp=timestamp2)
+    time_range2 = TimeRange(timestamp2, timestamp3)
 
     objects_list = [Detection(np.array([[1], [2]])),
                     Detection(np.array([[3], [4]])),
@@ -89,7 +96,9 @@ def test_associationset():
                                    timestamp=timestamp1)
 
     assoc2 = TimeRangeAssociation(objects=set(objects_list[1:]),
-                                  time_range=timerange)
+                                  time_range=time_range)
+    assoc_duplicate = TimeRangeAssociation(objects=set(objects_list[1:]),
+                                           time_range=time_range2)
 
     assoc_set = AssociationSet({assoc1, assoc2})
 
@@ -105,26 +114,79 @@ def test_associationset():
 
     assert len(assoc_set) == 2
 
+    # test _simplify method
+
+    simplify_test = AssociationSet({assoc1, assoc2, assoc_duplicate})
+
+    assert len(simplify_test.associations) == 2
+
     # Test associations including objects
 
     # Object only present in object 1
     assert assoc_set.associations_including_objects(objects_list[0]) \
-        == {assoc1}
+        == AssociationSet({assoc1})
     # Object present in both
     assert assoc_set.associations_including_objects(objects_list[1]) \
-        == {assoc1, assoc2}
+        == AssociationSet({assoc1, assoc2})
     # Object present in neither
-    assert not assoc_set.associations_including_objects(
-        Detection(np.array([[0], [0]])))
+    assert assoc_set.associations_including_objects(Detection(np.array([[0], [0]]))) \
+        == AssociationSet()
 
     # Test associations including timestamp
 
     # Timestamp present in one object
     assert assoc_set.associations_at_timestamp(timestamp2) \
-        == {assoc2}
+        == AssociationSet({assoc2})
     # Timestamp present in both
     assert assoc_set.associations_at_timestamp(timestamp1) \
-        == {assoc1, assoc2}
+        == AssociationSet({assoc1, assoc2})
     # Timestamp not present in either
-    timestamp3 = datetime.datetime(2018, 3, 1, 6, 8, 35)
-    assert not assoc_set.associations_at_timestamp(timestamp3)
+    timestamp4 = datetime.datetime(2022, 3, 1, 6, 8, 35)
+    assert assoc_set.associations_at_timestamp(timestamp4) \
+        == AssociationSet()
+
+
+def test_association_set_add_remove():
+    test = AssociationSet()
+    with pytest.raises(TypeError):
+        test.add("banana")
+    with pytest.raises(TypeError):
+        test.remove("banana")
+    objects = {Detection(np.array([[1], [2]])),
+               Detection(np.array([[3], [4]])),
+               Detection(np.array([[5], [6]]))}
+
+    assoc = Association(objects)
+    with pytest.raises(ValueError):
+        test.remove(assoc)
+    assert assoc not in test.associations
+    test.add(assoc)
+    assert assoc in test.associations
+    test.remove(assoc)
+    assert assoc not in test.associations
+
+
+def test_association_set_properties():
+    test = AssociationSet()
+    assert test.key_times == []
+    assert test.overall_time_range == CompoundTimeRange()
+    assert test.object_set == set()
+    objects = [Detection(np.array([[1], [2]])),
+               Detection(np.array([[3], [4]])),
+               Detection(np.array([[5], [6]]))]
+    assoc = Association(set(objects))
+    test2 = AssociationSet({assoc})
+    assert test2.key_times == []
+    assert test2.overall_time_range == CompoundTimeRange()
+    assert test2.object_set == set(objects)
+    timestamp1 = datetime.datetime(2018, 3, 1, 5, 3, 35)
+    timestamp2 = datetime.datetime(2018, 3, 1, 5, 8, 35)
+    time_range = TimeRange(start_timestamp=timestamp1, end_timestamp=timestamp2)
+    com_time_range = CompoundTimeRange([time_range])
+    assoc2 = TimeRangeAssociation(objects=set(objects[1:]),
+                                  time_range=com_time_range)
+    test3 = AssociationSet({assoc, assoc2})
+    assert test3.key_times == [timestamp1, timestamp2]
+    assert test3.overall_time_range == com_time_range
+    assert test3.object_set == set(objects)
+

--- a/stonesoup/types/tests/test_detection.py
+++ b/stonesoup/types/tests/test_detection.py
@@ -33,4 +33,3 @@ def test_composite_detection():
                                    mapping=[1, 0, 2, 3])
     # Last detection should overwrite metadata of earlier
     assert detection.metadata == {'colour': 'red', 'speed': 'fast', 'size': 'big'}
-

--- a/stonesoup/types/tests/test_detection.py
+++ b/stonesoup/types/tests/test_detection.py
@@ -33,3 +33,4 @@ def test_composite_detection():
                                    mapping=[1, 0, 2, 3])
     # Last detection should overwrite metadata of earlier
     assert detection.metadata == {'colour': 'red', 'speed': 'fast', 'size': 'big'}
+

--- a/stonesoup/types/tests/test_interval.py
+++ b/stonesoup/types/tests/test_interval.py
@@ -198,7 +198,13 @@ def test_intervals_len():
 
 def test_intervals_str():
     assert str(A) == str([[interval.left, interval.right] for interval in A])
-    assert A.__repr__() == 'Intervals{intervals}'.format(intervals=str(A))
+    assert A.__repr__() == ('Intervals(\n'
+                            '    intervals=[Interval(\n'
+                            '                  start=0,\n'
+                            '                  end=1),\n'
+                            '               Interval(\n'
+                            '                  start=2,\n'
+                            '                  end=3)])')
 
 
 def test_intervals_iter():

--- a/stonesoup/types/tests/test_interval.py
+++ b/stonesoup/types/tests/test_interval.py
@@ -167,9 +167,6 @@ def test_intervals_overlap():
 
 
 def test_intervals_disjoint():
-    # with pytest.raises(ValueError, match="Can only compare Intervals to Intervals"):
-    #     A.isdisjoint('a string')
-    # assert not A.isdisjoint(B)  # Overlap
     assert not A.isdisjoint(C)  # Meet with no overlap
     assert A.isdisjoint(D)
     assert not A.isdisjoint(A)
@@ -197,6 +194,11 @@ def test_intervals_len():
     assert Intervals([]).length == 0
     assert A.length == 2
     assert Intervals([Interval(0.5, 0.75), Interval(0.1, 0.2)]).length == 0.35
+
+
+def test_intervals_str():
+    assert str(A) == str([[interval.left, interval.right] for interval in A])
+    assert A.__repr__() == 'Intervals{intervals}'.format(intervals=str(A))
 
 
 def test_intervals_iter():

--- a/stonesoup/types/tests/test_interval.py
+++ b/stonesoup/types/tests/test_interval.py
@@ -38,11 +38,6 @@ def test_interval_contains():
     assert 'a string' not in a
 
 
-def test_interval_str():
-    assert str(a) == '[{left}, {right}]'.format(left=0, right=1)
-    assert a.__repr__() == 'Interval{interval}'.format(interval=str(a))
-
-
 def test_interval_eq():
     assert a == Interval(0, 1)
     assert a != (0, 1)
@@ -122,6 +117,7 @@ def test_interval_disjoint():
     assert a.isdisjoint(b)  # No overlap
     assert not a.isdisjoint(c)  # Overlap
     assert not a.isdisjoint(d)  # Meet and no overlap
+    assert not a.isdisjoint(a)  # a is not disjoint with itself
 
 
 def test_intervals_init():
@@ -134,7 +130,7 @@ def test_intervals_init():
     assert len(temp.intervals) == 1
     assert temp.intervals[0] == a
 
-    with pytest.raises(ValueError, match="Must contain Interval types"):
+    with pytest.raises(TypeError, match="Must contain Interval types"):
         Intervals('a string')
 
     temp = Intervals((0, 1))
@@ -146,7 +142,7 @@ def test_intervals_init():
     assert len(A.intervals) == 2
     assert A.intervals == [a, b]  # Converts lists of tuples to lists of Interval types
 
-    with pytest.raises(ValueError,
+    with pytest.raises(TypeError,
                        match="Individual intervals must be an Interval or Sequence type"):
         Intervals([(0, 1), 'a string'])
 
@@ -171,11 +167,12 @@ def test_intervals_overlap():
 
 
 def test_intervals_disjoint():
-    with pytest.raises(ValueError, match="Can only compare Intervals to Intervals"):
-        A.isdisjoint('a string')
-    assert not A.isdisjoint(B)  # Overlap
+    # with pytest.raises(ValueError, match="Can only compare Intervals to Intervals"):
+    #     A.isdisjoint('a string')
+    # assert not A.isdisjoint(B)  # Overlap
     assert not A.isdisjoint(C)  # Meet with no overlap
     assert A.isdisjoint(D)
+    assert not A.isdisjoint(A)
 
 
 def test_intervals_merge():
@@ -194,11 +191,6 @@ def test_intervals_contains():
     assert A in A
     assert Intervals([a]) in A
     assert Intervals([Interval(0.25, 0.75)]) in A
-
-
-def test_intervals_str():
-    assert str(A) == str([[interval.left, interval.right] for interval in A])
-    assert A.__repr__() == 'Intervals{intervals}'.format(intervals=str(A))
 
 
 def test_intervals_len():

--- a/stonesoup/types/tests/test_metric.py
+++ b/stonesoup/types/tests/test_metric.py
@@ -85,8 +85,8 @@ def test_timerangemetric():
     value = 5
     timestamp1 = datetime.datetime.now()
     timestamp2 = timestamp1 + datetime.timedelta(seconds=10)
-    time_range = TimeRange(start_timestamp=timestamp1,
-                           end_timestamp=timestamp2)
+    time_range = TimeRange(start=timestamp1,
+                           end=timestamp2)
 
     class temp_generator(MetricGenerator):
 
@@ -113,8 +113,8 @@ def test_timerangeplottingmetric():
     value = 5
     timestamp1 = datetime.datetime.now()
     timestamp2 = timestamp1 + datetime.timedelta(seconds=10)
-    time_range = TimeRange(start_timestamp=timestamp1,
-                           end_timestamp=timestamp2)
+    time_range = TimeRange(start=timestamp1,
+                           end=timestamp2)
 
     class temp_generator(MetricGenerator):
 

--- a/stonesoup/types/tests/test_time.py
+++ b/stonesoup/types/tests/test_time.py
@@ -218,7 +218,8 @@ def test_remove_overlap(times):
 
     test2 = CompoundTimeRange([TimeRange(times[0], times[4])])
 
-    assert test1_ro.duration == TimeRange(times[0], times[1]).duration + TimeRange(times[3], times[4]).duration
+    assert test1_ro.duration == TimeRange(times[0], times[1]).duration + \
+           TimeRange(times[3], times[4]).duration
     assert test2_ro == test2
     assert test3_ro == CompoundTimeRange()
 

--- a/stonesoup/types/tests/test_time.py
+++ b/stonesoup/types/tests/test_time.py
@@ -112,8 +112,6 @@ def test_contains(times):
     assert test_range2 not in compound_test
     assert test_range2 not in compound_test2
     assert test_range3 not in compound_test
-    print("         \n       range3", test_range3, "test2", compound_test2)
-    print(compound_test2.overlap(test_range3))
     assert test_range3 in compound_test2
 
 
@@ -152,29 +150,29 @@ def test_minus(times):
     test4 = TimeRange(times[4], times[5])
 
     with pytest.raises(TypeError):
-        test1.minus(15)
+        test1 - 15
 
-    assert test1.minus(test2) == test3
-    assert test1.minus(None) == test1
-    assert test2.minus(test1) is None
+    assert test1 - test2 == test3
+    assert test1 == test1 - None
+    assert test2 - test1 is None
 
     ctest1 = CompoundTimeRange([test2, test4])
     ctest2 = CompoundTimeRange([test1, test2])
     ctest3 = CompoundTimeRange([test4])
 
     with pytest.raises(TypeError):
-        ctest1.minus(15)
+        ctest1 - 15
 
-    assert ctest1.minus(ctest2) == ctest3
-    assert ctest1.minus(ctest1) == CompoundTimeRange()
-    assert ctest3.minus(ctest1) == CompoundTimeRange()
+    assert ctest1 - ctest2 == ctest3
+    assert ctest1 - ctest1 == CompoundTimeRange()
+    assert ctest3 - ctest1 == CompoundTimeRange()
 
-    assert test1.minus(ctest1) == TimeRange(times[2], times[3])
-    assert test4.minus(ctest2) == test4
-    assert ctest1.minus(test2) == ctest3
+    assert test1 - ctest1 == TimeRange(times[2], times[3])
+    assert test4 - ctest2 == test4
+    assert ctest1 - test2 == ctest3
 
 
-def test_overlap(times):
+def test_and(times):
     test1 = TimeRange(times[1], times[3])
     test2 = TimeRange(times[1], times[2])
     test3 = TimeRange(times[4], times[5])
@@ -182,16 +180,16 @@ def test_overlap(times):
     ctest1 = CompoundTimeRange([test2, test3])
     ctest2 = CompoundTimeRange([test1, test2])
 
-    assert test2.overlap(ctest1) == ctest1.overlap(test2)
+    assert test2 & ctest1 == ctest1 & test2
 
-    assert test1.overlap(test1) == test1
-    assert test1.overlap(None) is None
-    assert test1.overlap(test2) == test2
-    assert test2.overlap(test1) == test2
-    assert ctest1.overlap(None) is None
-    assert ctest1.overlap(test2) == CompoundTimeRange([test2])
-    assert ctest1.overlap(ctest2) == CompoundTimeRange([test2])
-    assert ctest1.overlap(ctest2) == ctest2.overlap(ctest1)
+    assert test1 & test1 == test1
+    assert test1 & None is None
+    assert test1 & test2 == test2
+    assert test2 & test1 == test2
+    assert ctest1 & None is None
+    assert ctest1 & test2 == CompoundTimeRange([test2])
+    assert ctest1 & ctest2 == CompoundTimeRange([test2])
+    assert ctest1 & ctest2 == ctest2 & ctest1
 
 
 def test_key_times(times):

--- a/stonesoup/types/tests/test_time.py
+++ b/stonesoup/types/tests/test_time.py
@@ -4,6 +4,7 @@ import pytest
 
 from ..time import TimeRange, CompoundTimeRange
 
+
 @pytest.fixture
 def times():
     # Note times are returned chronologically for ease of reading
@@ -200,11 +201,13 @@ def test_key_times(times):
                                TimeRange(times[0], times[1])])
     test3 = CompoundTimeRange()
     test4 = CompoundTimeRange([TimeRange(times[0], times[4])])
+    test5 = TimeRange(times[0], times[4])
 
     assert test1.key_times == [times[0], times[1], times[3], times[4]]
     assert test2.key_times == [times[0], times[1], times[3], times[4]]
     assert test3.key_times == []
     assert test4.key_times == [times[0], times[4]]
+    assert test5.key_times == [times[0], times[4]]
 
 
 def test_remove_overlap(times):
@@ -237,6 +240,7 @@ def test_fuse_components(times):
     assert test1 == CompoundTimeRange([TimeRange(times[1], times[2])])
     assert test2 == CompoundTimeRange([TimeRange(times[1], times[4])])
 
+
 def test_add(times):
     test1 = CompoundTimeRange([TimeRange(times[1], times[2])])
     test2 = CompoundTimeRange([TimeRange(times[0], times[1])])
@@ -254,13 +258,18 @@ def test_add(times):
     test3.add(TimeRange(times[4], times[5]))
     assert test3 == test4
 
+
 def test_remove(times):
     test1 = CompoundTimeRange([TimeRange(times[0], times[2]),
                                TimeRange(times[4], times[5])])
     with pytest.raises(TypeError):
         test1.remove(0.4)
     with pytest.raises(ValueError):
-        test1.remove(TimeRange(times[0], times[1]))
-
-    test1.remove(TimeRange(times[0], times[2]))
+        test1.remove(TimeRange(times[2], times[3]))
+    # Remove part of a component
+    test1.remove(TimeRange(times[0], times[1]))
+    assert test1 == CompoundTimeRange([TimeRange(times[1], times[2]),
+                                       TimeRange(times[4], times[5])])
+    # Remove whole component
+    test1.remove(TimeRange(times[1], times[2]))
     assert test1 == CompoundTimeRange([TimeRange(times[4], times[5])])

--- a/stonesoup/types/tests/test_time.py
+++ b/stonesoup/types/tests/test_time.py
@@ -211,12 +211,12 @@ def test_key_times(times):
 def test_remove_overlap(times):
     test1_ro = CompoundTimeRange([TimeRange(times[0], times[1]),
                                   TimeRange(times[3], times[4])])
-    test1_ro.remove_overlap()
+    test1_ro._remove_overlap()
     test2_ro = CompoundTimeRange([TimeRange(times[3], times[4]),
                                   TimeRange(times[0], times[4])])
-    test2_ro.remove_overlap()
+    test2_ro._remove_overlap()
     test3_ro = CompoundTimeRange()
-    test3_ro.remove_overlap()
+    test3_ro._remove_overlap()
 
     test1 = CompoundTimeRange([TimeRange(times[0], times[1]),
                                TimeRange(times[3], times[4])])
@@ -230,9 +230,9 @@ def test_remove_overlap(times):
 
 def test_fuse_components(times):
     # Note this is called inside the __init__ method, but is tested here explicitly
-    test1 = CompoundTimeRange([TimeRange(times[1], times[2])]).fuse_components()
+    test1 = CompoundTimeRange([TimeRange(times[1], times[2])])._fuse_components()
     test2 = CompoundTimeRange([TimeRange(times[1], times[2]),
-                               TimeRange(times[2], times[4])]).fuse_components()
+                               TimeRange(times[2], times[4])])._fuse_components()
     assert test1.time_ranges == {TimeRange(times[1], times[2])}
     assert test2.time_ranges == {TimeRange(times[1], times[4])}
 

--- a/stonesoup/types/tests/test_time.py
+++ b/stonesoup/types/tests/test_time.py
@@ -28,11 +28,11 @@ def test_timerange(times):
 
     # Without start time
     with pytest.raises(TypeError):
-        TimeRange(start=times[1])
+        TimeRange(end=times[3])
 
     # Without end time
     with pytest.raises(TypeError):
-        TimeRange(end=times[3])
+        TimeRange(start=times[1])
 
     # Test an error is caught when end is after start
     with pytest.raises(ValueError):
@@ -50,7 +50,7 @@ def test_timerange(times):
 
     test_compound2 = CompoundTimeRange([test_range])
 
-    # Tests fuse_components method
+    # Test fuse_components method
     fuse_test = CompoundTimeRange([test_range, TimeRange(times[3], times[4])])
 
     assert test_range.start_timestamp == times[1]
@@ -72,8 +72,8 @@ def test_duration(times):
     test_range2 = CompoundTimeRange([TimeRange(start=times[1], end=times[3]),
                                      TimeRange(start=times[2], end=times[4])])
 
-    assert test_range.duration == datetime.timedelta(seconds=3726)
-    assert test_range2.duration == datetime.timedelta(seconds=31539726)
+    assert test_range.duration == times[3] - times[1]
+    assert test_range2.duration == times[4] - times[1]
 
 
 def test_contains(times):
@@ -86,11 +86,11 @@ def test_contains(times):
     with pytest.raises(TypeError):
         16 in test3
 
-    assert times[2] in test_range
-    assert not times[4] in test_range
-    assert not times[0] in test_range
     assert times[1] in test_range
+    assert times[2] in test_range
     assert times[3] in test_range
+    assert not times[0] in test_range
+    assert not times[4] in test_range
 
     assert test2 in test_range
     assert test_range not in test2
@@ -120,7 +120,7 @@ def test_equality(times):
     test2 = TimeRange(times[1], times[2])
     test3 = TimeRange(times[1], times[3])
 
-    assert test1 != "stonesoup"
+    assert test1 != "a string"
 
     assert test1 == test2
     assert test2 == test1
@@ -129,13 +129,11 @@ def test_equality(times):
     ctest1 = CompoundTimeRange([test1, test3])
     ctest2 = CompoundTimeRange([TimeRange(times[1], times[3])])
 
-    assert ctest2 != "Stonesoup is the best!"
+    assert ctest2 != "a string"
 
-    assert ctest1 == ctest2
-    assert ctest2 == ctest1
+    assert ctest1 == ctest2 and ctest2 == ctest1
     ctest2.add(TimeRange(times[3], times[4]))
-    assert ctest1 != ctest2
-    assert ctest2 != ctest1
+    assert ctest1 != ctest2 and ctest2 != ctest1
 
     assert CompoundTimeRange() == CompoundTimeRange()
     assert ctest1 != CompoundTimeRange()
@@ -218,14 +216,11 @@ def test_remove_overlap(times):
     test3_ro = CompoundTimeRange()
     test3_ro._remove_overlap()
 
-    test1 = CompoundTimeRange([TimeRange(times[0], times[1]),
-                               TimeRange(times[3], times[4])])
-    test3 = CompoundTimeRange()
-    test4 = CompoundTimeRange([TimeRange(times[0], times[4])])
+    test2 = CompoundTimeRange([TimeRange(times[0], times[4])])
 
-    assert test1_ro == test1
-    assert test2_ro == test4
-    assert test3_ro == test3
+    assert test1_ro.duration == TimeRange(times[0], times[1]).duration + TimeRange(times[3], times[4]).duration
+    assert test2_ro == test2
+    assert test3_ro == CompoundTimeRange()
 
 
 def test_fuse_components(times):

--- a/stonesoup/types/tests/test_time.py
+++ b/stonesoup/types/tests/test_time.py
@@ -6,6 +6,7 @@ from ..time import TimeRange, CompoundTimeRange
 
 @pytest.fixture
 def times():
+    # Note times are returned chronologically for ease of reading
     before = datetime.datetime(year=2018, month=3, day=1, hour=3, minute=10, second=3)
     t1 = datetime.datetime(year=2018, month=3, day=1, hour=5, minute=3,
                            second=35, microsecond=500)
@@ -14,7 +15,9 @@ def times():
                            second=41, microsecond=500)
     after = datetime.datetime(year=2019, month=3, day=1, hour=6, minute=5,
                               second=41, microsecond=500)
-    return [before, t1, inside, t2, after]
+    long_after = datetime.datetime(year=2022, month=6, day=1, hour=6, minute=5,
+                                   second=41, microsecond=500)
+    return [before, t1, inside, t2, after, long_after]
 
 
 def test_timerange(times):
@@ -40,16 +43,20 @@ def test_timerange(times):
     with pytest.raises(TypeError):
         CompoundTimeRange([times[1], times[3]])
 
-    test_range = test_range = TimeRange(start_timestamp=times[1], end_timestamp=times[3])
+    test_range = TimeRange(start_timestamp=times[1], end_timestamp=times[3])
 
     test_compound = CompoundTimeRange()
 
     test_compound2 = CompoundTimeRange([test_range])
 
+    # Tests fuse_components method
+    fuse_test = CompoundTimeRange([test_range, TimeRange(times[3], times[4])])
+
     assert test_range.start_timestamp == times[1]
     assert test_range.end_timestamp == times[3]
     assert len(test_compound.time_ranges) == 0
     assert test_compound2.time_ranges[0] == test_range
+    assert fuse_test.time_ranges == [TimeRange(times[1], times[4])]
 
 
 def test_duration(times):
@@ -61,37 +68,198 @@ def test_duration(times):
     # CompoundTimeRange
 
     # times[2] is inside of [1] and [3], so should be equivalent to a TimeRange(times[1], times[4])
-    test_range2 = CompoundTimeRange(TimeRange(start_timestamp=times[1], end_timestamp=times[3]),
-                                    TimeRange(start_timestamp=times[2], end_timestamp=times[4]))
+    test_range2 = CompoundTimeRange([TimeRange(start_timestamp=times[1], end_timestamp=times[3]),
+                                    TimeRange(start_timestamp=times[2], end_timestamp=times[4])])
 
     assert test_range.duration == datetime.timedelta(seconds=3726)
-    assert test_range.duration == datetime.timedelta(seconds=31539726)
+    assert test_range2.duration == datetime.timedelta(seconds=31539726)
 
 
-def test_timerange_contains():
+def test_contains(times):
     # Test that timestamps are correctly determined to be in the range
 
-    t1 = datetime.datetime(year=2018, month=3, day=1, hour=5, minute=3,
-                           second=35, microsecond=500)
-    t2 = datetime.datetime(year=2018, month=3, day=1, hour=6, minute=5,
-                           second=41, microsecond=500)
-    test_range = TimeRange(start_timestamp=t1, end_timestamp=t2)
+    test_range = TimeRange(start_timestamp=times[1], end_timestamp=times[3])
+    test2 = TimeRange(times[1], times[2])
+    test3 = TimeRange(times[1], times[4])
 
-    # Inside
-    assert datetime.datetime(
-        year=2018, month=3, day=1, hour=5, minute=10, second=3) in test_range
+    with pytest.raises(TypeError):
+        16 in test3
 
-    # Outside
+    assert times[2] in test_range
+    assert not times[4] in test_range
+    assert not times[0] in test_range
+    assert times[1] in test_range
+    assert times[3] in test_range
 
-    assert not datetime.datetime(
-        year=2018, month=3, day=1, hour=3, minute=10, second=3) in test_range
+    assert test2 in test_range
+    assert test_range not in test2
+    assert test2 in test2
+    assert test3 not in test_range
 
-    # Lower edge
-    assert t1 in test_range
+    # CompoundTimeRange
 
-    # Upper edge
-    assert t2 in test_range
+    compound_test = CompoundTimeRange([test_range])
+    # Should be in neither
+    test_range2 = TimeRange(times[4], times[5])
+    # Should be in compound_range2 but not 1
+    test_range3 = TimeRange(times[2], times[4])
+    compound_test2 = CompoundTimeRange([test_range, TimeRange(times[3], times[4])])
 
-def test_timerange_minus():
+    assert compound_test in compound_test2
+    assert times[2] in compound_test
+    assert times[2] in compound_test2
+    assert test_range2 not in compound_test
+    assert test_range2 not in compound_test2
+    assert test_range3 not in compound_test
+    assert test_range3 in compound_test2
+
+
+def test_equality(times):
+    test1 = TimeRange(times[1], times[2])
+    test2 = TimeRange(times[1], times[2])
+    test3 = TimeRange(times[1], times[3])
+
+    with pytest.raises(TypeError):
+        test1 == "stonesoup"
+
+    assert test1 == test2
+    assert test2 == test1
+    assert test3 != test1 and test1 != test3
+
+    ctest1 = CompoundTimeRange([test1, test3])
+    ctest2 = CompoundTimeRange([TimeRange(times[1], times[3])])
+
+    with pytest.raises(TypeError):
+        ctest2 == "Stonesoup is the best!"
+
+    assert ctest1 == ctest2
+    assert ctest2 == ctest1
+    ctest2.add(TimeRange(times[3], times[4]))
+    assert ctest1 != ctest2
+    assert ctest2 != ctest1
+
+    assert CompoundTimeRange() == CompoundTimeRange()
+    assert ctest1 != CompoundTimeRange()
+    assert CompoundTimeRange() != ctest1
+
+
+def test_minus(times):
     # Test the minus function
-    test1 = TimeRange()
+    test1 = TimeRange(times[1], times[3])
+    test2 = TimeRange(times[1], times[2])
+    test3 = TimeRange(times[2], times[3])
+    test4 = TimeRange(times[4], times[5])
+
+    with pytest.raises(TypeError):
+        test1.minus(15)
+
+    assert test1.minus(test2) == test3
+    assert test1.minus(None) == test1
+    assert test2.minus(test1) is None
+
+    ctest1 = CompoundTimeRange([test2, test4])
+    ctest2 = CompoundTimeRange([test1, test2])
+    ctest3 = CompoundTimeRange([test4])
+
+    with pytest.raises(TypeError):
+        ctest1.minus(15)
+
+    assert ctest1.minus(ctest2) == ctest3
+    assert ctest1.minus(ctest1) == CompoundTimeRange()
+    assert ctest3.minus(ctest1) == CompoundTimeRange()
+
+    assert test1.minus(ctest1) == TimeRange(times[2], times[3])
+    assert test4.minus(ctest2) == test4
+    assert ctest1.minus(test2) == ctest3
+
+
+def test_overlap(times):
+    test1 = TimeRange(times[1], times[3])
+    test2 = TimeRange(times[1], times[2])
+    test3 = TimeRange(times[4], times[5])
+
+    ctest1 = CompoundTimeRange([test2, test3])
+    ctest2 = CompoundTimeRange([test1, test2])
+
+    with pytest.raises(TypeError):
+        test2.overlap(ctest1)
+
+    assert test1.overlap(test1) == test1
+    assert test1.overlap(None) is None
+    assert test1.overlap(test2) == test2
+    assert test2.overlap(test1) == test2
+    assert ctest1.overlap(None) is None
+    assert ctest1.overlap(test2) == CompoundTimeRange([test2])
+    assert ctest1.overlap(ctest2) == CompoundTimeRange([test2])
+    assert ctest1.overlap(ctest2) == ctest2.overlap(ctest1)
+
+
+def test_key_times(times):
+    test1 = CompoundTimeRange([TimeRange(times[0], times[1]),
+                               TimeRange(times[3], times[4])])
+    test2 = CompoundTimeRange([TimeRange(times[3], times[4]),
+                               TimeRange(times[0], times[1])])
+    test3 = CompoundTimeRange()
+    test4 = CompoundTimeRange([TimeRange(times[0], times[4])])
+
+    assert test1.key_times == [times[0], times[1], times[3], times[4]]
+    assert test2.key_times == [times[0], times[1], times[3], times[4]]
+    assert test3.key_times == []
+    assert test4.key_times == [times[0], times[4]]
+
+
+def test_remove_overlap(times):
+    test1_ro = CompoundTimeRange([TimeRange(times[0], times[1]),
+                                  TimeRange(times[3], times[4])])
+    test1_ro.remove_overlap()
+    test2_ro = CompoundTimeRange([TimeRange(times[3], times[4]),
+                                  TimeRange(times[0], times[4])])
+    test2_ro.remove_overlap()
+    test3_ro = CompoundTimeRange()
+    test3_ro.remove_overlap()
+
+    test1 = CompoundTimeRange([TimeRange(times[0], times[1]),
+                               TimeRange(times[3], times[4])])
+    test3 = CompoundTimeRange()
+    test4 = CompoundTimeRange([TimeRange(times[0], times[4])])
+
+    assert test1_ro == test1
+    assert test2_ro == test4
+    assert test3_ro == test3
+
+
+def test_fuse_components(times):
+    # Note this is called inside the __init__ method, but is tested here explicitly
+    test1 = CompoundTimeRange([TimeRange(times[1], times[2])]).fuse_components()
+    test2 = CompoundTimeRange([TimeRange(times[1], times[2]),
+                               TimeRange(times[2], times[4])]).fuse_components()
+    assert test1.time_ranges == {TimeRange(times[1], times[2])}
+    assert test2.time_ranges == {TimeRange(times[1], times[4])}
+
+def test_add(times):
+    test1 = CompoundTimeRange([TimeRange(times[1], times[2])])
+    test2 = CompoundTimeRange([TimeRange(times[0], times[1])])
+    test3 = CompoundTimeRange([TimeRange(times[0], times[2])])
+    test4 = CompoundTimeRange([TimeRange(times[0], times[2]),
+                               TimeRange(times[4], times[5])])
+    with pytest.raises(TypeError):
+        test1.add(True)
+    assert test1 != test2
+    test1_copy = test1
+    test1.add(None)
+    assert test1 == test1_copy
+    test1.add(test2)
+    assert test1 == test3
+    test3.add(TimeRange(times[4], times[5]))
+    assert test3 == test4
+
+def test_remove(times):
+    test1 = CompoundTimeRange([TimeRange(times[0], times[2]),
+                               TimeRange(times[4], times[5])])
+    with pytest.raises(TypeError):
+        test1.remove(0.4)
+    with pytest.raises(ValueError):
+        test1.remove(TimeRange(times[0], times[1]))
+
+    test1.remove(TimeRange(times[0], times[2]))
+    assert test1 == CompoundTimeRange([TimeRange(times[4], times[5])])

--- a/stonesoup/types/tests/test_time.py
+++ b/stonesoup/types/tests/test_time.py
@@ -111,6 +111,8 @@ def test_contains(times):
     assert test_range2 not in compound_test
     assert test_range2 not in compound_test2
     assert test_range3 not in compound_test
+    print("         \n       range3", test_range3, "test2", compound_test2)
+    print(compound_test2.overlap(test_range3))
     assert test_range3 in compound_test2
 
 
@@ -119,8 +121,7 @@ def test_equality(times):
     test2 = TimeRange(times[1], times[2])
     test3 = TimeRange(times[1], times[3])
 
-    with pytest.raises(TypeError):
-        test1 == "stonesoup"
+    assert test1 != "stonesoup"
 
     assert test1 == test2
     assert test2 == test1
@@ -129,8 +130,7 @@ def test_equality(times):
     ctest1 = CompoundTimeRange([test1, test3])
     ctest2 = CompoundTimeRange([TimeRange(times[1], times[3])])
 
-    with pytest.raises(TypeError):
-        ctest2 == "Stonesoup is the best!"
+    assert ctest2 != "Stonesoup is the best!"
 
     assert ctest1 == ctest2
     assert ctest2 == ctest1
@@ -181,8 +181,7 @@ def test_overlap(times):
     ctest1 = CompoundTimeRange([test2, test3])
     ctest2 = CompoundTimeRange([test1, test2])
 
-    with pytest.raises(TypeError):
-        test2.overlap(ctest1)
+    assert test2.overlap(ctest1) == ctest1.overlap(test2)
 
     assert test1.overlap(test1) == test1
     assert test1.overlap(None) is None
@@ -230,11 +229,13 @@ def test_remove_overlap(times):
 
 def test_fuse_components(times):
     # Note this is called inside the __init__ method, but is tested here explicitly
-    test1 = CompoundTimeRange([TimeRange(times[1], times[2])])._fuse_components()
+    test1 = CompoundTimeRange([TimeRange(times[1], times[2])])
+    test1._fuse_components()
     test2 = CompoundTimeRange([TimeRange(times[1], times[2]),
-                               TimeRange(times[2], times[4])])._fuse_components()
-    assert test1.time_ranges == {TimeRange(times[1], times[2])}
-    assert test2.time_ranges == {TimeRange(times[1], times[4])}
+                               TimeRange(times[2], times[4])])
+    test2._fuse_components()
+    assert test1 == CompoundTimeRange([TimeRange(times[1], times[2])])
+    assert test2 == CompoundTimeRange([TimeRange(times[1], times[4])])
 
 def test_add(times):
     test1 = CompoundTimeRange([TimeRange(times[1], times[2])])

--- a/stonesoup/types/tests/test_time.py
+++ b/stonesoup/types/tests/test_time.py
@@ -28,15 +28,15 @@ def test_timerange(times):
 
     # Without start time
     with pytest.raises(TypeError):
-        TimeRange(start_timestamp=times[1])
+        TimeRange(start=times[1])
 
     # Without end time
     with pytest.raises(TypeError):
-        TimeRange(end_timestamp=times[3])
+        TimeRange(end=times[3])
 
     # Test an error is caught when end is after start
     with pytest.raises(ValueError):
-        TimeRange(start_timestamp=times[3], end_timestamp=times[1])
+        TimeRange(start=times[3], end=times[1])
 
     # Test with wrong types for time_ranges
     with pytest.raises(TypeError):
@@ -44,7 +44,7 @@ def test_timerange(times):
     with pytest.raises(TypeError):
         CompoundTimeRange([times[1], times[3]])
 
-    test_range = TimeRange(start_timestamp=times[1], end_timestamp=times[3])
+    test_range = TimeRange(start=times[1], end=times[3])
 
     test_compound = CompoundTimeRange()
 
@@ -64,13 +64,13 @@ def test_duration(times):
     # Test that duration is calculated properly
 
     # TimeRange
-    test_range = TimeRange(start_timestamp=times[1], end_timestamp=times[3])
+    test_range = TimeRange(start=times[1], end=times[3])
 
     # CompoundTimeRange
 
     # times[2] is inside of [1] and [3], so should be equivalent to a TimeRange(times[1], times[4])
-    test_range2 = CompoundTimeRange([TimeRange(start_timestamp=times[1], end_timestamp=times[3]),
-                                    TimeRange(start_timestamp=times[2], end_timestamp=times[4])])
+    test_range2 = CompoundTimeRange([TimeRange(start=times[1], end=times[3]),
+                                     TimeRange(start=times[2], end=times[4])])
 
     assert test_range.duration == datetime.timedelta(seconds=3726)
     assert test_range2.duration == datetime.timedelta(seconds=31539726)
@@ -79,7 +79,7 @@ def test_duration(times):
 def test_contains(times):
     # Test that timestamps are correctly determined to be in the range
 
-    test_range = TimeRange(start_timestamp=times[1], end_timestamp=times[3])
+    test_range = TimeRange(start=times[1], end=times[3])
     test2 = TimeRange(times[1], times[2])
     test3 = TimeRange(times[1], times[4])
 

--- a/stonesoup/types/time.py
+++ b/stonesoup/types/time.py
@@ -78,7 +78,7 @@ class TimeRange(Interval):
         Returns
         -------
         TimeRange
-            This instance less the overlap
+            This instance less the overlap with the other time_range
         """
         if time_range is None:
             return copy.copy(self)
@@ -87,7 +87,7 @@ class TimeRange(Interval):
         if isinstance(time_range, CompoundTimeRange):
             ans = self
             for t_range in time_range.time_ranges:
-                ans = ans - t_range
+                ans -= t_range
                 if not ans:
                     return None
             return ans

--- a/stonesoup/types/time.py
+++ b/stonesoup/types/time.py
@@ -1,5 +1,6 @@
 import datetime
 from itertools import combinations, permutations
+from typing import List
 
 from ..base import Property
 from .base import Type
@@ -151,7 +152,7 @@ class CompoundTimeRange(Type):
 
     A container class representing one or more :class:`TimeRange` objects together
     """
-    time_ranges: list[TimeRange] = Property(doc="List of TimeRange objects.  Can be empty",
+    time_ranges: List[TimeRange] = Property(doc="List of TimeRange objects.  Can be empty",
                                             default=None)
 
     def __init__(self, *args, **kwargs):

--- a/stonesoup/types/time.py
+++ b/stonesoup/types/time.py
@@ -1,4 +1,5 @@
 import datetime
+from typing import Union
 
 from ..base import Property
 from .base import Type
@@ -35,6 +36,11 @@ class TimeRange(Type):
 
         return self.end_timestamp - self.start_timestamp
 
+    @property
+    def key_times(self):
+        """Returns the start and end timestamp in a list"""
+        return [self.start_timestamp, self.end_timestamp]
+
     def __contains__(self, timestamp):
         """Checks if timestamp is within range
 
@@ -51,3 +57,107 @@ class TimeRange(Type):
         """
 
         return self.start_timestamp <= timestamp <= self.end_timestamp
+
+    def overlap(self, time_range):
+        """Finds the intersection between this instance and another :class:`~.TimeRange`
+
+        Parameters
+        ----------
+        time_range: TimeRange
+
+        Returns
+        -------
+        TimeRange
+            The times contained by both this and time_range
+        """
+        start_timestamp = max(self.start_timestamp, time_range.start_timestamp)
+        end_timestamp = min(self.end_timestamp, time_range.end_timestamp)
+        if end_timestamp > start_timestamp:
+            return TimeRange(start_timestamp, end_timestamp)
+        else:
+            return None
+
+
+class CompoundTimeRange(Type):
+    """CompoundTimeRange type
+
+    A container class representing one or more :class:`TimeRange` objects together
+    """
+    time_ranges: list[TimeRange] = Property(doc="List of TimeRange objects", default=None)
+
+    def __init__(self, time_ranges, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if not time_ranges:
+            self.time_ranges = []
+        self.check_overlap()
+
+    def check_overlap(self):
+        """Returns a :class:`~.CompoundTimeRange` with overlap removed"""
+        overlap_check = CompoundTimeRange()
+        for time_range in self.time_ranges:
+            overlap_check.add(time_range.minus(overlap_check.overlap(time_range)))
+        self.time_ranges = overlap_check
+
+    def add(self, time_range):
+        """Add a :class:`~.TimeRange` or :class:`~.CompoundTimeRange` object to `time_ranges`"""
+        if time_range is None:
+            return
+        if isinstance(time_range, CompoundTimeRange):
+            for component in time_range.time_ranges:
+                self.add(component)
+        else:
+            self.time_ranges.append(time_range)
+        self.check_overlap()
+
+    def __contains__(self, time):
+        """Checks if timestamp or is within range
+
+        Parameters
+        ----------
+        time : Union[datetime.datetime, TimeRange, CompoundTimeRange]
+            Time stamp or range to check if contained within this instance
+
+        Returns
+        -------
+        bool
+            `True` if time is fully contained within this instance
+        """
+
+        if isinstance(time, datetime):
+            for component in self.time_ranges:
+                if datetime in component:
+                    return True
+            return False
+        elif isinstance(time, TimeRange) or isinstance(time, CompoundTimeRange):
+            return True if self.overlap(time) == time else False
+        else:
+            raise TypeError("Supplied parameter must be an instance of either "
+                            "datetime, TimeRange, or CompoundTimeRange")
+
+    def overlap(self, time_range):
+        """Finds the intersection between this instance and another time range
+
+        In the case of an input :class:`~.CompoundTimeRange` this  is done recursively.
+
+        Parameters
+        ----------
+        time_range: Union[TimeRange, CompoundTimeRange]
+
+        Returns
+        -------
+        CompoundTimeRange
+            The times contained by both this and time_range
+        """
+        total_overlap = CompoundTimeRange()
+        if isinstance(time_range, CompoundTimeRange):
+            for component in time_range.time_ranges:
+                total_overlap.add(self.overlap(component))
+            return total_overlap
+        elif isinstance(time_range, TimeRange):
+            for component in self.time_ranges:
+                total_overlap.add(component.overlap(time_range))
+            return total_overlap
+        else:
+            raise TypeError("Supplied parameter must be an instance of either "
+                            "TimeRange, or CompoundTimeRange")
+

--- a/stonesoup/types/time.py
+++ b/stonesoup/types/time.py
@@ -131,7 +131,7 @@ class TimeRange(Type):
         Returns
         -------
         TimeRange
-            The times contained by both this and time_range
+            The times contained by both this and `time_range`
         """
         if time_range is None:
             return None
@@ -150,7 +150,7 @@ class TimeRange(Type):
 class CompoundTimeRange(Type):
     """CompoundTimeRange type
 
-    A container class representing one or more :class:`TimeRange` objects together
+    A container class representing one or more :class:`~.TimeRange` objects together
     """
     time_ranges: List[TimeRange] = Property(doc="List of TimeRange objects.  Can be empty",
                                             default=None)
@@ -187,7 +187,7 @@ class CompoundTimeRange(Type):
         return sorted(key_times)
 
     def _remove_overlap(self):
-        """Removes overlap between components of time_ranges"""
+        """Removes overlap between components of `time_ranges`"""
         if len(self.time_ranges) in {0, 1}:
             return
         if all([component.overlap(component2) is None for (component, component2) in
@@ -210,7 +210,7 @@ class CompoundTimeRange(Type):
                 self._fuse_components()
 
     def add(self, time_range):
-        """Add a :class:`~.TimeRange` or :class:`~.CompoundTimeRange` object to `time_ranges`"""
+        """Add a :class:`~.TimeRange` or :class:`~.CompoundTimeRange` object to `time_ranges`."""
         if time_range is None:
             return
         if isinstance(time_range, CompoundTimeRange):
@@ -224,7 +224,7 @@ class CompoundTimeRange(Type):
         self._fuse_components()
 
     def remove(self, time_range):
-        """Remove a :class:`.~TimeRange` object from the time ranges.
+        """Removes a :class:`.~TimeRange` object from the time ranges.
         It must be a member of self.time_ranges"""
         if not isinstance(time_range, TimeRange):
             raise TypeError("Supplied parameter must be a TimeRange object")

--- a/stonesoup/types/time.py
+++ b/stonesoup/types/time.py
@@ -185,8 +185,9 @@ class CompoundTimeRange(Intervals):
             return
         overlap_check = CompoundTimeRange()
         for time_range in self.time_ranges:
-            overlap_check.add(time_range - overlap_check & time_range)
-        self.time_ranges = overlap_check.time_ranges
+            if time_range - overlap_check:
+                overlap_check.add(time_range - overlap_check & time_range)
+        self.intervals = copy.copy(overlap_check.time_ranges)
 
     def _fuse_components(self):
         """Fuses two time ranges [a,b], [b,c] into [a,c] for all such pairs in this instance"""

--- a/stonesoup/types/time.py
+++ b/stonesoup/types/time.py
@@ -183,7 +183,7 @@ class CompoundTimeRange(Type):
         for component in self.time_ranges:
             key_times.add(component.start_timestamp)
             key_times.add(component.end_timestamp)
-        return sorted(list(key_times))
+        return sorted(key_times)
 
     def _remove_overlap(self):
         """Removes overlap between components of time_ranges"""

--- a/stonesoup/types/time.py
+++ b/stonesoup/types/time.py
@@ -36,11 +36,6 @@ class TimeRange(Type):
 
         return self.end_timestamp - self.start_timestamp
 
-    @property
-    def key_times(self):
-        """Returns the start and end timestamp in a list"""
-        return [self.start_timestamp, self.end_timestamp]
-
     def __contains__(self, timestamp):
         """Checks if timestamp is within range
 
@@ -90,6 +85,22 @@ class CompoundTimeRange(Type):
         if not time_ranges:
             self.time_ranges = []
         self.check_overlap()
+
+    @property
+    def duration(self):
+        """Duration of the time range"""
+        total_duration = 0
+        for component in self.time_ranges:
+            total_duration += component.duration
+
+    @property
+    def key_times(self):
+        """Returns all timestamps at which a component starts or ends"""
+        key_times = set()
+        for component in self.time_ranges:
+            key_times.add(component.start_timestamp)
+            key_times.add(component.end_timestamp)
+        return list(key_times).sort()
 
     def check_overlap(self):
         """Returns a :class:`~.CompoundTimeRange` with overlap removed"""

--- a/stonesoup/types/time.py
+++ b/stonesoup/types/time.py
@@ -1,5 +1,4 @@
 import datetime
-from typing import Union
 from itertools import combinations, permutations
 
 from ..base import Property
@@ -36,6 +35,11 @@ class TimeRange(Type):
         """Duration of the time range"""
 
         return self.end_timestamp - self.start_timestamp
+
+    @property
+    def key_times(self):
+        """Times the TimeRange begins and ends"""
+        return [self.start_timestamp, self.end_timestamp]
 
     def __contains__(self, time):
         """Checks if timestamp is within range
@@ -325,4 +329,3 @@ class CompoundTimeRange(Type):
         else:
             raise TypeError("Supplied parameter must be an instance of either "
                             "TimeRange, or CompoundTimeRange")
-

--- a/stonesoup/types/time.py
+++ b/stonesoup/types/time.py
@@ -84,7 +84,7 @@ class CompoundTimeRange(Type):
         super().__init__(*args, **kwargs)
         if not time_ranges:
             self.time_ranges = []
-        self.check_overlap()
+        self.remove_overlap()
 
     @property
     def duration(self):
@@ -102,7 +102,7 @@ class CompoundTimeRange(Type):
             key_times.add(component.end_timestamp)
         return list(key_times).sort()
 
-    def check_overlap(self):
+    def remove_overlap(self):
         """Returns a :class:`~.CompoundTimeRange` with overlap removed"""
         overlap_check = CompoundTimeRange()
         for time_range in self.time_ranges:
@@ -118,7 +118,7 @@ class CompoundTimeRange(Type):
                 self.add(component)
         else:
             self.time_ranges.append(time_range)
-        self.check_overlap()
+        self.remove_overlap()
 
     def __contains__(self, time):
         """Checks if timestamp or is within range


### PR DESCRIPTION
Created a new `CompoundTimeRange` class, a container class for `TimeRange`.  This allows much greater flexibility for association objects, for example to associate two objects between the ranges [a,b] and [c,d] in a single `TimeRangeAssociation`.  

New additions were made to the `AssociationSet` class mainly to reflect these changes.  

The last main change was the new `multidimensional_deconfliction` algorithm.  This is a very rudimentary but hopefully functional algorithm to ensure an `AssociationSet` has no associations that conflict - we can't have two different associations involving the same object at any given time.  The algorithm is very basic, simply using the total length of an association as a proxy for strength of association, but I believe the groundwork has been laid to quickly implement something more advanced much more easily now.  