### PR TITLE
Enable use of kDTree with Gaussian Mixture Hypothesiser

### DIFF
--- a/stonesoup/hypothesiser/tests/test_gaussianmixture.py
+++ b/stonesoup/hypothesiser/tests/test_gaussianmixture.py
@@ -2,9 +2,10 @@
 import datetime
 
 import numpy as np
+import pytest
 
 from ..distance import DistanceHypothesiser
-from ..gaussianmixture import GaussianMixtureHypothesiser
+from ..gaussianmixture import GaussianMixtureHypothesiser, GaussianMixtureKDTreeHypothesiser
 from ...types.detection import Detection
 from ...types.state import WeightedGaussianState
 from ...types.hypothesis import SingleHypothesis
@@ -13,7 +14,25 @@ from ...types.mixture import GaussianMixture
 from ... import measures
 
 
-def test_gm_ordered_by_measurement(predictor, updater):
+@pytest.fixture(params=(GaussianMixtureHypothesiser, GaussianMixtureKDTreeHypothesiser))
+def hypothesiser(updater, predictor, request):
+    measure = measures.Mahalanobis()
+    hypothesiser = DistanceHypothesiser(
+        predictor, updater, measure=measure, missed_distance=20)
+    kwargs = dict(
+        hypothesiser=hypothesiser,
+        order_by_detection=True
+    )
+    if request.param is GaussianMixtureKDTreeHypothesiser:
+        kwargs.update(
+            predictor=predictor,
+            updater=updater,
+            max_distance_covariance_multiplier=1,
+        )
+    return request.param(**kwargs)
+
+
+def test_gm_ordered_by_measurement(hypothesiser):
 
     timestamp = datetime.datetime.now()
     gaussian_mixture = GaussianMixture(
@@ -26,11 +45,6 @@ def test_gm_ordered_by_measurement(predictor, updater):
     detection2 = Detection(np.array([[6.2]]),
                            timestamp=timestamp+datetime.timedelta(seconds=1))
     detections = {detection1, detection2}
-    measure = measures.Mahalanobis()
-    hypothesiser = DistanceHypothesiser(
-        predictor, updater, measure=measure, missed_distance=20)
-    hypothesiser = GaussianMixtureHypothesiser(hypothesiser=hypothesiser,
-                                               order_by_detection=True)
 
     hypotheses = hypothesiser.hypothesise(gaussian_mixture,
                                           detections, timestamp)
@@ -42,8 +56,12 @@ def test_gm_ordered_by_measurement(predictor, updater):
                for multi_hyp in hypotheses for hyp in multi_hyp)
     # Last element is the miss detected components
     assert len(hypotheses) == 3
-    assert len(hypotheses[0]) == 2
-    assert len(hypotheses[1]) == 2
+    if isinstance(hypothesiser, GaussianMixtureKDTreeHypothesiser):
+        assert len(hypotheses[0]) == 1
+        assert len(hypotheses[1]) == 1
+    else:
+        assert len(hypotheses[0]) == 2
+        assert len(hypotheses[1]) == 2
 
     # each SingleHypothesis has a distance attribute
     assert all(hyp.distance >= 0
@@ -51,16 +69,18 @@ def test_gm_ordered_by_measurement(predictor, updater):
 
     # sanity-check the values returned by the hypothesiser
     assert hypotheses[0][0].distance < 10
-    assert hypotheses[0][1].distance > 0
     assert hypotheses[1][0].distance > 0
-    assert hypotheses[1][1].distance < 10
+    if not isinstance(hypothesiser, GaussianMixtureKDTreeHypothesiser):
+        assert hypotheses[0][1].distance > 0
+        assert hypotheses[1][1].distance < 10
 
     # Check the measurements are the same
-    assert hypotheses[0][0].measurement == hypotheses[0][1].measurement
-    assert hypotheses[1][0].measurement == hypotheses[1][1].measurement
+    assert len(set(hypothesis.measurement for hypothesis in hypotheses[0])) == 1
+    assert len(set(hypothesis.measurement for hypothesis in hypotheses[1])) == 1
 
 
-def test_gm_ordered_by_component(predictor, updater):
+def test_gm_ordered_by_component(hypothesiser):
+    hypothesiser.order_by_detection = False
 
     timestamp = datetime.datetime.now()
     gaussian_mixture = GaussianMixture(
@@ -73,11 +93,6 @@ def test_gm_ordered_by_component(predictor, updater):
     detection2 = Detection(np.array([[6.2]]),
                            timestamp=timestamp+datetime.timedelta(seconds=1))
     detections = {detection1, detection2}
-    measure = measures.Mahalanobis()
-    hypothesiser = DistanceHypothesiser(
-        predictor, updater, measure=measure, missed_distance=20)
-    hypothesiser = GaussianMixtureHypothesiser(hypothesiser=hypothesiser,
-                                               order_by_detection=False)
 
     hypotheses = hypothesiser.hypothesise(gaussian_mixture,
                                           detections, timestamp)
@@ -90,8 +105,12 @@ def test_gm_ordered_by_component(predictor, updater):
                for multi_hyp in hypotheses for hyp in multi_hyp)
     assert len(hypotheses) == 2
     # Last element in each array is the miss detected component
-    assert len(hypotheses[0]) == 3
-    assert len(hypotheses[1]) == 3
+    if isinstance(hypothesiser, GaussianMixtureKDTreeHypothesiser):
+        assert len(hypotheses[0]) == 2
+        assert len(hypotheses[1]) == 2
+    else:
+        assert len(hypotheses[0]) == 3
+        assert len(hypotheses[1]) == 3
 
     # each SingleHypothesis has a distance attribute
     assert all(hyp.distance >= 0
@@ -99,12 +118,14 @@ def test_gm_ordered_by_component(predictor, updater):
 
     # sanity-check the values returned by the hypothesiser
     assert hypotheses[0][0].distance < 10
-    assert hypotheses[0][1].distance > 0
     assert hypotheses[1][0].distance > 0
-    assert hypotheses[1][1].distance < 10
+    if not isinstance(hypothesiser, GaussianMixtureKDTreeHypothesiser):
+        assert hypotheses[0][1].distance > 0
+        assert hypotheses[1][1].distance < 10
 
     # Check the components are the same
     assert hypotheses[0][0].prediction.state_vector == np.array([[1.3]])
-    assert hypotheses[0][1].prediction.state_vector == np.array([[1.3]])
     assert hypotheses[1][0].prediction.state_vector == np.array([[6]])
-    assert hypotheses[1][1].prediction.state_vector == np.array([[6]])
+    if not isinstance(hypothesiser, GaussianMixtureKDTreeHypothesiser):
+        assert hypotheses[0][1].prediction.state_vector == np.array([[1.3]])
+        assert hypotheses[1][1].prediction.state_vector == np.array([[6]])


### PR DESCRIPTION
This enables use of kDTree with Gaussian Mixture Hypothesiser, adds ability to set tree search distance based on track covariance and fixes existing tree data associator tests.