### PR TITLE
Fix covar for ConstantNthDerivative model

### DIFF
--- a/stonesoup/models/transition/linear.py
+++ b/stonesoup/models/transition/linear.py
@@ -147,7 +147,7 @@ class ConstantNthDerivative(LinearGaussianTransitionModel, TimeVariantModel):
             covar = np.zeros((N + 1, N + 1))
             for l in range(0, N + 1):  # noqa: E741
                 for k in range(0, N + 1):
-                    covar[l, k] = (igrand[l, k]*dt / (1 + N**2 - l - k))
+                    covar[l, k] = (igrand[l, k]*dt / (1 + N*2 - l - k))
         covar *= self.noise_diff_coeff
         return CovarianceMatrix(covar)
 


### PR DESCRIPTION
Fixed covar calculation of constant nth derivative. Line 150 had “N**2”, corrected to “N*2”.