### PR TITLE
Make StateVectors Hashable

### DIFF
--- a/stonesoup/types/array.py
+++ b/stonesoup/types/array.py
@@ -47,6 +47,12 @@ class Matrix(np.ndarray):
         else:
             return self._cast(result)
 
+    def __hash__(self):
+        return hash(self.tobytes())
+
+    def __eq__(self, other):
+        return type(other) == type(self) and self.tobytes() == other.tobytes()
+
 
 class StateVector(Matrix):
     r"""State vector wrapper for :class:`numpy.ndarray`


### PR DESCRIPTION
The most noticable difference would be the change to equals

A small code snippet to display the differences
```
sv1 = StateVector([1, 2])
sv2 = StateVector([2, 3])
sv3 = StateVector([1, 2])

print(sv1 == sv2)
print(sv1 == sv3)
print(sv1 is sv3)

x = {sv1: 1, sv2: 2, sv3: 3}
print(x[sv1], x[sv2], x[sv3])
```