### PR TITLE
Disable documentation table of content entries for objects

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -106,6 +106,7 @@ source_suffix = '.rst'
 
 # The master toctree document.
 master_doc = 'index'
+toc_object_entries = False
 
 # General information about the project.
 project = 'Stone Soup'


### PR DESCRIPTION
A new feature, enabled by default, in Sphinx includes object entries in table of contents, which is too verbose. Disabling to keep previous behaviour.