### PR TITLE
Allow default values for MeasurementInitiators

### DIFF
--- a/docs/demos/OpenSky_Demo.py
+++ b/docs/demos/OpenSky_Demo.py
@@ -195,7 +195,7 @@ from stonesoup.initiator.simple import MultiMeasurementInitiator
 from stonesoup.types.state import GaussianState
 
 initiator = MultiMeasurementInitiator(
-    GaussianState(
+    prior_state=GaussianState(
         np.array([[0], [0], [0], [0], [0], [0]]),   # Prior State
         np.diag([15**2, 100**2, 15**2, 100**2, 15**2, 20**2])),
     measurement_model=None,

--- a/docs/examples/Metrics.py
+++ b/docs/examples/Metrics.py
@@ -70,7 +70,7 @@ data_associator = GNNWith2DAssignment(hypothesiser)
 # Initiator & Deleter
 deleter = CovarianceBasedDeleter(covar_trace_thresh=1E3)
 initiator = MultiMeasurementInitiator(
-    GaussianState(np.array([[0], [0], [0], [0]]), np.diag([0, 100, 0, 1000])),
+    prior_state=GaussianState(np.array([[0], [0], [0], [0]]), np.diag([0, 100, 0, 1000])),
     measurement_model=measurement_model,
     deleter=deleter,
     data_associator=data_associator,

--- a/stonesoup/initiator/tests/test_simple.py
+++ b/stonesoup/initiator/tests/test_simple.py
@@ -293,8 +293,8 @@ def test_multi_measurement(updates_only):
     deleter = UpdateTimeDeleter(datetime.timedelta(seconds=59))
 
     measurement_initiator = MultiMeasurementInitiator(
-        GaussianState([[0], [0], [0], [0]], np.diag([0, 15, 0, 15])),
         deleter, data_associator, updater,
+        prior_state=GaussianState([[0], [0], [0], [0]], np.diag([0, 15, 0, 15])),
         measurement_model=measurement_model, updates_only=updates_only)
 
     timestamp = datetime.datetime.now()


### PR DESCRIPTION
Add default value to prior_state for `SimpleMeasurementInitiator` & `MultiMeasurementInitiator`

- The prior state is overwritten with 0s in the function so it makes little sense to require a value for it when a `StateVector` and `CovarianceMatrix` can initalised with zeros

- Slight breaking change to `MultiMeasurementInitiator` as the order of arguments has changed. No effect when initialising the object with keyword arguments

Add option to skip detections in `MultiMeasurementInitiator` with a non reversible measurement model