### PR TITLE
Modify assign2D to exploit NumPy indexing

### DIFF
--- a/stonesoup/dataassociator/neighbour.py
+++ b/stonesoup/dataassociator/neighbour.py
@@ -238,7 +238,7 @@ class GNNWith2DAssignment(DataAssociator):
             distance_matrix, probability_flag)
 
         # Ensure the problem was feasible
-        if gain.size <= 0:
+        if gain is None:
             raise RuntimeError("Assignment was not feasible")
 
         # Generate dict of key/value pairs


### PR DESCRIPTION
Previously this used iteration rather than indexing. By changing to using indexing and vectorising some calculations, gives a performance benefit for large number of tracks/detections.

Performance difference isn't noticeable on a small cost matrix, but testing on a `(1988, 4808)` cost matrix results in identical output with ~50x to 60x speed up.