### PR TITLE
Add logpdf method to models, and implement in particle filter

### DIFF
--- a/stonesoup/models/measurement/nonlinear.py
+++ b/stonesoup/models/measurement/nonlinear.py
@@ -1152,3 +1152,7 @@ class RangeRangeRateBinning(CartesianToElevationBearingRangeRate):
             return Probability(range_pdf * velocity_pdf * az_el_pdf)
         else:
             return Probability(0)
+
+    def logpdf(self, *args, **kwargs):
+        # As pdf replaced, need to go to first non GaussianModel parent
+        return super(ReversibleModel, self).logpdf(*args, **kwargs)

--- a/stonesoup/models/measurement/tests/test_models.py
+++ b/stonesoup/models/measurement/tests/test_models.py
@@ -910,7 +910,9 @@ def test_binning_pdf():
 
     measured = measurement_model.function(real_state, noise=True)
     pdf = measurement_model.pdf(State(measured), real_state)
+    logpdf = measurement_model.logpdf(State(measured), real_state)
     assert pdf != 0
+    assert np.log(pdf) == pytest.approx(logpdf)
     not_measured = measured.copy()
     not_measured[2, 0] = not_measured[2, 0] + 0.5*measurement_model.range_res
     pdf = measurement_model.pdf(State(not_measured), real_state)

--- a/stonesoup/resampler/particle.py
+++ b/stonesoup/resampler/particle.py
@@ -27,7 +27,7 @@ class SystematicResampler(Resampler):
         n_particles = len(particles)
         weight = Probability(1 / n_particles)
 
-        log_weights = np.array([weight.log_value for weight in particles.weight])
+        log_weights = np.asfarray(np.log(particles.weight))
         weight_order = np.argsort(log_weights, kind='stable')
         max_log_value = log_weights[weight_order[-1]]
         with np.errstate(divide='ignore'):

--- a/stonesoup/types/numeric.py
+++ b/stonesoup/types/numeric.py
@@ -10,6 +10,13 @@ class Probability(Real):
     Similar to a float, but value stored as natural log value internally.
     All operations are attempted with log values where possible, and failing
     that a float will be returned instead.
+
+    Parameters
+    ----------
+    value : float
+        Value for probability.
+    log_value : bool
+        Set to `True` if :attr:`value` already a log value. Default `False`.
     """
 
     def __init__(self, value, *, log_value=False):
@@ -212,7 +219,7 @@ class Probability(Real):
         if value == 0 and self.log_value != float("-inf"):  # Too close to zero
             return "Probability({!r}, log_value=True)".format(self.log_value)
         else:
-            return "Probability({!r})".format(float(self))
+            return "Probability({!r})".format(value)
 
     def __str__(self):
         value = float(self)
@@ -244,3 +251,21 @@ class Probability(Real):
         value_sum = np.sum(np.exp(log_values - max_log_value))
 
         return Probability(cls._log(value_sum) + max_log_value, log_value=True)
+
+    @classmethod
+    def from_log(cls, value):
+        """Create Probability type from a log value; same as Probability(value, log_value=True)
+
+        Parameters
+        ----------
+        value : float
+            Value for probability.
+
+        Returns
+        -------
+        Probability
+        """
+        return cls(value, log_value=True)
+
+
+Probability.from_log_ufunc = np.frompyfunc(Probability.from_log, 1, 1)

--- a/stonesoup/types/state.py
+++ b/stonesoup/types/state.py
@@ -682,14 +682,14 @@ class ParticleState(State):
         """Sample mean for particles"""
         if len(self) == 1:  # No need to calculate mean
             return self.state_vector
-        return np.average(self.state_vector, axis=1, weights=self.weight)
+        return np.average(self.state_vector, axis=1, weights=np.asfarray(self.weight))
 
     @clearable_cached_property('state_vector', 'weight', 'fixed_covar')
     def covar(self):
         """Sample covariance matrix for particles"""
         if self.fixed_covar is not None:
             return self.fixed_covar
-        return np.cov(self.state_vector, ddof=0, aweights=self.weight)
+        return np.cov(self.state_vector, ddof=0, aweights=np.asfarray(self.weight))
 
 
 State.register(ParticleState)  # noqa: E305

--- a/stonesoup/types/tests/test_numeric.py
+++ b/stonesoup/types/tests/test_numeric.py
@@ -1,5 +1,6 @@
 from math import log, floor, ceil, trunc, sqrt
 
+import numpy as np
 import pytest
 from pytest import approx
 
@@ -12,10 +13,19 @@ def test_probability_init():
     assert probability == 0.2
     assert probability.log_value == log(0.2)
 
-    Probability(log(0.2), log_value=True)
+    probability = Probability(log(0.2), log_value=True)
 
     assert probability == 0.2
     assert probability.log_value == log(0.2)
+
+    probability = Probability.from_log(log(0.2))
+    assert probability == 0.2
+    assert probability.log_value == log(0.2)
+
+    probabilities = Probability.from_log_ufunc(np.log(np.array([0.2, 0.3])))
+    for probability, val in zip(probabilities, [0.2, 0.3]):
+        assert float(probability) == pytest.approx(val)
+        assert probability.log_value == pytest.approx(log(val))
 
     with pytest.raises(ValueError, match="value must be greater than 0"):
         Probability(-0.2)


### PR DESCRIPTION
This avoids a number a nugatory calculations switching in/out of log space with Probability class.

Also modified mean/covar calculation in particle state to use float array to avoid similar issue caused by Probability class forcing use of object arrays.