### PR TITLE
Add caching of mean and covar on ParticleState

### DIFF
--- a/stonesoup/types/_util.py
+++ b/stonesoup/types/_util.py
@@ -1,0 +1,60 @@
+"""
+Back port from Python 3.8: https://github.com/python/cpython/blob/4f100fe9f1c691145e3fa959ef324646e303cdf3/Lib/functools.py#L924-L976
+
+LICENSE: https://github.com/python/cpython/blob/4f100fe9f1c691145e3fa959ef324646e303cdf3/LICENSE
+Copyright (c) 2001-2022 Python Software Foundation. All rights reserved.
+"""
+# flake8: noqa
+# TODO: Remove once support for Python 3.7 dropped; replace with functools
+
+from threading import RLock
+
+_NOT_FOUND = object()
+
+
+class cached_property:
+    def __init__(self, func):
+        self.func = func
+        self.attrname = None
+        self.__doc__ = func.__doc__
+        self.lock = RLock()
+
+    def __set_name__(self, owner, name):
+        if self.attrname is None:
+            self.attrname = name
+        elif name != self.attrname:
+            raise TypeError(
+                "Cannot assign the same cached_property to two different names "
+                f"({self.attrname!r} and {name!r})."
+            )
+
+    def __get__(self, instance, owner=None):
+        if instance is None:
+            return self
+        if self.attrname is None:
+            raise TypeError(
+                "Cannot use cached_property instance without calling __set_name__ on it.")
+        try:
+            cache = instance.__dict__
+        except AttributeError:  # not all objects have __dict__ (e.g. class defines slots)
+            msg = (
+                f"No '__dict__' attribute on {type(instance).__name__!r} "
+                f"instance to cache {self.attrname!r} property."
+            )
+            raise TypeError(msg) from None
+        val = cache.get(self.attrname, _NOT_FOUND)
+        if val is _NOT_FOUND:
+            with self.lock:
+                # check if another thread filled cache while we awaited lock
+                val = cache.get(self.attrname, _NOT_FOUND)
+                if val is _NOT_FOUND:
+                    val = self.func(instance)
+                    try:
+                        cache[self.attrname] = val
+                    except TypeError:
+                        msg = (
+                            f"The '__dict__' attribute on {type(instance).__name__!r} instance "
+                            f"does not support item assignment for caching {self.attrname!r} property."
+                        )
+                        raise TypeError(msg) from None
+        return val

--- a/stonesoup/types/_util.py
+++ b/stonesoup/types/_util.py
@@ -12,7 +12,7 @@ from threading import RLock
 _NOT_FOUND = object()
 
 
-class cached_property:
+class cached_property:  # pragma: no cover
     def __init__(self, func):
         self.func = func
         self.attrname = None

--- a/stonesoup/types/tests/test_state.py
+++ b/stonesoup/types/tests/test_state.py
@@ -246,6 +246,39 @@ def test_particlestate_angle():
     assert np.allclose(state.covar, CovarianceMatrix([[0.01, -1.5], [-1.5, 225]]))
 
 
+def test_particlestate_cache():
+    num_particles = 10
+    weight = Probability(1/num_particles)
+    particles = StateVectors(np.concatenate(
+        (np.tile([[0]], num_particles//2), np.tile([[100]], num_particles//2)), axis=1))
+    weights = np.tile(weight, num_particles)
+
+    state = ParticleState(particles, weight=weights)
+    assert np.allclose(state.mean, StateVector([[50]]))
+    assert np.allclose(state.covar, CovarianceMatrix([[2500]]))
+
+    with pytest.raises(ValueError, match="read-only"):
+        state.state_vector += 10
+
+    with pytest.raises(ValueError, match="read-only"):
+        state.weight *= 0.5
+
+    state.state_vector = particles + 50  # Cache cleared
+    with pytest.raises(ValueError, match="read-only"):
+        state.weight *= 0.5  # But still not writable
+    state.weight = state.weight * 0.5
+    assert np.allclose(state.mean, StateVector([[100]]))
+    assert np.allclose(state.covar, CovarianceMatrix([[2500]]))
+
+    state = ParticleState(particles, weight=weights, fixed_covar=np.array([[1]]))
+    assert np.allclose(state.mean, StateVector([[50]]))
+    assert np.allclose(state.covar, CovarianceMatrix([[1]]))
+
+    state.fixed_covar = np.array([[2]])
+    assert np.allclose(state.mean, StateVector([[50]]))
+    assert np.allclose(state.covar, CovarianceMatrix([[2]]))
+
+
 def test_ensemblestate():
 
     # 1D


### PR DESCRIPTION
This has significant performance improvements, for the trade off of limiting editing to state vector and weight of the ParticleState. However, they can still be replaced with another array, clearing the cache.

Minor issue is use of standard library `functools.cached_property` is only available from Python 3.8, so to maintain compatibility with Python 3.7, `cached_property` code snippet is also included.