### PR TITLE
Reset NumPy random state when running Sphinx-Gallery examples

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -25,7 +25,7 @@ import re
 sys.path.insert(0, os.path.abspath('.'))
 sys.path.insert(0, os.path.abspath('../../'))
 
-from doc_extensions import gallery_scraper
+from doc_extensions import gallery_scraper, reset_numpy_random_seed
 from sphinx_gallery.sorting import FileNameSortKey
 
 # -- General configuration ------------------------------------------------
@@ -66,6 +66,8 @@ sphinx_gallery_conf = {
     'gallery_dirs': ['auto_tutorials', 'auto_examples', 'auto_demos'],
     'filename_pattern': re.escape(os.sep),
     'image_scrapers': (gallery_scraper(),),
+    'reset_modules': ('matplotlib', 'seaborn', reset_numpy_random_seed()),
+    'reset_modules_order': 'both',
     'abort_on_example_error': False,
     'reference_url': {'stonesoup': None},
     'remove_config_comments': True,

--- a/docs/source/doc_extensions.py
+++ b/docs/source/doc_extensions.py
@@ -187,3 +187,17 @@ class gallery_scraper():
                           for image in image_rsts]
             rst = HLIST_HEADER + ''.join(image_rsts)
         return rst
+
+
+class reset_numpy_random_seed:
+
+    def __init__(self):
+        self.state = None
+
+    def __call__(self, gallery_conf, fname, when):
+        import numpy as np
+        if when == 'before':
+            self.state = np.random.get_state()
+        elif when == 'after':
+            # Set state attribute back to `None`
+            self.state = np.random.set_state(self.state)

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(name='stonesoup',
       ],
       extras_require={
           'dev': [
-              'pytest-flake8', 'pytest-cov', 'pytest-remotedata',
+              'pytest-flake8', 'pytest-cov', 'pytest-remotedata', 'flake8<5',
               'Sphinx', 'sphinx_rtd_theme', 'sphinx-gallery>=0.10.1', 'pillow', 'folium',
           ],
           'video': ['ffmpeg-python', 'moviepy', 'opencv-python'],

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(name='stonesoup',
       extras_require={
           'dev': [
               'pytest-flake8', 'pytest-cov', 'pytest-remotedata',
-              'Sphinx', 'sphinx_rtd_theme', 'sphinx-gallery>=0.8', 'pillow', 'folium',
+              'Sphinx', 'sphinx_rtd_theme', 'sphinx-gallery>=0.10.1', 'pillow', 'folium',
           ],
           'video': ['ffmpeg-python', 'moviepy', 'opencv-python'],
           'tensorflow': ['tensorflow>=2.2.0'],


### PR DESCRIPTION
A number of examples modify the seed when run, and this seed is then carried on into further examples currently. This may unintentionally fix the output of later examples, in particular when running all examples (e.g. CircleCI tests and Read the Docs).