### PR TITLE
Remove `hasattr` in Measures to avoid calling `mean` twice

### DIFF
--- a/stonesoup/measures.py
+++ b/stonesoup/measures.py
@@ -82,14 +82,8 @@ class Euclidean(Measure):
 
         """
         # Calculate Euclidean distance between two state
-        if hasattr(state1, 'mean'):
-            state_vector1 = state1.mean
-        else:
-            state_vector1 = state1.state_vector
-        if hasattr(state2, 'mean'):
-            state_vector2 = state2.mean
-        else:
-            state_vector2 = state2.state_vector
+        state_vector1 = getattr(state1, 'mean', state1.state_vector)
+        state_vector2 = getattr(state2, 'mean', state2.state_vector)
 
         if self.mapping is not None:
             return distance.euclidean(state_vector1[self.mapping, 0],
@@ -136,14 +130,8 @@ class EuclideanWeighted(Measure):
             :class:`~.State` objects
 
         """
-        if hasattr(state1, 'mean'):
-            state_vector1 = state1.mean
-        else:
-            state_vector1 = state1.state_vector
-        if hasattr(state2, 'mean'):
-            state_vector2 = state2.mean
-        else:
-            state_vector2 = state2.state_vector
+        state_vector1 = getattr(state1, 'mean', state1.state_vector)
+        state_vector2 = getattr(state2, 'mean', state2.state_vector)
 
         if self.mapping is not None:
             return distance.euclidean(state_vector1[self.mapping, 0],
@@ -185,14 +173,8 @@ class Mahalanobis(Measure):
             objects
 
         """
-        if hasattr(state1, 'mean'):
-            state_vector1 = state1.mean
-        else:
-            state_vector1 = state1.state_vector
-        if hasattr(state2, 'mean'):
-            state_vector2 = state2.mean
-        else:
-            state_vector2 = state2.state_vector
+        state_vector1 = getattr(state1, 'mean', state1.state_vector)
+        state_vector2 = getattr(state2, 'mean', state2.state_vector)
 
         if self.mapping is not None:
             u = state_vector1[self.mapping, 0]


### PR DESCRIPTION
This is in particular an issue with Particle States as calculating the mean can be costly.