### PR TITLE
test_ess_inequality fails sometimes

### DIFF
--- a/stonesoup/resampler/tests/test_particle.py
+++ b/stonesoup/resampler/tests/test_particle.py
@@ -74,7 +74,7 @@ def test_ess_inequality():
                  for i in range(10)]
     particles = ParticleState(None, particle_list=particles)
 
-    resampler1 = ESSResampler(3025/385)  # This resampler should not resample
+    resampler1 = ESSResampler()  # This resampler should not resample
     resampler2 = ESSResampler(3025/385 + 0.01)  # This resampler should resample
 
     new_particles1 = resampler1.resample(particles)


### PR DESCRIPTION
test_ess_inequality will fail on some occasions due to floating point issues (you're essentially testing two floats for equality, which is never a good idea). Lowering the threshold to the default allows the test to pass.