### PR TITLE
Update references and documentation of Updater classes

### DIFF
--- a/stonesoup/updater/chernoff.py
+++ b/stonesoup/updater/chernoff.py
@@ -9,12 +9,12 @@ from ..types.update import Update
 
 class ChernoffUpdater(Updater):
     r"""A class which performs state updates using the Chernoff fusion rule. In this context,
-    measurements come in the form of states with a mean and covariance instead of just the
-    traditional mean. The measurements are expected to come as :class:`~.GaussianDetection`
-    objects.
+    measurements come in the form of states with a mean and covariance (compared to traditional
+    measurements which contain solely a mean). The measurements are expected to come as
+    :class:`~.GaussianDetection` objects.
 
 
-    The Chernoff fusion rule is written as
+    The Chernoff fusion rule is written as [#]_
 
     .. math::
            p_{\omega}(x_{k}) = \frac{p_{1}(x_{k})^{\omega}p_{2}(x_{k})^{1-\omega}}
@@ -24,11 +24,12 @@ class ChernoffUpdater(Updater):
     using an optimization algorithm.
 
     In situations where :math:`p_1(x)` and :math:`p_2(x)` are multivariate Gaussian distributions,
-    the above formula is equal to the Covariance Intersection Algorithm from Julier and Uhlmann.
+    the above formula is equal to the Covariance Intersection Algorithm from Julier et al [#]_.
     Let :math:`(a,A)` and :math:`(b,B)` be the means and covariances of the measurement and
     prediction respectively. The Covariance Intersection Algorithm was reformulated for use in
-    Bayesian state estimation by Clark et al, yielding the update formulas for the covariance,
-    mean, and innovation:
+    Bayesian state estimation by Clark and Campbell [#]_, yielding formulas for the updated
+    covariance and mean, :math:`D` and :math:`d`, and the innovation covariance matrix, :math:`V`,
+    as follows:
 
     .. math::
 
@@ -45,23 +46,33 @@ class ChernoffUpdater(Updater):
             \mathcal{V}(\gamma) = \left\{ (a,A) : (a-b)^T V^{-1} (a-b) \leq \gamma \right\}
 
 
-    Note: If you have tracks that you would like to use as measurements for this updater, the
+    The specifics for implementing the Covariance Intersection Algorithm in several popular
+    multi-target tracking algorithms was expanded upon by Clark et al [#]_. The work includes a
+    discussion of Stone Soup and can be used to apply this class to a tracking algorithm of
+    choice.
+
+    Note
+    ----
+    If you have tracks that you would like to use as measurements for this updater, the
     :class:`~.Tracks2GaussianDetectionFeeder` class can be used to convert the tracks to the
     appropriate format.
 
     References
     ----------
-    [1] Hurley, M. B., “An information theoretic justification for covariance intersection and its
-    generalization,” in [Proceedings of the Fifth International Conference on Information Fusion.
-    FUSION 2002.(IEEE Cat. No. 02EX5997) ], 1, 505–511, IEEE (2002).
-    https://ieeexplore.ieee.org/document/1021196.
-    [2] Julier, S., Uhlmann, J., and Durrant-Whyte, H. F., “A new method for the nonlinear
-    transformation of means and covariances in filters and estimators,” IEEE Transactions on
-    automatic control 45(3), 477–482 (2000).
-    https://ieeexplore.ieee.org/abstract/document/847726/similar#similar.
-    [3] Clark, D. E. and Campbell, M. A., “Integrating covariance intersection into Bayesian
-    multi-target tracking filters,” preprint on TechRxiv. submitted to IEEE Transactions on
-    Aerospace and Electronic Systems .
+    .. [#] Hurley, M., “An information theoretic justification for covariance intersection and its
+       generalization,” in [Proceedings of the Fifth International Conference on Information Fusion.
+       FUSION 2002.(IEEE Cat. No. 02EX5997) ], 1, 505–511, IEEE (2002).
+       https://ieeexplore.ieee.org/document/1021196.
+    .. [#] Julier, S., Uhlmann, J., and Durrant-Whyte, H., “A new method for the nonlinear
+       transformation of means and covariances in filters and estimators,” IEEE Transactions on
+       automatic control 45(3), 477–482 (2000).
+       https://ieeexplore.ieee.org/abstract/document/847726/similar#similar.
+    .. [#] Clark, D. and Campbell, M., “Integrating covariance intersection into Bayesian
+       multi-target tracking filters,” preprint on TechRxiv. submitted to IEEE Transactions on
+       Aerospace and Electronic Systems.
+    .. [#] Clark, D. and Hunter, E. and Balaji, B. and O'Rourke, S., “Centralized multi-sensor
+       multi-target data fusion with tracks as measurements,” to be submitted to SPIE Defense and
+       Security Symposium 2023.
     """
 
     omega: float = Property(
@@ -69,10 +80,23 @@ class ChernoffUpdater(Updater):
         doc="A weighting parameter in the range :math:`(0,1]`")
 
     def predict_measurement(self, predicted_state, measurement_model=None,  **kwargs):
-        '''
-        This function predicts the measurement in situations where the predicted state consists
+        r"""
+        This function predicts the measurement of a state in situations where measurements consist
         of a covariance and state vector.
-        '''
+
+        Parameters
+        ----------
+        predicted_state : :class:`~.State`
+            The predicted state :math:`\mathbf{x}_{k|k-1}`
+        measurement_model : :class:`~.MeasurementModel`
+            The measurement model. If omitted, the updater will use the model that was specified
+            on initialization.
+
+        Returns
+        -------
+        : :class:`~.MeasurementPrediction`
+            The measurement prediction
+        """
 
         measurement_model = self._check_measurement_model(measurement_model)
 
@@ -91,9 +115,25 @@ class ChernoffUpdater(Updater):
                                                 cross_covar=meas_cross_cov)
 
     def update(self, hypothesis, force_symmetric_covariance=False, **kwargs):
-        '''
-        Given a hypothesis, calculate the posterior mean and covariance
-        '''
+        r"""
+        Given a hypothesis, calculate the posterior mean and covariance.
+
+        Parameters
+        ----------
+        hypothesis : :class:`~.Hypothesis`
+            Hypothesis with the predicted state and the actual/associated measurement which should
+            be used for updating. If the hypothesis does not contain a measurement prediction, one
+            will be calculated.
+
+        force_symmetric_covariance: bool
+            A flag to force the output covariance matrix to be symmetric by way of a simple
+            geometric combination of the matrix and transpose. Default is False.
+
+        Returns
+        -------
+        : :class:`~.Update`
+            The state posterior, saved in a generic :class:`~.Update` object.
+        """
 
         # Get the predicted state out of the hypothesis. These are 'B' and 'b', the
         # covariance and mean of the predicted Gaussian

--- a/stonesoup/updater/chernoff.py
+++ b/stonesoup/updater/chernoff.py
@@ -60,8 +60,8 @@ class ChernoffUpdater(Updater):
     References
     ----------
     .. [#] Hurley, M., “An information theoretic justification for covariance intersection and its
-       generalization,” in [Proceedings of the Fifth International Conference on Information Fusion.
-       FUSION 2002.(IEEE Cat. No. 02EX5997) ], 1, 505–511, IEEE (2002).
+       generalization,” in [Proceedings of the Fifth International Conference on Information
+       Fusion. FUSION 2002.(IEEE Cat. No. 02EX5997) ], 1, 505–511, IEEE (2002).
        https://ieeexplore.ieee.org/document/1021196.
     .. [#] Julier, S., Uhlmann, J., and Durrant-Whyte, H., “A new method for the nonlinear
        transformation of means and covariances in filters and estimators,” IEEE Transactions on
@@ -86,7 +86,7 @@ class ChernoffUpdater(Updater):
 
         Parameters
         ----------
-        predicted_state : :class:`~.State`
+        predicted_state : :class:`~.GaussianState`
             The predicted state :math:`\mathbf{x}_{k|k-1}`
         measurement_model : :class:`~.MeasurementModel`
             The measurement model. If omitted, the updater will use the model that was specified

--- a/stonesoup/updater/pointprocess.py
+++ b/stonesoup/updater/pointprocess.py
@@ -138,6 +138,10 @@ class PHDUpdater(PointProcessUpdater):
     [1] B.-N. Vo and W.-K. Ma, “The Gaussian Mixture Probability Hypothesis
     Density Filter,” Signal Processing,IEEE Transactions on, vol. 54, no. 11,
     pp. 4091–4104, 2006. https://ieeexplore.ieee.org/document/1710358.
+
+    [2] D. E. Clark, K. Panta and B. Vo, "The GM-PHD Filter Multiple Target Tracker," 2006 9th
+    International Conference on Information Fusion, 2006, pp. 1-8, doi: 10.1109/ICIF.2006.301809.
+    https://ieeexplore.ieee.org/document/4086095.
     """
     @staticmethod
     def _calculate_update_terms(updated_sum_list, hypotheses):


### PR DESCRIPTION
I have updated the documentation for the `ChernoffUpdater` class. This included editing the documentation to be clearer, and adding another reference. I also specified the parameters and returns of the class methods, following the style of the other update classes.

Second, I added another reference to the `PHDUpdater` class. This reference specifies the track management system that is used in the class, namely using track tags. This distinguishes it from the tree-based track management algorithms.