### PR TITLE
Add new plotter based on plotly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,7 +71,8 @@ jobs:
             python -m venv venv
             . venv/bin/activate
             pip install --upgrade pip
-            pip install -e .[dev] opencv-python-headless kaleido
+            pip install -r docs/ci-requirements.txt
+            pip install -e .[dev] opencv-python-headless
       - save_cache:
           paths:
             - ./venv

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,18 +64,18 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: dependencies-{{ .Environment.CACHE_VERSION }}-{{ checksum "/home/circleci/.pyenv/version" }}-{{ checksum "setup.py" }}
+          key: dependencies-doc-{{ .Environment.CACHE_VERSION }}-{{ checksum "/home/circleci/.pyenv/version" }}-{{ checksum "setup.py" }}
       - run:
           name: Install Dependencies
           command: |
             python -m venv venv
             . venv/bin/activate
             pip install --upgrade pip
-            pip install -e .[dev] opencv-python-headless
+            pip install -e .[dev] opencv-python-headless kaleido
       - save_cache:
           paths:
             - ./venv
-          key: dependencies-{{ .Environment.CACHE_VERSION }}-{{ checksum "/home/circleci/.pyenv/version" }}-{{ checksum "setup.py" }}
+          key: dependencies-doc-{{ .Environment.CACHE_VERSION }}-{{ checksum "/home/circleci/.pyenv/version" }}-{{ checksum "setup.py" }}
       - run:
           name: Build Docs
           command: |

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -7,6 +7,7 @@ build:
 
 python:
   install:
+    - requirements: docs/ci-requirements.txt
     - method: pip
       path: .
       extra_requirements:

--- a/docs/ci-requirements.txt
+++ b/docs/ci-requirements.txt
@@ -1,0 +1,3 @@
+# Additional requirement for CircleCI and Read The Docs
+# Needed to generate thumbnails in Sphinx-Gallery
+kaleido

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -26,6 +26,8 @@ sys.path.insert(0, os.path.abspath('../../'))
 
 from doc_extensions import gallery_scraper, reset_numpy_random_seed
 from sphinx_gallery.sorting import FileNameSortKey
+import plotly.io as pio
+pio.renderers.default = 'sphinx_gallery'
 
 # -- General configuration ------------------------------------------------
 

--- a/docs/source/doc_extensions.py
+++ b/docs/source/doc_extensions.py
@@ -79,6 +79,14 @@ from sphinx_gallery.scrapers import (
     figure_rst, _anim_rst, _matplotlib_fig_titles, HLIST_HEADER,
     HLIST_IMAGE_MATPLOTLIB)
 
+import plotly.graph_objects as go
+try:
+    import kaleido
+except ImportError:
+    write_plotly_image = None
+else:
+    from plotly.io import write_image as write_plotly_image
+
 
 class gallery_scraper():
     def __init__(self):
@@ -141,6 +149,13 @@ class gallery_scraper():
         else:
             if isinstance(output, Figure):
                 new_figures.add(output.number)
+            elif isinstance(output, go.Figure):
+                if write_plotly_image is not None:
+                    image_path = next(image_path_iterator)
+                    if 'format' in kwargs:
+                        image_path = '%s.%s' % (os.path.splitext(image_path)[0],
+                                                kwargs['format'])
+                    write_plotly_image(output, image_path, kwargs.get('format'))
 
         for fig_num, image_path in zip(new_figures, image_path_iterator):
             if 'format' in kwargs:

--- a/docs/tutorials/01_KalmanFilterTutorial.py
+++ b/docs/tutorials/01_KalmanFilterTutorial.py
@@ -174,13 +174,14 @@ for k in range(1, num_steps + 1):
 #
 # Stone Soup has an in-built plotting class which can be used to plot
 # ground truths, measurements and tracks in a consistent format. It can be accessed by importing
-# the class :class:`Plotter` from Stone Soup as below.
+# the class :class:`Plotterly` from Stone Soup as below.
 #
 # Note that the mapping argument is [0, 2] because those are the x and y position indices from our state vector.
 
-from stonesoup.plotter import Plotter
-plotter = Plotter()
+from stonesoup.plotter import Plotterly
+plotter = Plotterly()
 plotter.plot_ground_truths(truth, [0, 2])
+plotter.fig
 
 
 # %%

--- a/docs/tutorials/02_ExtendedKalmanFilterTutorial.py
+++ b/docs/tutorials/02_ExtendedKalmanFilterTutorial.py
@@ -93,9 +93,10 @@ for k in range(1, 21):
 # %%
 # Plot this
 
-from stonesoup.plotter import Plotter
-plotter = Plotter()
+from stonesoup.plotter import Plotterly
+plotter = Plotterly()
 plotter.plot_ground_truths(truth, [0, 2])
+plotter.fig
 
 # %%
 # A bearing-range sensor

--- a/docs/tutorials/03_UnscentedKalmanFilterTutorial.py
+++ b/docs/tutorials/03_UnscentedKalmanFilterTutorial.py
@@ -97,9 +97,10 @@ for k in range(1, 21):
 # %%
 # Set-up plot to render ground truth, as before.
 
-from stonesoup.plotter import Plotter
-plotter = Plotter()
+from stonesoup.plotter import Plotterly
+plotter = Plotterly()
 plotter.plot_ground_truths(truth, [0, 2])
+plotter.fig
 
 # %%
 # Simulate the measurement
@@ -168,7 +169,7 @@ for measurement in measurements:
 # %%
 # And plot
 
-plotter.plot_tracks(track, [0, 2], uncertainty=True, color='r')
+plotter.plot_tracks(track, [0, 2], uncertainty=True)
 plotter.fig
 
 # %%
@@ -266,6 +267,7 @@ ekf_pred_meas = extended_updater.predict_measurement(prediction)
 
 # Plot UKF's predicted measurement distribution
 from matplotlib.patches import Ellipse
+from stonesoup.plotter import Plotter
 w, v = np.linalg.eig(ukf_pred_meas.covar)
 max_ind = np.argmax(w)
 min_ind = np.argmin(w)
@@ -293,7 +295,7 @@ ax.add_artist(ekf_ellipse)
 # Add ellipses to legend
 label_list = ["UKF Prediction", "EKF Prediction"]
 color_list = ['r', 'g']
-plotter.ellipse_legend(ax, label_list, color_list)
+Plotter.ellipse_legend(ax, label_list, color_list)
 fig
 
 # %%

--- a/docs/tutorials/04_ParticleFilter.py
+++ b/docs/tutorials/04_ParticleFilter.py
@@ -97,9 +97,10 @@ for k in range(1, 21):
 # %%
 # Plot the ground truth.
 
-from stonesoup.plotter import Plotter
-plotter = Plotter()
+from stonesoup.plotter import Plotterly
+plotter = Plotterly()
 plotter.plot_ground_truths(truth, [0, 2])
+plotter.fig
 
 
 # %%

--- a/docs/tutorials/05_DataAssociation-Clutter.py
+++ b/docs/tutorials/05_DataAssociation-Clutter.py
@@ -125,13 +125,14 @@ for state in truth:
 # Plot the ground truth and measurements with clutter.
 
 # Plot ground truth.
-from stonesoup.plotter import Plotter
-plotter = Plotter()
-plotter.ax.set_ylim(0, 25)  # Can set additional axes properties e.g. limits
+from stonesoup.plotter import Plotterly
+plotter = Plotterly()
 plotter.plot_ground_truths(truth, [0, 2])
 
 # Plot true detections and clutter.
 plotter.plot_measurements(all_measurements, [0, 2])
+
+plotter.fig
 
 # %%
 # Distance Hypothesiser and Nearest Neighbour

--- a/docs/tutorials/06_DataAssociation-MultiTargetTutorial.py
+++ b/docs/tutorials/06_DataAssociation-MultiTargetTutorial.py
@@ -98,10 +98,10 @@ truths.add(truth)
 # %%
 # Plot the ground truth
 
-from stonesoup.plotter import Plotter
-plotter = Plotter()
-plotter.ax.set_ylim(0, 25)
+from stonesoup.plotter import Plotterly
+plotter = Plotterly()
 plotter.plot_ground_truths(truths, [0, 2])
+plotter.fig
 
 # %%
 # Generate detections with clutter
@@ -145,7 +145,7 @@ for k in range(20):
     all_measurements.append(measurement_set)
 
 # Plot true detections and clutter.
-plotter.plot_measurements(all_measurements, [0, 2], color='g')
+plotter.plot_measurements(all_measurements, [0, 2])
 plotter.fig
 
 # %%

--- a/docs/tutorials/07_PDATutorial.py
+++ b/docs/tutorials/07_PDATutorial.py
@@ -111,13 +111,13 @@ for state in truth:
 # %%
 # Plot the ground truth and measurements with clutter.
 
-from stonesoup.plotter import Plotter
-plotter = Plotter()
-plotter.ax.set_ylim(0, 25)
+from stonesoup.plotter import Plotterly
+plotter = Plotterly()
 plotter.plot_ground_truths(truth, [0, 2])
 
 # Plot true detections and clutter.
 plotter.plot_measurements(all_measurements, [0, 2])
+plotter.fig
 
 
 # %%

--- a/docs/tutorials/08_JPDATutorial.py
+++ b/docs/tutorials/08_JPDATutorial.py
@@ -98,9 +98,8 @@ for k in range(1, 21):
 truths.add(truth)
 
 # Plot ground truth.
-from stonesoup.plotter import Plotter
-plotter = Plotter()
-plotter.ax.set_ylim(0, 25)
+from stonesoup.plotter import Plotterly
+plotter = Plotterly()
 plotter.plot_ground_truths(truths, [0, 2])
 
 # Generate measurements.
@@ -138,7 +137,8 @@ for k in range(20):
     all_measurements.append(measurement_set)
 
 # Plot true detections and clutter.
-plotter.plot_measurements(all_measurements, [0, 2], color='g')
+plotter.plot_measurements(all_measurements, [0, 2])
+plotter.fig
 
 # %%
 from stonesoup.predictor.kalman import KalmanPredictor

--- a/docs/tutorials/09_Initiators_&_Deleters.py
+++ b/docs/tutorials/09_Initiators_&_Deleters.py
@@ -55,10 +55,10 @@ for k in range(20):
         current_truths.add(truth)
         truths.add(truth)
 
-from stonesoup.plotter import Plotter
-plotter = Plotter()
-plotter.ax.set_ylim(-5, 25)
+from stonesoup.plotter import Plotterly
+plotter = Plotterly()
 plotter.plot_ground_truths(truths, [0, 2])
+plotter.fig
 
 # %%
 # Generate Detections and Clutter
@@ -108,7 +108,7 @@ for k in range(20):
     all_measurements.append(measurement_set)
 
 # Plot true detections and clutter.
-plotter.plot_measurements(all_measurements, [0, 2], color='g')
+plotter.plot_measurements(all_measurements, [0, 2])
 plotter.fig
 
 # %%

--- a/docs/tutorials/10_Simulation_&_Tracking_Components.py
+++ b/docs/tutorials/10_Simulation_&_Tracking_Components.py
@@ -213,9 +213,10 @@ for time, ctracks in tracker:
     tracks.update(ctracks)
 
 # %%
-from stonesoup.plotter import Plotter
+from stonesoup.plotter import Plotterly
 
-plotter = Plotter()
+plotter = Plotterly()
 plotter.plot_ground_truths(groundtruth, mapping=[0, 2])
 plotter.plot_measurements(detections, mapping=[0, 2])
 plotter.plot_tracks(tracks, mapping=[0, 2])
+plotter.fig

--- a/docs/tutorials/11_GMPHDTutorial.py
+++ b/docs/tutorials/11_GMPHDTutorial.py
@@ -179,9 +179,10 @@ for k in range(number_steps):
 # %%
 # Plot the ground truth
 #
-from stonesoup.plotter import Plotter
-plotter = Plotter()
+from stonesoup.plotter import Plotterly
+plotter = Plotterly()
 plotter.plot_ground_truths(truths, [0, 2])
+plotter.fig
 
 
 # %%
@@ -246,7 +247,7 @@ for k in range(number_steps):
 
 
 # Plot true detections and clutter.
-plotter.plot_measurements(all_measurements, [0, 2], color='g')
+plotter.plot_measurements(all_measurements, [0, 2])
 plotter.fig
 
 # %%
@@ -484,12 +485,13 @@ for measurement_set in all_measurements:
 # This ellipse need not cover the entire state space, as long as the distribution does.
 
 # Plot the tracks
-plotter = Plotter()
+plotter = Plotterly()
 plotter.plot_ground_truths(truths, [0, 2])
-plotter.plot_measurements(all_measurements, [0, 2], color='g')
+plotter.plot_measurements(all_measurements, [0, 2])
 plotter.plot_tracks(tracks, [0, 2], uncertainty=True)
-plotter.ax.set_xlim(x_min-5, x_max+5)
-plotter.ax.set_ylim(y_min-5, y_max+5)
+plotter.fig.update_xaxes(range=[x_min-5, x_max+5])
+plotter.fig.update_yaxes(range=[y_min-5, y_max+5])
+plotter.fig
 
 
 # %%

--- a/docs/tutorials/12_InformationFilterTutorial.py
+++ b/docs/tutorials/12_InformationFilterTutorial.py
@@ -56,7 +56,7 @@ for k in range(1,21):
     timestamp=start_time + timedelta(seconds=k)))
     
 # %%
-# Importing the :class:`~.Plotter` class from Stone Soup, we can plot the results.
+# Importing the :class:`~.Plotterly` class from Stone Soup, we can plot the results.
 # Note that the mapping argument is [0, 2] because those are the :math:`x` and :math:`y` position
 # indices from our state vector.
 
@@ -65,9 +65,10 @@ for k in range(1,21):
 # Plotting Ground Truths:
 # ^^^^^^^^^^^^^^^^^^^^^^^
 
-from stonesoup.plotter import Plotter
-plotter = Plotter()
+from stonesoup.plotter import Plotterly
+plotter = Plotterly()
 plotter.plot_ground_truths(truth,[0,2])
+plotter.fig
 
 # %%
 # Taking Measurements:
@@ -102,7 +103,7 @@ for state in truth:
 
 
 # %%
-# We plot the measurements using the Plotter class in Stone Soup. Again specifying the :math:`x`, :math:`y` position
+# We plot the measurements using the Plotterly class in Stone Soup. Again specifying the :math:`x`, :math:`y` position
 # indicies from the state vector.
 
 

--- a/docs/tutorials/sensormanagement/01_SingleSensorManagement.py
+++ b/docs/tutorials/sensormanagement/01_SingleSensorManagement.py
@@ -152,16 +152,16 @@ for j in range(0, ntruths):
         ydirection *= -1
 
 # %%
-# Plot the ground truths. This is done using the :class:`~.Plotter` class from Stone Soup.
+# Plot the ground truths. This is done using the :class:`~.Plotterly` class from Stone Soup.
 
-from stonesoup.plotter import Plotter
+from stonesoup.plotter import Plotterly
 
 # Stonesoup plotter requires sets not lists
 truths_set = set(truths)
 
-plotter = Plotter()
-plotter.ax.axis('auto')
+plotter = Plotterly()
 plotter.plot_ground_truths(truths_set, [0, 2])
+plotter.fig
 
 # %%
 # Create sensors
@@ -386,10 +386,11 @@ for timestep in timesteps[1:]:
 # %%
 # Plot ground truths, tracks and uncertainty ellipses for each target.
 
-plotterA = Plotter()
+plotterA = Plotterly()
 plotterA.plot_sensors(sensorA)
 plotterA.plot_ground_truths(truths_set, [0, 2])
 plotterA.plot_tracks(set(tracksA), [0, 2], uncertainty=True)
+plotterA.fig
 
 # %%
 # Run brute force sensor manager
@@ -450,10 +451,11 @@ for timestep in timesteps[1:]:
 # %%
 # Plot ground truths, tracks and uncertainty ellipses for each target.
 
-plotterB = Plotter()
+plotterB = Plotterly()
 plotterB.plot_sensors(sensorB)
 plotterB.plot_ground_truths(truths_set, [0, 2])
 plotterB.plot_tracks(set(tracksB), [0, 2], uncertainty=True)
+plotterB.fig
 
 # %%
 # The smaller uncertainty ellipses in this plot suggest that the :class:`~.BruteForceSensorManager` provides a much

--- a/docs/tutorials/sensormanagement/02_MultiSensorManagement.py
+++ b/docs/tutorials/sensormanagement/02_MultiSensorManagement.py
@@ -102,16 +102,16 @@ for j in range(0, ntruths):
         ydirection *= -1
 
 # %%
-# Plot the ground truths. This is done using the :class:`~.Plotter` class from Stone Soup.
+# Plot the ground truths. This is done using the :class:`~.Plotterly` class from Stone Soup.
 
-from stonesoup.plotter import Plotter
+from stonesoup.plotter import Plotterly
 
 # Stonesoup plotter requires sets not lists
 truths_set = set(truths)
 
-plotter = Plotter()
-plotter.ax.axis('auto')
+plotter = Plotterly()
 plotter.plot_ground_truths(truths_set, [0, 2])
+plotter.fig
 
 # %%
 # Create sensors
@@ -350,10 +350,11 @@ for timestep in timesteps[1:]:
 # Plot ground truths, tracks and uncertainty ellipses for each target. The positions of the sensors are indicated
 # by black x markers.
 
-plotterA = Plotter()
+plotterA = Plotterly()
 plotterA.plot_sensors(sensor_setA)
 plotterA.plot_ground_truths(truths_set, [0, 2])
 plotterA.plot_tracks(set(tracksA), [0, 2], uncertainty=True)
+plotterA.fig
 
 # %%
 # In comparison to Tutorial 1 the performance of the :class:`~.RandomSensorManager` has improved. This is
@@ -419,10 +420,11 @@ for timestep in timesteps[1:]:
 # %%
 # Plot ground truths, tracks and uncertainty ellipses for each target.
 
-plotterB = Plotter()
+plotterB = Plotterly()
 plotterB.plot_sensors(sensor_setB)
 plotterB.plot_ground_truths(truths_set, [0, 2])
 plotterB.plot_tracks(set(tracksB), [0, 2], uncertainty=True)
+plotterB.fig
 
 # %%
 # The smaller uncertainty ellipses in this plot suggest that the :class:`~.BruteForceSensorManager` provides a much

--- a/docs/tutorials/sensormanagement/03_OptimisedSensorManagement.py
+++ b/docs/tutorials/sensormanagement/03_OptimisedSensorManagement.py
@@ -95,16 +95,16 @@ for j in range(0, ntruths):
         ydirection *= -1
 
 # %%
-# Plot the ground truths. This is done using the :class:`~.Plotter` class from Stone Soup.
+# Plot the ground truths. This is done using the :class:`~.Plotterly` class from Stone Soup.
 
-from stonesoup.plotter import Plotter
+from stonesoup.plotter import Plotterly
 
 # Stonesoup plotter requires sets not lists
 truths_set = set(truths)
 
-plotter = Plotter()
-plotter.ax.axis('auto')
+plotter = Plotterly()
 plotter.plot_ground_truths(truths_set, [0, 2])
+plotter.fig
 
 # %%
 # Create sensors
@@ -359,10 +359,11 @@ cell_run_time1 = round(time.time() - cell_start_time1, 2)
 # Plot ground truths, tracks and uncertainty ellipses for each target. The positions of the sensors are indicated
 # by black x markers.
 
-plotterA = Plotter()
+plotterA = Plotterly()
 plotterA.plot_sensors(sensor_setA)
 plotterA.plot_ground_truths(truths_set, [0, 2])
 plotterA.plot_tracks(set(tracksA), [0, 2], uncertainty=True)
+plotterA.fig
 
 # %%
 # The resulting plot is exactly the same as Tutorial 2.
@@ -409,10 +410,11 @@ cell_run_time2 = round(time.time() - cell_start_time2, 2)
 # %%
 # Plot ground truths, tracks and uncertainty ellipses for each target.
 
-plotterB = Plotter()
+plotterB = Plotterly()
 plotterB.plot_sensors(sensor_setB)
 plotterB.plot_ground_truths(truths_set, [0, 2])
 plotterB.plot_tracks(set(tracksB), [0, 2], uncertainty=True)
+plotterB.fig
 
 # %%
 # Run optimised basin hopping sensor manager
@@ -456,10 +458,11 @@ cell_run_time3 = round(time.time() - cell_start_time3, 2)
 # %%
 # Plot ground truths, tracks and uncertainty ellipses for each target.
 
-plotterC = Plotter()
+plotterC = Plotterly()
 plotterC.plot_sensors(sensor_setC)
 plotterC.plot_ground_truths(truths_set, [0, 2])
 plotterC.plot_tracks(set(tracksC), [0, 2], uncertainty=True)
+plotterC.fig
 
 # %%
 # At first glance, the plots for each of the optimised sensor managers show a very

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(name='stonesoup',
       extras_require={
           'dev': [
               'pytest-flake8', 'pytest-cov', 'pytest-remotedata', 'flake8<5',
-              'Sphinx', 'sphinx_rtd_theme', 'sphinx-gallery>=0.10.1', 'pillow', 'folium',
+              'Sphinx', 'sphinx_rtd_theme', 'sphinx-gallery>=0.10.1', 'pillow', 'folium', 'plotly',
           ],
           'video': ['ffmpeg-python', 'moviepy', 'opencv-python'],
           'tensorflow': ['tensorflow>=2.2.0'],

--- a/stonesoup/tests/test_plotter.py
+++ b/stonesoup/tests/test_plotter.py
@@ -120,7 +120,7 @@ def test_plot_sensors():
     )
     plotter3d.plot_sensors(sensor, marker='o', color='red')
     plt.close()
-    assert 'Sensor' in plotter3d.legend_dict
+    assert 'Sensors' in plotter3d.legend_dict
 
 
 def test_empty_tracks():


### PR DESCRIPTION
This adds a new plotter based on `plotly`, which offers the same interface as the `matplotlib` one (interchangeable unless custom `matplotlib` commands have been used). These new plots introduce hover over info on states, ability to switch layers off/on, and easier ability to zoom and pan, etc.

The tutorials have been updated to use `plotly` based plotter.

One minor issue is thumbnails may not be produced locally without additional dependency `kaleido`, which I've left as optional but included in the CircleCI and Read the Docs build.

Also tested on Read the Docs to confirm build.