### PR TITLE
Maintain order of truths in tutorials for reproducibility

### DIFF
--- a/docs/tutorials/06_DataAssociation-MultiTargetTutorial.py
+++ b/docs/tutorials/06_DataAssociation-MultiTargetTutorial.py
@@ -73,10 +73,11 @@ from stonesoup.types.groundtruth import GroundTruthPath, GroundTruthState
 # %%
 # Generate ground truth
 # ^^^^^^^^^^^^^^^^^^^^^
+from ordered_set import OrderedSet
 
 np.random.seed(1991)
 
-truths = set()
+truths = OrderedSet()
 
 transition_model = CombinedLinearGaussianTransitionModel([ConstantVelocity(0.005),
                                                           ConstantVelocity(0.005)])
@@ -93,7 +94,7 @@ for k in range(1, 21):
     truth.append(GroundTruthState(
         transition_model.function(truth[k-1], noise=True, time_interval=timedelta(seconds=1)),
         timestamp=start_time+timedelta(seconds=k)))
-truths.add(truth)
+_ = truths.add(truth)
 
 # %%
 # Plot the ground truth

--- a/docs/tutorials/08_JPDATutorial.py
+++ b/docs/tutorials/08_JPDATutorial.py
@@ -65,6 +65,7 @@
 
 from datetime import datetime
 from datetime import timedelta
+from ordered_set import OrderedSet
 import numpy as np
 from scipy.stats import uniform
 
@@ -77,7 +78,7 @@ from stonesoup.models.measurement.linear import LinearGaussian
 
 np.random.seed(1991)
 
-truths = set()
+truths = OrderedSet()
 
 start_time = datetime.now()
 transition_model = CombinedLinearGaussianTransitionModel([ConstantVelocity(0.005),

--- a/docs/tutorials/09_Initiators_&_Deleters.py
+++ b/docs/tutorials/09_Initiators_&_Deleters.py
@@ -20,6 +20,7 @@ from datetime import datetime
 from datetime import timedelta
 
 import numpy as np
+from ordered_set import OrderedSet
 
 from stonesoup.models.transition.linear import CombinedLinearGaussianTransitionModel, \
                                                ConstantVelocity
@@ -28,7 +29,7 @@ from stonesoup.types.groundtruth import GroundTruthPath, GroundTruthState
 np.random.seed(1991)
 
 start_time = datetime.now()
-truths = set()  # Truths across all time
+truths = OrderedSet()  # Truths across all time
 current_truths = set()  # Truths alive at current time
 
 transition_model = CombinedLinearGaussianTransitionModel([ConstantVelocity(0.005),

--- a/docs/tutorials/filters/GMPHDTutorial.py
+++ b/docs/tutorials/filters/GMPHDTutorial.py
@@ -110,6 +110,7 @@ plt.rcParams['figure.figsize'] = (14, 12)
 plt.style.use('seaborn-colorblind')
 # Other general imports
 import numpy as np
+from ordered_set import OrderedSet
 from datetime import datetime, timedelta
 start_time = datetime.now()
 
@@ -129,7 +130,7 @@ transition_model = CombinedLinearGaussianTransitionModel(
 
 from stonesoup.types.groundtruth import GroundTruthPath, GroundTruthState
 start_time = datetime.now()
-truths = set()  # Truths across all time
+truths = OrderedSet()  # Truths across all time
 current_truths = set()  # Truths alive at current time
 start_truths = set()
 number_steps = 20


### PR DESCRIPTION
Due to simulating detections in tutorials, the order of the truths, will change which random noise sample goes with each detections, centred on the truth. Maintaining order of truths should ensure that same random sample is used consistently.

Fixes #718