### PR TITLE
Update install instructions to make compatible with zsh

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -62,6 +62,14 @@ following:
     cd Stone-Soup
     python -m pip install -e .[dev]
 
+If you are using ``zsh``:
+
+.. code::
+
+    git clone "https://github.com/dstl/Stone-Soup.git"
+    cd Stone-Soup
+    python -m pip install -e ".[dev]"
+
 Please also see our :ref:`contributing:Contributing` page.
 
 Contents

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -60,7 +60,7 @@ following:
 
     git clone "https://github.com/dstl/Stone-Soup.git"
     cd Stone-Soup
-    python -m pip install -e .[dev]
+    python -m pip install -e ".[dev]"
 
 Please also see our :ref:`contributing:Contributing` page.
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -62,14 +62,6 @@ following:
     cd Stone-Soup
     python -m pip install -e .[dev]
 
-If you are using ``zsh``:
-
-.. code::
-
-    git clone "https://github.com/dstl/Stone-Soup.git"
-    cd Stone-Soup
-    python -m pip install -e ".[dev]"
-
 Please also see our :ref:`contributing:Contributing` page.
 
 Contents


### PR DESCRIPTION
I've recently tried to install StoneSoup using the provided `python -m pip install -e .[dev]` command, and it didn't work. I've found out, that when using `zsh`, the location and the extra have to be enclosed by quotation marks. For the sake of other `zsh` users, I think a quick instruction could be given in the docs.