### PR TITLE
Fix plotting error when a track only has a single state

### DIFF
--- a/stonesoup/plotter.py
+++ b/stonesoup/plotter.py
@@ -310,9 +310,10 @@ class Plotter(_Plotter):
                 else:
                     not_update_indexes.append(n)
 
-            data = np.array(
+            data = np.concatenate(
                 [(getattr(state, 'mean', state.state_vector)[mapping, :])
-                 for state in track]).squeeze().T
+                 for state in track],
+                axis=1)
 
             line = self.ax.plot(
                 *data,


### PR DESCRIPTION
This was caused by squeeze removing extra dimension when only a single state was present. Using concatenate along correct dimension avoids this.