### PR TITLE
Improve logic of readonly property checking to avoid double settting

### DIFF
--- a/stonesoup/base.py
+++ b/stonesoup/base.py
@@ -137,13 +137,9 @@ class Property:
             return self._getter(instance)
 
     def __set__(self, instance, value):
-        if self.readonly:
-            if not hasattr(instance, self._property_name):
-                setattr(instance, self._property_name, value)
-            else:
-                # if the value has been set, raise an AttributeError
-                raise AttributeError(
-                    '{} is readonly'.format(self._property_name))
+        if self.readonly and hasattr(instance, self._property_name):
+            # if the value has been set, raise an AttributeError
+            raise AttributeError('{} is readonly'.format(self._property_name))
 
         for cached_value in self._clear_cached:
             if cached_value in instance.__dict__:


### PR DESCRIPTION
I haven't manged to write a test which fails with the old logic and passes with the new, but in testing other things I spotted this logic error, so thought it should be fixed. 

It has no effect on functionality that I can detect.