### PR TITLE
TimeBasedPlotter default timestamps and Notebook animation docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ htmlcov/
 
 # pytest
 .pytest_cache/
+
+#Animation plotting example
+docs/examples/example_animation.gif

--- a/docs/examples/TimePlotterExample.py
+++ b/docs/examples/TimePlotterExample.py
@@ -133,8 +133,6 @@ print("The simulation produced:\n",
 # Create the Animation
 # --------------------
 from stonesoup.plotter import AnimationPlotter
-from matplotlib import pyplot as plt
-
 
 # %%
 # Create the plotter object and use the plot_# functions to assign the data to plot
@@ -146,15 +144,15 @@ plotter.plot_tracks(all_tracks, mapping=[0, 2])
 # %%
 # Run the Animation
 # -----------------
-# The times to refresh the animation are chosen to co-inside with the simulator times
-#
+# The following is needed to ensure that the animation is made playable via interactive
+# player in Jupyter Notebooks.
+import matplotlib
+matplotlib.rcParams['animation.html'] = 'jshtml'
+
+# %%
 # To avoid the figure becoming too cluttered with old information, states older than 60 seconds will
 # not be shown.
-times_to_plot = [start_time + x * groundtruth_sim.timestep
-                 for x in range(groundtruth_sim.number_steps)]
-
-ani = plotter.run(times_to_plot, plot_item_expiry=datetime.timedelta(seconds=60))
-plt.show()
+plotter.run(plot_item_expiry=datetime.timedelta(seconds=60))
 
 # %%
 # Save the Animation
@@ -162,12 +160,3 @@ plt.show()
 # Save the animation to a gif format. Other formats are available.
 plotter.save('example_animation.gif')
 
-# %%
-# Viewing the Animation in a Jupyter notebook
-# -------------------------------------------
-# The following section displays the animation when using a Jupyter notebook. This option is
-# commented out for the sphinx documentation to build properly. Uncomment `HTML(ani.to_jshtml())`
-# and `from IPython.display import HTML` to view the animation in a jupyter notebook
-
-# from IPython.display import HTML
-# HTML(ani.to_jshtml())

--- a/stonesoup/plotter.py
+++ b/stonesoup/plotter.py
@@ -998,20 +998,29 @@ class AnimationPlotter(_Plotter):
 
         self.animation_output: animation.FuncAnimation = None
 
-    def run(self, times_to_plot=List[datetime], plot_item_expiry: Optional[timedelta] = None,
+    def run(self,
+            times_to_plot: List[datetime] = None,
+            plot_item_expiry: Optional[timedelta] = None,
             **kwargs):
         """Run the animation
 
         Parameters
         ----------
         times_to_plot : List of :class:`~.datetime`
-            List of datetime objects of when to refresh and draw the animation
+            List of datetime objects of when to refresh and draw the animation. Default `None`,
+            where unique timestamps of data will be used.
         plot_item_expiry: :class:`~.timedelta`, Optional
             Describes how long states will remain present in the figure. Default value of None
             means data is shown indefinitely
         \\*\\*kwargs: dict
             Additional arguments to be passed to the animation.FuncAnimation function
         """
+
+        if times_to_plot is None:
+            times_to_plot = sorted({
+                state.timestamp
+                for plotting_data in self.plotting_data
+                for state in plotting_data.plotting_data})
 
         self.animation_output = self.run_animation(
             times_to_plot=times_to_plot,


### PR DESCRIPTION
- Use all timestamps by default for TimeBasedPlotter
  This no longer requires specifying the time stamps, as they default to
those from data being plotted
- Simplify docs for Notebook use of animations in TimeBasedPlotter
   Also ignore example gif file that is saved.