### PR TITLE
Directly set arguments when instantiating a class

### DIFF
--- a/stonesoup/tests/test_declarative.py
+++ b/stonesoup/tests/test_declarative.py
@@ -10,6 +10,18 @@ def test_properties(base):
     assert base(1, "2").property_a == 1
     assert base(1, "2").property_c == 123
 
+    with pytest.raises(TypeError, match="too many positional arguments"):
+        base(1, 2, 3, 4, 5)
+
+    with pytest.raises(TypeError, match="multiple values for argument 'property_a'"):
+        base(1, "2", property_a=2)
+
+    with pytest.raises(TypeError, match="missing a required argument: 'property_b'"):
+        base(1)
+
+    with pytest.raises(TypeError, match="got an unexpected keyword argument 'property_d'"):
+        assert base(1, "2", property_d=True)
+
 
 def test_subclass(base):
     class _TestSubclass(base):


### PR DESCRIPTION
This avoids the need to first get the signature and avoid more complex bind method which handles things like positional only and keyword only arguments which aren't relevant.

This offers a small performance improvement.