### PR TITLE
Progress Trackers Manually

### DIFF
--- a/stonesoup/tracker/pointprocess.py
+++ b/stonesoup/tracker/pointprocess.py
@@ -1,16 +1,20 @@
-from .base import Tracker
+import datetime
+from typing import Tuple, Set
+
+from .base import TrackerWithDetector
 from ..base import Property
-from ..reader import DetectionReader
-from ..types.state import TaggedWeightedGaussianState
-from ..types.mixture import GaussianMixture
-from ..types.numeric import Probability
-from ..types.track import Track
-from ..updater import Updater
 from ..hypothesiser.gaussianmixture import GaussianMixtureHypothesiser
 from ..mixturereducer.gaussianmixture import GaussianMixtureReducer
+from ..reader import DetectionReader
+from ..types.detection import Detection
+from ..types.mixture import GaussianMixture
+from ..types.numeric import Probability
+from ..types.state import TaggedWeightedGaussianState
+from ..types.track import Track
+from ..updater import Updater
 
 
-class PointProcessMultiTargetTracker(Tracker):
+class PointProcessMultiTargetTracker(TrackerWithDetector):
     """
     Base class for Gaussian Mixture (GM) style implementations of
     point process derived filters
@@ -40,15 +44,11 @@ class PointProcessMultiTargetTracker(Tracker):
         self.gaussian_mixture = GaussianMixture()
 
     @property
-    def tracks(self):
+    def tracks(self) -> Set[Track]:
         tracks = set()
         for track in self.target_tracks.values():
             tracks.add(track)
         return tracks
-
-    def __iter__(self):
-        self.detector_iter = iter(self.detector)
-        return super().__iter__()
 
     def update_tracks(self):
         """
@@ -77,8 +77,8 @@ class PointProcessMultiTargetTracker(Tracker):
                             self.extraction_threshold:
                         self.target_tracks[tag] = Track([component], id=tag)
 
-    def __next__(self):
-        time, detections = next(self.detector_iter)
+    def update_tracker(self, time: datetime.datetime, detections: Set[Detection]) \
+            -> Tuple[datetime.datetime, Set[Track]]:
         # Add birth component
         self.birth_component.timestamp = time
         self.gaussian_mixture.append(self.birth_component)

--- a/stonesoup/tracker/simple.py
+++ b/stonesoup/tracker/simple.py
@@ -1,19 +1,24 @@
+import datetime
+from typing import Tuple, Set
+
 import numpy as np
 
-from .base import Tracker
+from .base import TrackerWithDetector
 from ..base import Property
 from ..dataassociator import DataAssociator
 from ..deleter import Deleter
-from ..reader import DetectionReader
-from ..initiator import Initiator
-from ..updater import Updater
-from ..types.array import StateVectors
-from ..types.prediction import GaussianStatePrediction
-from ..types.update import GaussianStateUpdate
 from ..functions import gm_reduce_single
+from ..initiator import Initiator
+from ..reader import DetectionReader
+from ..types.array import StateVectors
+from ..types.detection import Detection
+from ..types.prediction import GaussianStatePrediction
+from ..types.track import Track
+from ..types.update import GaussianStateUpdate
+from ..updater import Updater
 
 
-class SingleTargetTracker(Tracker):
+class SingleTargetTracker(TrackerWithDetector):
     """A simple single target tracker.
 
     Track a single object using Stone Soup components. The tracker works by
@@ -46,15 +51,12 @@ class SingleTargetTracker(Tracker):
         self._track = None
 
     @property
-    def tracks(self):
+    def tracks(self) -> Set[Track]:
         return {self._track} if self._track else set()
 
-    def __iter__(self):
-        self.detector_iter = iter(self.detector)
-        return super().__iter__()
+    def update_tracker(self, time: datetime.datetime, detections: Set[Detection]) \
+            -> Tuple[datetime.datetime, Set[Track]]:
 
-    def __next__(self):
-        time, detections = next(self.detector_iter)
         if self._track is not None:
             associations = self.data_associator.associate(
                 self.tracks, detections, time)
@@ -75,7 +77,7 @@ class SingleTargetTracker(Tracker):
         return time, self.tracks
 
 
-class MultiTargetTracker(Tracker):
+class MultiTargetTracker(TrackerWithDetector):
     """A simple multi target tracker.
 
     Track multiple objects using Stone Soup components. The tracker works by
@@ -101,15 +103,11 @@ class MultiTargetTracker(Tracker):
         self._tracks = set()
 
     @property
-    def tracks(self):
+    def tracks(self) -> Set[Track]:
         return self._tracks
 
-    def __iter__(self):
-        self.detector_iter = iter(self.detector)
-        return super().__iter__()
-
-    def __next__(self):
-        time, detections = next(self.detector_iter)
+    def update_tracker(self, time: datetime.datetime, detections: Set[Detection]) \
+            -> Tuple[datetime.datetime, Set[Track]]:
 
         associations = self.data_associator.associate(
             self.tracks, detections, time)
@@ -129,7 +127,7 @@ class MultiTargetTracker(Tracker):
         return time, self.tracks
 
 
-class MultiTargetMixtureTracker(Tracker):
+class MultiTargetMixtureTracker(TrackerWithDetector):
     """A simple multi target tracker that receives associations from a
     (Gaussian) Mixture associator.
 
@@ -157,15 +155,11 @@ class MultiTargetMixtureTracker(Tracker):
         self._tracks = set()
 
     @property
-    def tracks(self):
+    def tracks(self) -> Set[Track]:
         return self._tracks
 
-    def __iter__(self):
-        self.detector_iter = iter(self.detector)
-        return super().__iter__()
-
-    def __next__(self):
-        time, detections = next(self.detector_iter)
+    def update_tracker(self, time: datetime.datetime, detections: Set[Detection]) \
+            -> Tuple[datetime.datetime, Set[Track]]:
 
         associations = self.data_associator.associate(
             self.tracks, detections, time)

--- a/stonesoup/tracker/tests/test_simple.py
+++ b/stonesoup/tracker/tests/test_simple.py
@@ -5,8 +5,9 @@ from ..simple import SingleTargetTracker, MultiTargetTracker, \
 
 def test_single_target_tracker(
         initiator, deleter, detector, data_associator, updater):
-    tracker = SingleTargetTracker(
-        initiator, deleter, detector, data_associator, updater)
+
+    tracker = SingleTargetTracker(initiator=initiator, deleter=deleter, detector=detector,
+                                  data_associator=data_associator, updater=updater)
 
     previous_time = datetime.datetime(2018, 1, 1, 13, 59)
     total_tracks = set()
@@ -24,8 +25,9 @@ def test_single_target_tracker(
 
 def test_multi_target_tracker(
         initiator, deleter, detector, data_associator, updater):
-    tracker = MultiTargetTracker(
-        initiator, deleter, detector, data_associator, updater)
+
+    tracker = MultiTargetTracker(initiator=initiator, deleter=deleter, detector=detector,
+                                 data_associator=data_associator, updater=updater)
 
     previous_time = datetime.datetime(2018, 1, 1, 13, 59)
     max_tracks = 0
@@ -51,8 +53,9 @@ def test_multi_target_tracker(
 
 def test_multi_target_mixture_tracker(
         initiator, deleter, detector, data_mixture_associator, updater):
-    tracker = MultiTargetMixtureTracker(
-        initiator, deleter, detector, data_mixture_associator, updater)
+
+    tracker = MultiTargetMixtureTracker(initiator=initiator, deleter=deleter, detector=detector,
+                                        data_associator=data_mixture_associator, updater=updater)
 
     previous_time = datetime.datetime(2018, 1, 1, 13, 59)
     max_tracks = 0


### PR DESCRIPTION
All current trackers require a detection feeder. It can be useful to progress a tracker manually without a detection feeder (see Multi-Sensor Fusion: Covariance Intersection Using Tracks as Measurements example). 

All current trackers and start their `__next__` function with:
```
time, detections = next(self.detector_iter)
# Some tracking logic
```

I've abstracted this line to the new `TrackerWithDetector` class and added an `update_tracker` function which takes the time and detections from the detection feeder as an input. With this being a separate function, you can access it directly and bypass the detection feeder which may be easier in instances