### PR TITLE
Add instance check for reward function

### DIFF
--- a/stonesoup/sensormanager/reward.py
+++ b/stonesoup/sensormanager/reward.py
@@ -5,6 +5,7 @@ from typing import Mapping, Sequence, Set
 
 import numpy as np
 
+from ..types.detection import TrueDetection
 from ..base import Base, Property
 from ..predictor.kalman import KalmanPredictor
 from ..updater.kalman import ExtendedKalmanUpdater
@@ -102,7 +103,8 @@ class UncertaintyRewardFunction(RewardFunction):
 
             # Assumes one detection per track
             detections = {detection.groundtruth_path: detection
-                          for detection in sensor.measure(predicted_tracks, noise=False)}
+                          for detection in sensor.measure(predicted_tracks, noise=False)
+                          if isinstance(detection, TrueDetection)}
 
             for predicted_track, detection in detections.items():
                 # Generate hypothesis based on prediction/previous update and detection


### PR DESCRIPTION
Current reward function assumes a single detection per track. This adds an instance check to manage when clutter (or non TrueDetection types) is present.