### PR TITLE
Fixed TypeError being thrown on certain Gaussian states in the Plotter.plot_tracks function

### DIFF
--- a/stonesoup/plotter.py
+++ b/stonesoup/plotter.py
@@ -343,6 +343,10 @@ class Plotter(_Plotter):
                     HH = np.eye(track.ndim)[mapping, :]  # Get position mapping matrix
                     for state in track:
                         w, v = np.linalg.eig(HH @ state.covar @ HH.T)
+                        if np.iscomplexobj(w) or np.iscomplexobj(v):
+                            warnings.warn("Can not plot uncertainty for all states due to complex "
+                                          "eignevalues or eigenvectors", UserWarning)
+                            continue
                         max_ind = np.argmax(w)
                         min_ind = np.argmin(w)
                         orient = np.arctan2(v[1, max_ind], v[0, max_ind])

--- a/stonesoup/tests/test_plotter.py
+++ b/stonesoup/tests/test_plotter.py
@@ -196,3 +196,16 @@ def test_plot_density_equal_x_y():
             timestamp=start_time + timedelta(seconds=k + 1)))
     with pytest.raises(ValueError):
         plotter.plot_density({truth}, index=None)
+
+
+def test_plot_complex_uncertainty():
+    plotter = Plotter()
+    track = Track([
+        GaussianState(
+            state_vector=[0, 0],
+            covar=[[10, -1], [1, 10]])
+    ])
+    with pytest.warns(UserWarning, match="Can not plot uncertainty for all states due to complex "
+                                         "eignevalues or eigenvectors"):
+
+        plotter.plot_tracks(track, mapping=[0, 1], uncertainty=True)


### PR DESCRIPTION
For some Gaussian states the uncertainity can't be plotted by the `Plotter` class. You can see if you try running the following code
```
from stonesoup.plotter import Plotter
from stonesoup.types.track import Track
from stonesoup.types.state import GaussianState, StateVector

track = Track([GaussianState(state_vector=[0, 0], covar=[[10, -1], [1, 10]])])
Plotter().plot_tracks(track, mapping=[0, 1], uncertainty=True)
# TypeError: ufunc 'arctan2' not supported for the input types, and the inputs could not be safely coerced to any supported types according to the casting rule ''safe''
```

This is caused by complex eignevalues or eigenvectors from the uncertainity matrix. I've put in a check for these in the `Plotter` class. States which cause complex eignevalues or eigenvectors are now skipped in the plot_tracks function and a warning is raised. A test has been created for this behaviour