### PR TITLE
Implement generic readers for HDF5

### DIFF
--- a/docs/source/stonesoup.reader.rst
+++ b/docs/source/stonesoup.reader.rst
@@ -20,6 +20,11 @@ YAML
 .. automodule:: stonesoup.reader.yaml
     :show-inheritance:
 
+HDF5
+----
+.. automodule:: stonesoup.reader.hdf5
+    :show-inheritance:
+
 AISHub
 ------
 .. automodule:: stonesoup.reader.aishub

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,6 +32,7 @@ install_requires =
 dev =
     flake8<5
     folium
+    h5py
     pillow
     plotly
     pytest-flake8

--- a/stonesoup/reader/hdf5.py
+++ b/stonesoup/reader/hdf5.py
@@ -10,7 +10,7 @@ from typing import Collection, Sequence
 
 try:
     import h5py
-except ImportError as error:
+except ImportError as error:  # pragma: no cover
     raise ImportError(
         "HDF5 Readers require the dependency 'h5py' to be installed."
     ) from error

--- a/stonesoup/reader/hdf5.py
+++ b/stonesoup/reader/hdf5.py
@@ -1,0 +1,244 @@
+"""Generic HDF5 readers for Stone Soup.
+
+This is a collection of generic readers for Stone Soup, allowing quick reading
+of data that is in `HDF5 <https://hdfgroup.org/>`_ format, using the `h5py
+<https://docs.h5py.org/>`_ library.
+"""
+
+from datetime import datetime, timedelta
+from typing import Collection, Sequence
+
+try:
+    import h5py
+except ImportError as error:
+    raise ImportError(
+        "HDF5 Readers require the dependency 'h5py' to be installed."
+    ) from error
+import numpy as np
+from dateutil.parser import parse
+
+from .base import GroundTruthReader, DetectionReader
+from .file import BinaryFileReader
+from ..base import Property
+from ..buffered_generator import BufferedGenerator
+from ..types.detection import Detection
+from ..types.groundtruth import GroundTruthPath, GroundTruthState
+
+
+class _HDF5Reader(BinaryFileReader):
+    state_vector_fields: Sequence[str] = Property(
+        doc="Paths of datasets to be used in state vector"
+    )
+    time_field: str = Property(doc="Path of dataset to be used as time field")
+    time_field_format: str = Property(default=None, doc="Optional datetime format")
+    timestamp: bool = Property(
+        default=False, doc="Treat time field as a timestamp from epoch"
+    )
+    time_res_second: int = Property(
+        default=1, doc="Desired maximum resolution of time values in seconds",
+    )
+    time_res_micro: int = Property(
+        default=1e6,
+        doc="Desired maximum sub-second resolution of time values in microseconds",
+    )
+    metadata_fields: Collection[str] = Property(
+        default=None, doc="Paths of datasets to be saved as metadata, default all"
+    )
+
+    def _discover_metadata_fields(self, hdf5_file):
+        """Recurse through all objects in a file and treat any dataset with
+        the same number of records as a valid metadata field path, excluding
+        datasets that are already specified for state values.
+
+        Parameters
+        ----------
+        hdf5_file : :class:`h5py.File`
+            The HDF5 file to walk through
+        """
+
+        self.metadata_fields = []
+        record_count = len(hdf5_file[self.time_field])
+        obj_paths = []
+        hdf5_file.visit(obj_paths.append)
+
+        for obj_path in obj_paths:
+            obj = hdf5_file[obj_path]
+            if isinstance(obj, h5py.Dataset):
+                if (
+                    obj_path not in self.state_vector_fields
+                    and obj_path != self.time_field
+                    and len(obj) == record_count
+                ):
+                    self.metadata_fields.append(obj_path)
+
+    def _get_metadata(self, hdf5_file, row):
+        """Construct a dictionary of metadata values for a single record.
+
+        Parameters
+        ----------
+        hdf5_file : :class:`h5py.File`
+            The HDF5 file to read from
+        row : int
+            The row index of the record
+
+        Returns
+        -------
+        : dict
+            The metadata values for the record
+        """
+        if self.metadata_fields is None:
+            self._discover_metadata_fields(hdf5_file)
+
+        local_metadata = {
+            **{
+                field: hdf5_file[field][row]
+                for field in self.metadata_fields
+                if field in hdf5_file
+                and h5py.check_string_dtype(hdf5_file[field].dtype) is None
+            },  # Merge string and non-string fields into the same dict
+            **{
+                field: hdf5_file[field].asstr()[row]
+                for field in self.metadata_fields
+                if field in hdf5_file
+                and h5py.check_string_dtype(hdf5_file[field].dtype) is not None
+            },
+        }
+
+        return local_metadata
+
+    def _get_time(self, raw_time_val):
+        """Interpret a time value as a datetime object.
+
+        Parameters
+        ----------
+        raw_time_val : str or float or int
+            A formatted time string, or a POSIX timestamp to convert
+
+        Returns
+        -------
+        : :class:`datetime.datetime`
+            The parsed time value
+        """
+        if self.time_field_format is not None:
+            time_field_value = datetime.strptime(raw_time_val, self.time_field_format)
+        elif self.timestamp is True:
+            time_field_value = datetime.utcfromtimestamp(raw_time_val)
+        else:
+            time_field_value = parse(raw_time_val, ignoretz=True)
+
+        # Reduce timing resolution, as applicable
+        time_field_value = time_field_value - timedelta(
+            seconds=time_field_value.second % self.time_res_second,
+            microseconds=time_field_value.microsecond % self.time_res_micro,
+        )
+        return time_field_value
+
+
+class HDF5GroundTruthReader(GroundTruthReader, _HDF5Reader):
+    """A simple reader for HDF5 files of truth data.
+
+    HDF5 files are hierarchically structured data files with embedded metadata. This
+    reader will extract values that are placed anywhere within the hierarchy, but it
+    assumes all datasets are 1D arrays of base types representing 'columns' of data.
+    All fields must be the same length, and a 'row' of data is constructed from the
+    values at the same positional index in each column. Those states with the same ID
+    will be put into a :class:`~.GroundTruthPath` in sequence, and all paths that are
+    updated at the same time are yielded together, and such assumes file is in time
+    order.
+
+    Parameters
+    ----------
+    """
+
+    path_id_field: str = Property(doc="Path of dataset to be used as path ID")
+
+    @BufferedGenerator.generator_method
+    def groundtruth_paths_gen(self):
+        with h5py.File(self.path, "r") as hdf5_file:
+            groundtruth_dict = {}
+            updated_paths = set()
+            previous_time = None
+
+            time_values = hdf5_file[self.time_field]
+            if not self.timestamp:
+                time_values = time_values.asstr()
+
+            for i, raw_time_val in enumerate(time_values):
+
+                time = self._get_time(raw_time_val)
+                if previous_time is not None and previous_time != time:
+                    yield previous_time, updated_paths
+                    updated_paths = set()
+                previous_time = time
+
+                state = GroundTruthState(
+                    np.array(
+                        [
+                            [hdf5_file[field_path][i]]
+                            for field_path in self.state_vector_fields
+                        ],
+                        dtype=np.float64,
+                    ),
+                    timestamp=time,
+                    metadata=self._get_metadata(hdf5_file, i),
+                )
+
+                id_ = hdf5_file[self.path_id_field][i]
+                if id_ not in groundtruth_dict:
+                    groundtruth_dict[id_] = GroundTruthPath(id=id_)
+                groundtruth_path = groundtruth_dict[id_]
+                groundtruth_path.append(state)
+                updated_paths.add(groundtruth_path)
+
+            # Yield remaining
+            yield previous_time, updated_paths
+
+
+class HDF5DetectionReader(DetectionReader, _HDF5Reader):
+    """A simple detection reader for HDF5 files of detections.
+
+    HDF5 files are hierarchically structured data files with embedded metadata. This
+    reader will extract values that are placed anywhere within the hierarchy, but it
+    assumes all datasets are 1D arrays of base types representing 'columns' of data.
+    All fields must be the same length, and a 'row' of data is constructed from the
+    values at the same positional index in each column. Detections at the same time
+    are yielded together, and such assume file is in time order.
+
+    Parameters
+    ----------
+    """
+
+    @BufferedGenerator.generator_method
+    def detections_gen(self):
+        with h5py.File(self.path, "r") as hdf5_file:
+            detections = set()
+            previous_time = None
+
+            time_values = hdf5_file[self.time_field]
+            if not self.timestamp:
+                time_values = time_values.asstr()
+
+            for i, raw_time_val in enumerate(time_values):
+
+                time = self._get_time(raw_time_val)
+                if previous_time is not None and previous_time != time:
+                    yield previous_time, detections
+                    detections = set()
+                previous_time = time
+
+                detections.add(
+                    Detection(
+                        np.array(
+                            [
+                                [hdf5_file[field_path][i]]
+                                for field_path in self.state_vector_fields
+                            ],
+                            dtype=np.float64,
+                        ),
+                        timestamp=time,
+                        metadata=self._get_metadata(hdf5_file, i),
+                    )
+                )
+
+            # Yield remaining
+            yield previous_time, detections

--- a/stonesoup/reader/tests/test_hdf5.py
+++ b/stonesoup/reader/tests/test_hdf5.py
@@ -1,0 +1,346 @@
+import datetime
+from operator import attrgetter
+
+import h5py
+import numpy as np
+import pytest
+
+from ..hdf5 import HDF5DetectionReader, HDF5GroundTruthReader
+
+
+@pytest.fixture()
+def hdf5_gt_filename(tmpdir):
+    hdf5_filename = tmpdir.join("test.hdf5")
+    with h5py.File(hdf5_filename, "w") as hdf5_file:
+        hdf5_file.create_dataset("state/x", data=[10, 11, 12, 13, 14])
+        hdf5_file.create_dataset("state/y", data=[20, 21, 22, 23, 24])
+        hdf5_file.create_dataset("state/z", data=[30, 31, 32, 33, 34])
+        hdf5_file.create_dataset(
+            "identifier",
+            data=["22018332", "22018332", "22018332", "32018332", "32018332"],
+            compression="gzip",
+            compression_opts=1,
+        )
+        hdf5_file.create_dataset("meta/valid", data=[40, 41, 42, 43, 44])
+        hdf5_file.create_dataset("meta/invalid", data=[1, 2, 3, 4])
+        hdf5_file.create_dataset(
+            "t",
+            data=[
+                "2018-01-01T14:00:00Z",
+                "2018-01-01T14:01:00Z",
+                "2018-01-01T14:02:00Z",
+                "2018-01-01T14:03:00Z",
+                "2018-01-01T14:04:00Z",
+            ],
+        )
+    return hdf5_filename
+
+
+def test_hdf5_gt_2d(hdf5_gt_filename):
+    # run test with:
+    #   - 2d co-ordinates
+    #   - default time field format
+    hdf5_reader = HDF5GroundTruthReader(
+        hdf5_gt_filename.strpath,
+        state_vector_fields=["state/x", "state/y"],
+        time_field="t",
+        path_id_field="identifier",
+    )
+
+    final_gt_paths = set()
+    for _, gt_paths_at_timestep in hdf5_reader:
+        final_gt_paths.update(gt_paths_at_timestep)
+    assert len(final_gt_paths) == 2
+
+    ground_truth_states = [
+        gt_state for gt_path in final_gt_paths for gt_state in gt_path
+    ]
+
+    for n, gt_state in enumerate(
+        sorted(ground_truth_states, key=attrgetter("timestamp"))
+    ):
+        assert np.array_equal(gt_state.state_vector, np.array([[10 + n], [20 + n]]))
+        assert gt_state.timestamp.hour == 14
+        assert gt_state.timestamp.minute == n
+        assert gt_state.timestamp.date() == datetime.date(2018, 1, 1)
+
+        assert isinstance(gt_state.metadata, dict)
+        assert len(gt_state.metadata) == 3
+        assert "identifier" in gt_state.metadata
+        assert "state/z" in gt_state.metadata
+        assert "meta/valid" in gt_state.metadata
+        assert "meta/invalid" not in gt_state.metadata
+        assert int(gt_state.metadata["meta/valid"]) == 40 + n
+
+
+def test_hdf5_gt_3d_time(hdf5_gt_filename):
+    # run test with:
+    #   - 3d co-ordinates
+    #   - time field format specified
+    hdf5_reader = HDF5GroundTruthReader(
+        hdf5_gt_filename.strpath,
+        state_vector_fields=["state/x", "state/y", "state/z"],
+        time_field="t",
+        time_field_format="%Y-%m-%dT%H:%M:%SZ",
+        path_id_field="identifier",
+    )
+
+    final_gt_paths = set()
+    for _, gt_paths_at_timestep in hdf5_reader:
+        final_gt_paths.update(gt_paths_at_timestep)
+    assert len(final_gt_paths) == 2
+
+    ground_truth_states = [
+        gt_state for gt_path in final_gt_paths for gt_state in gt_path
+    ]
+
+    for n, gt_state in enumerate(
+        sorted(ground_truth_states, key=attrgetter("timestamp"))
+    ):
+        assert np.array_equal(
+            gt_state.state_vector, np.array([[10 + n], [20 + n], [30 + n]])
+        )
+        assert gt_state.timestamp.hour == 14
+        assert gt_state.timestamp.minute == n
+        assert gt_state.timestamp.date() == datetime.date(2018, 1, 1)
+
+        assert isinstance(gt_state.metadata, dict)
+        assert len(gt_state.metadata) == 2
+        assert "identifier" in gt_state.metadata
+        assert "meta/valid" in gt_state.metadata
+        assert "meta/invalid" not in gt_state.metadata
+        assert int(gt_state.metadata["meta/valid"]) == 40 + n
+
+
+def test_hdf5_gt_multi_per_timestep(tmpdir):
+    hdf5_gt_filename = tmpdir.join("test.hdf5")
+    with h5py.File(hdf5_gt_filename, "w") as hdf5_file:
+        hdf5_file.create_dataset("x", data=[10, 11, 12, 13, 14])
+        hdf5_file.create_dataset("y", data=[20, 21, 22, 23, 24])
+        hdf5_file.create_dataset("z", data=[30, 31, 32, 33, 34])
+        hdf5_file.create_dataset(
+            "identifier",
+            data=[22018332, 22018332, 22018332, 32018332, 32018332],
+            compression="gzip",
+            compression_opts=1,
+        )
+        hdf5_file.create_dataset(
+            "t",
+            data=[
+                "2018-01-01T14:00:00Z",
+                "2018-01-01T14:01:00Z",
+                "2018-01-01T14:02:00Z",
+                "2018-01-01T14:02:00Z",
+                "2018-01-01T14:03:00Z",
+            ],
+        )
+
+    hdf5_reader = HDF5GroundTruthReader(
+        hdf5_gt_filename.strpath,
+        state_vector_fields=["x", "y"],
+        time_field="t",
+        path_id_field="identifier",
+    )
+
+    for time, ground_truth_paths in hdf5_reader:
+        if time == datetime.datetime(2018, 1, 1, 14, 2):
+            assert len(ground_truth_paths) == 2
+        else:
+            assert len(ground_truth_paths) == 1
+
+
+@pytest.fixture()
+def hdf5_det_filename(tmpdir):
+    hdf5_filename = tmpdir.join("test.hdf5")
+
+    with h5py.File(hdf5_filename, "w") as hdf5_file:
+        hdf5_file.create_dataset("state/x", data=[10, 11, 12])
+        hdf5_file.create_dataset("state/y", data=[20, 21, 22])
+        hdf5_file.create_dataset("state/z", data=[30, 31, 32])
+        hdf5_file.create_dataset(
+            "identifier",
+            data=["22018332", "22018332", "22018332"],
+            compression="gzip",
+            compression_opts=1,
+        )
+        hdf5_file.create_dataset("meta/valid", data=[40, 41, 42])
+        hdf5_file.create_dataset("meta/invalid", data=[1, 2, 3, 4])
+        hdf5_file.create_dataset(
+            "t",
+            data=[
+                "2018-01-01T14:00:00Z",
+                "2018-01-01T14:01:00Z",
+                "2018-01-01T14:02:00Z",
+            ],
+        )
+    return hdf5_filename
+
+
+def test_hdf5_default(hdf5_det_filename):
+    # run test with:
+    #   - 'metadata_fields' for 'HDF5DetectionReader' == default
+    #   - copy all metadata items
+    hdf5_reader = HDF5DetectionReader(
+        hdf5_det_filename.strpath, ["state/x", "state/y"], "t"
+    )
+    detections = [
+        detection for _, detections in hdf5_reader for detection in detections
+    ]
+
+    for n, detection in enumerate(detections):
+        assert np.array_equal(detection.state_vector, np.array([[10 + n], [20 + n]]))
+        assert detection.timestamp.hour == 14
+        assert detection.timestamp.minute == n
+        assert detection.timestamp.date() == datetime.date(2018, 1, 1)
+        assert isinstance(detection.metadata, dict)
+        assert len(detection.metadata) == 3
+        assert "state/z" in detection.metadata
+        assert "identifier" in detection.metadata
+        assert "meta/valid" in detection.metadata
+        assert int(detection.metadata["state/z"]) == 30 + n
+        assert detection.metadata["identifier"] == "22018332"
+        assert int(detection.metadata["meta/valid"]) == 40 + n
+
+
+def test_hdf5_metadata_time(hdf5_det_filename):
+    # run test with:
+    #   - 'metadata_fields' for 'HDF5DetectionReader' contains
+    #       'z' but not 'identifier'
+    #   - 'time_field_format' is specified
+    hdf5_reader = HDF5DetectionReader(
+        hdf5_det_filename.strpath,
+        ["state/x", "state/y"],
+        "t",
+        time_field_format="%Y-%m-%dT%H:%M:%SZ",
+        metadata_fields=["state/z"],
+    )
+    detections = [
+        detection for _, detections in hdf5_reader for detection in detections
+    ]
+
+    for n, detection in enumerate(detections):
+        assert np.array_equal(detection.state_vector, np.array([[10 + n], [20 + n]]))
+        assert detection.timestamp.hour == 14
+        assert detection.timestamp.minute == n
+        assert detection.timestamp.date() == datetime.date(2018, 1, 1)
+        assert isinstance(detection.metadata, dict)
+        assert len(detection.metadata) == 1
+        assert "state/z" in detection.metadata.keys()
+        assert int(detection.metadata["state/z"]) == 30 + n
+
+
+def test_hdf5_missing_metadata_timestamp(tmpdir):
+    # run test with:
+    #   - 'metadata_fields' for 'HDF5DetectionReader' contains
+    #       field names that do not exist in hdf5 file
+    #   - 'time' field represented as a Unix epoch timestamp
+    hdf5_filename = tmpdir.join("test.hdf5")
+    with h5py.File(hdf5_filename, "w") as hdf5_file:
+        hdf5_file.create_dataset("state/x", data=[10, 11, 12])
+        hdf5_file.create_dataset("state/y", data=[20, 21, 22])
+        hdf5_file.create_dataset("state/z", data=[30, 31, 32])
+        hdf5_file.create_dataset(
+            "identifier",
+            data=["22018332", "22018332", "22018332"],
+            compression="gzip",
+            compression_opts=1,
+        )
+        hdf5_file.create_dataset("t", data=[1514815200, 1514815260, 1514815320])
+
+    hdf5_reader = HDF5DetectionReader(
+        hdf5_filename.strpath,
+        ["state/x", "state/y"],
+        "t",
+        metadata_fields=["heading"],
+        timestamp=True,
+    )
+    detections = [
+        detection for _, detections in hdf5_reader for detection in detections
+    ]
+
+    for n, detection in enumerate(detections):
+        assert np.array_equal(detection.state_vector, np.array([[10 + n], [20 + n]]))
+        assert detection.timestamp.hour == 14
+        assert detection.timestamp.minute == n
+        assert detection.timestamp.date() == datetime.date(2018, 1, 1)
+        assert isinstance(detection.metadata, dict)
+        assert len(detection.metadata) == 0
+
+
+def test_hdf5_multi_per_timestep(tmpdir):
+    hdf5_filename = tmpdir.join("test.hdf5")
+    with h5py.File(hdf5_filename, "w") as hdf5_file:
+        hdf5_file.create_dataset("state/x", data=[10, 11, 12, 13, 14])
+        hdf5_file.create_dataset("state/y", data=[20, 21, 22, 23, 24])
+        hdf5_file.create_dataset("state/z", data=[30, 31, 32, 33, 34])
+        hdf5_file.create_dataset(
+            "identifier",
+            data=["22018332", "22018332", "22018332", "32018332", "32018332"],
+            compression="gzip",
+            compression_opts=1,
+        )
+        hdf5_file.create_dataset(
+            "t",
+            data=[
+                "2018-01-01T14:00:00Z",
+                "2018-01-01T14:01:00Z",
+                "2018-01-01T14:02:00Z",
+                "2018-01-01T14:02:00Z",
+                "2018-01-01T14:03:00Z",
+            ],
+        )
+
+    hdf5_reader = HDF5DetectionReader(
+        hdf5_filename.strpath, ["state/x", "state/y"], "t"
+    )
+
+    for time, detections in hdf5_reader:
+        if time == datetime.datetime(2018, 1, 1, 14, 2):
+            assert len(detections) == 2
+        else:
+            assert len(detections) == 1
+
+
+def test_hdf5_time_resolution(tmpdir):
+    hdf5_filename = tmpdir.join("test.hdf5")
+    with h5py.File(hdf5_filename, "w") as hdf5_file:
+        hdf5_file.create_dataset("state/x", data=[10, 11, 12, 13, 14, 15])
+        hdf5_file.create_dataset("state/y", data=[20, 21, 22, 23, 24, 25])
+        hdf5_file.create_dataset(
+            "t",
+            data=[
+                "2018-01-01T14:00:0.01Z",
+                "2018-01-01T14:00:0.05Z",
+                "2018-01-01T14:00:0.15Z",
+                "2018-01-01T14:01:17Z",
+                "2018-01-01T14:01:22Z",
+                "2018-01-01T14:01:27Z",
+            ],
+        )
+
+    hdf5_reader = HDF5DetectionReader(
+        hdf5_filename.strpath, ["state/x", "state/y"], "t", time_res_micro=10000
+    )
+
+    for time, detections in hdf5_reader:
+        if time == datetime.datetime(2018, 1, 1, 14, 0, 0):
+            assert len(detections) == 2
+        elif time == datetime.datetime(2018, 1, 1, 14, 0, 0, 10000):
+            assert len(detections) == 1
+        elif time == datetime.datetime(2018, 1, 1, 14, 1, 17):
+            assert len(detections) == 1
+        elif time == datetime.datetime(2018, 1, 1, 14, 1, 22):
+            assert len(detections) == 1
+        elif time == datetime.datetime(2018, 1, 1, 14, 1, 27):
+            assert len(detections) == 1
+
+    hdf5_reader = HDF5DetectionReader(
+        hdf5_filename.strpath, ["state/x", "state/y"], "t", time_res_second=10
+    )
+    for time, detections in hdf5_reader:
+        if time == datetime.datetime(2018, 1, 1, 14, 0):
+            assert len(detections) == 3
+        if time == datetime.datetime(2018, 1, 1, 14, 1, 10):
+            assert len(detections) == 1
+        elif time == datetime.datetime(2018, 1, 1, 14, 1, 20):
+            assert len(detections) == 2


### PR DESCRIPTION
Borrowed from the generic CSV readers to support HDF5 files, adding the option to reduce the resolution of time fields while reading data in.