### PR TITLE
Modified dotproduct to work with StateVectors 

### DIFF
--- a/stonesoup/functions/__init__.py
+++ b/stonesoup/functions/__init__.py
@@ -633,7 +633,7 @@ def dotproduct(a, b):
 
     def _dotproductvectors(v1, v2):
         # This operates on a StateVector
-        oout=0
+        oout = 0
         for a_i, b_i in zip(v1, v2):
             oout += a_i*b_i
         return oout

--- a/stonesoup/functions/__init__.py
+++ b/stonesoup/functions/__init__.py
@@ -614,37 +614,43 @@ def build_rotation_matrix(angle_vector: np.ndarray):
 
 
 def dotproduct(a, b):
-    r"""Returns the dot (or scalar) product of two StateVectors.
+    r"""Returns the dot (or scalar) product of two StateVectors or two sets of StateVectors.
 
-    The result for vectors of length :math:`n` is
-    :math:`\Sigma_i^n a_i b_i`.
-
-    Inputs are state vectors, i.e. the second dimension is 1
+    The result for vectors of length :math:`n` is :math:`\Sigma_i^n a_i b_i`.
 
     Parameters
     ----------
-    a : StateVector
-        A state vector
-    b : StateVector
-        A state vector of equal length to :math:`a`
+    a : StateVector, StateVectors
+        A (set of) state vector(s)
+    b : StateVector, StateVectors
+        A state vector(s) object of equal dimension to :math:`a`
 
     Returns
     -------
-    : float
-        A scalar value representing the dot product of the vectors.
+    : float, numpy.array
+        A (set of) scalar value(s) representing the dot product of the vectors.
     """
-    if np.shape(a)[1] != 1 or np.shape(b)[1] != 1 or np.ndim(a) != 2 or \
-            np.ndim(b) != 2:
-        raise ValueError("Inputs must be column vectors")
 
-    if np.shape(a)[0] != np.shape(b)[0]:
-        raise ValueError("Input vectors must be the same length")
+    def _dotproductvectors(v1, v2):
+        # This operates on a StateVector
+        oout=0
+        for a_i, b_i in zip(v1, v2):
+            oout += a_i*b_i
+        return oout
 
-    out = 0
-    for a_i, b_i in zip(a, b):
-        out += a_i*b_i
+    if np.shape(a) != np.shape(b):
+        raise ValueError("Inputs must be (a collection of) column vectors of the same dimension")
 
-    return out
+    # Decide whether this is a StateVector or a StateVectors
+    if type(a) is StateVector and type(b) is StateVector:
+        return _dotproductvectors(a, b)
+    elif type(a) is StateVectors and type(b) is StateVectors:
+        out = []
+        for aa, bb in zip(a, b):
+            out.append(_dotproductvectors(aa, bb))
+        return np.reshape(out, np.shape(np.atleast_2d(a[0, :])))
+    else:
+        raise ValueError("Inputs must be `StateVector` or `StateVectors` and of the same type")
 
 
 def sde_euler_maruyama_integration(fun, t_values, state_x0):

--- a/stonesoup/functions/__init__.py
+++ b/stonesoup/functions/__init__.py
@@ -631,24 +631,14 @@ def dotproduct(a, b):
         A (set of) scalar value(s) representing the dot product of the vectors.
     """
 
-    def _dotproductvectors(v1, v2):
-        # This operates on a StateVector
-        oout = 0
-        for a_i, b_i in zip(v1, v2):
-            oout += a_i*b_i
-        return oout
-
     if np.shape(a) != np.shape(b):
         raise ValueError("Inputs must be (a collection of) column vectors of the same dimension")
 
     # Decide whether this is a StateVector or a StateVectors
     if type(a) is StateVector and type(b) is StateVector:
-        return _dotproductvectors(a, b)
+        return np.sum(a*b)
     elif type(a) is StateVectors and type(b) is StateVectors:
-        out = []
-        for aa, bb in zip(a, b):
-            out.append(_dotproductvectors(aa, bb))
-        return np.reshape(out, np.shape(np.atleast_2d(a[0, :])))
+        return np.asarray(np.sum(a*b, axis=0))
     else:
         raise ValueError("Inputs must be `StateVector` or `StateVectors` and of the same type")
 

--- a/stonesoup/functions/__init__.py
+++ b/stonesoup/functions/__init__.py
@@ -638,7 +638,7 @@ def dotproduct(a, b):
     if type(a) is StateVector and type(b) is StateVector:
         return np.sum(a*b)
     elif type(a) is StateVectors and type(b) is StateVectors:
-        return np.asarray(np.sum(a*b, axis=0))
+        return np.atleast_2d(np.asarray(np.sum(a*b, axis=0)))
     else:
         raise ValueError("Inputs must be `StateVector` or `StateVectors` and of the same type")
 

--- a/stonesoup/functions/tests/test_functions.py
+++ b/stonesoup/functions/tests/test_functions.py
@@ -255,7 +255,7 @@ def test_dotproduct(state_vector1, state_vector2):
         with pytest.raises(ValueError):
             dotproduct(state_vector1, state_vector2)
     elif type(state_vector1) != StateVectors and type(state_vector2) != StateVectors and \
-        type(state_vector2) != StateVector and type(state_vector1) != StateVector:
+            type(state_vector2) != StateVector and type(state_vector1) != StateVector:
         with pytest.raises(ValueError):
             dotproduct(state_vector1, state_vector2)
     else:

--- a/stonesoup/functions/tests/test_functions.py
+++ b/stonesoup/functions/tests/test_functions.py
@@ -243,13 +243,19 @@ def test_cart_sphere_inversions(x, y, z):
         (StateVector([-1, 1, -4]), StateVector([-2, 1, 1])),
         (StateVector([-2, 0, 3, -1]), StateVector([1, 0, -1, 4])),
         (StateVector([-1, 0]), StateVector([1, -2, 3])),
-        (Matrix([[1, 0], [0, 1]]), Matrix([[3, 1], [1, -3]]))
+        (Matrix([[1, 0], [0, 1]]), Matrix([[3, 1], [1, -3]])),
+        (StateVectors([[1, 0], [0, 1]]), StateVectors([[3, 1], [1, -3]])),
+        (StateVectors([[1, 0], [0, 1]]), StateVector([3, 1]))
      ]
 )
 def test_dotproduct(state_vector1, state_vector2):
 
     # Test that they raise the right error if not 1d, i.e. vectors
-    if np.shape(state_vector1)[1] != 1 | np.shape(state_vector2)[1] != 1:
+    if type(state_vector1) != type(state_vector2):
+        with pytest.raises(ValueError):
+            dotproduct(state_vector1, state_vector2)
+    elif type(state_vector1) != StateVectors and type(state_vector2) != StateVectors and \
+        type(state_vector2) != StateVector and type(state_vector1) != StateVector:
         with pytest.raises(ValueError):
             dotproduct(state_vector1, state_vector2)
     else:
@@ -263,4 +269,5 @@ def test_dotproduct(state_vector1, state_vector2):
             for a_i, b_i in zip(state_vector1, state_vector2):
                 out += a_i * b_i
 
-            assert dotproduct(state_vector1, state_vector2) == out
+            assert np.allclose(dotproduct(state_vector1, state_vector2),
+                               np.reshape(out, np.shape(dotproduct(state_vector1, state_vector2))))


### PR DESCRIPTION
Dotproduct function previously only worked with `StateVector`. This is designed to make it work with `StateVectors` and return an numpy.array of dimension 1x the number of `StateVector`s.