### PR TITLE
Rotation matrix fix

### DIFF
--- a/stonesoup/functions/__init__.py
+++ b/stonesoup/functions/__init__.py
@@ -610,7 +610,7 @@ def build_rotation_matrix(angle_vector: np.ndarray):
     theta_x = -angle_vector[0, 0]  # roll
     theta_y = angle_vector[1, 0]  # pitch#elevation
     theta_z = -angle_vector[2, 0]  # yaw#azimuth
-    return rotz(theta_z) @ roty(theta_y) @ rotx(theta_x)
+    return rotx(theta_x) @ roty(theta_y) @ rotz(theta_z)
 
 
 def dotproduct(a, b):

--- a/stonesoup/models/measurement/tests/test_models.py
+++ b/stonesoup/models/measurement/tests/test_models.py
@@ -339,9 +339,9 @@ position_measurement_sets = [((0, 1, 0, 0, 0, 0), (1, 0, 0, 0, 0, 0),
                               (-np.pi / 4, 0, np.sqrt(200), -1 / np.sqrt(2))),
                              ((0, 0, 0, 0, 0, 1), (0, 0, 0, 0, 10, 0),
                               (0, 0, 10, -1)),    # original tests up to here
-                             ((0, 2, 0, 0, 0, 1),(1, 2, 0, 0, 1, 1),
+                             ((0, 2, 0, 0, 0, 1), (1, 2, 0, 0, 1, 1),
                               (np.pi/4-np.arctan(0.5), 0, np.sqrt(2), 0)),
-                             ((0, 2, 0, 0, 0, -1),(1, 2, 0, 0, 1, -1),
+                             ((0, 2, 0, 0, 0, -1), (1, 2, 0, 0, 1, -1),
                               (np.pi/4+np.arctan(0.5), 0, np.sqrt(2), 0)),
                              ((0, -2, 0, 0, 0, 1), (1, -2, 0, 0, 1, 1),
                               (np.pi/4+np.arctan(0.5), np.pi, np.sqrt(2), 0)),
@@ -403,11 +403,15 @@ position_measurement_sets = [((0, 1, 0, 0, 0, 0), (1, 0, 0, 0, 0, 0),
                               (0, np.pi/4+np.arctan(0.5), np.sqrt(2), 0)),
                              ((0, -2, 0, -1, 0, 0), (-1, -2, -1, -1, 0, 0),
                               (0, np.pi/4-np.arctan(0.5), np.sqrt(2), 0)),
-                             ((1, -1, 0, 1, 0, 1),(0, -1, 0, 1, 0, 1),
-                              (-np.arccos((np.sqrt((np.cos(np.arctan(1/np.sqrt(2)))**2)+1))/np.sqrt(2)), np.pi/2-np.arctan(np.cos(np.arctan(1/np.sqrt(2)))), 1, 0)),
-                             ((0, 1, 0, 1, 0, 1),(1, 1, 0, 1, 0, 1),
-                              (-np.arccos((np.sqrt((np.cos(np.arctan(1/np.sqrt(2)))**2)+1))/np.sqrt(2)), -(np.pi/2-np.arctan(np.cos(np.arctan(1/np.sqrt(2))))), 1, 0)),
-                             ((0, 1, 0, 0 ,0 ,0),(1, 1, 1, 0, 1, 0),
+                             ((1, -1, 0, 1, 0, 1), (0, -1, 0, 1, 0, 1),
+                              (-np.arccos((np.sqrt((np.cos(np.arctan(1/np.sqrt(2)))**2)+1)) /
+                                          np.sqrt(2)),
+                               np.pi/2-np.arctan(np.cos(np.arctan(1/np.sqrt(2)))), 1, 0)),
+                             ((0, 1, 0, 1, 0, 1), (1, 1, 0, 1, 0, 1),
+                              (-np.arccos((np.sqrt((np.cos(np.arctan(1/np.sqrt(2)))**2)+1)) /
+                                          np.sqrt(2)),
+                               -(np.pi/2-np.arctan(np.cos(np.arctan(1/np.sqrt(2))))), 1, 0)),
+                             ((0, 1, 0, 0, 0, 0), (1, 1, 1, 0, 1, 0),
                               (np.arctan(1/np.sqrt(2)), np.pi/4, np.sqrt(3), 0))
                              ]
 

--- a/stonesoup/models/measurement/tests/test_models.py
+++ b/stonesoup/models/measurement/tests/test_models.py
@@ -228,8 +228,6 @@ def test_models(h, ModelClass, state_vec, R,
     # (without noise)
     meas_pred_wo_noise = model.function(state)
     eval_m = h(state_vec, mapping, model.translation_offset, model.rotation_offset)
-    if not np.array_equal(meas_pred_wo_noise, eval_m):
-        pause=0
     assert np.array_equal(meas_pred_wo_noise, eval_m)
 
     # Ensure ```lg.transfer_function()``` returns H
@@ -441,12 +439,7 @@ def test_model_predictions(sensor_state, target_state, expected_measurement, mod
     if use_velocity:
         model.velocity = sensor_velocity
     actual_measurement = model.function(target_state, noise=False)
-    expected_values = expected_measurement[measure_mapping]
-    for i, v in enumerate(expected_values):
-        if isinstance(v, Bearing):
-            expected_values[i] = v._value
-    #assert np.allclose(actual_measurement, expected_measurement[measure_mapping])
-    assert np.allclose(actual_measurement, expected_values)
+    assert np.allclose(actual_measurement, expected_measurement[measure_mapping])
 
 
 def test_angle_pdf():
@@ -1046,11 +1039,7 @@ def test_noiseless_binning_predictions(sensor_state, target_state, expected_meas
         velocity=sensor_velocity)
     actual_measurement = model.function(target_state, noise=False)
     measure_mapping = [0, 1, 2, 3]
-    expected_values = expected_measurement[measure_mapping]
-    for i, v in enumerate(expected_values):
-        if isinstance(v, Bearing):
-            expected_values[i] = v._value
-    assert np.allclose(actual_measurement, expected_values)
+    assert np.allclose(actual_measurement, expected_measurement[measure_mapping])
 
 
 def test_compare_rrrb_to_ctebrr():

--- a/stonesoup/models/measurement/tests/test_models.py
+++ b/stonesoup/models/measurement/tests/test_models.py
@@ -26,7 +26,7 @@ def h1d(state_vector, pos_map, translation_offset, rotation_offset):
     # Get rotation matrix
     theta_x, theta_y, theta_z = - rotation_offset[:, 0]
 
-    rotation_matrix = rotz(theta_z) @ roty(theta_y) @ rotx(theta_x)
+    rotation_matrix = rotx(theta_x) @ roty(theta_y) @ rotz(theta_z)
     xyz_rot = rotation_matrix @ xyz
 
     _, phi, _ = cart2sphere(*xyz_rot)
@@ -43,7 +43,7 @@ def h2d(state_vector, pos_map, translation_offset, rotation_offset):
     # Get rotation matrix
     theta_x, theta_y, theta_z = - rotation_offset[:, 0]
 
-    rotation_matrix = rotz(theta_z) @ roty(theta_y) @ rotx(theta_x)
+    rotation_matrix = rotx(theta_x) @ roty(theta_y) @ rotz(theta_z)
     xyz_rot = rotation_matrix @ xyz
 
     rho, phi, _ = cart2sphere(*xyz_rot)
@@ -58,7 +58,7 @@ def h3d(state_vector, pos_map,  translation_offset, rotation_offset):
     theta_x, theta_y, theta_z = - rotation_offset[:, 0]
     theta_y = - theta_y
 
-    rotation_matrix = rotz(theta_z) @ roty(theta_y) @ rotx(theta_x)
+    rotation_matrix = rotx(theta_x) @ roty(theta_y) @ rotz(theta_z)
     xyz_rot = rotation_matrix @ xyz
 
     rho, phi, theta = cart2sphere(*xyz_rot)
@@ -72,7 +72,7 @@ def hbearing(state_vector, pos_map, translation_offset, rotation_offset):
     # Get rotation matrix
     theta_x, theta_y, theta_z = - rotation_offset[:, 0]
 
-    rotation_matrix = rotz(theta_z) @ roty(theta_y) @ rotx(theta_x)
+    rotation_matrix = rotx(theta_x) @ roty(theta_y) @ rotz(theta_z)
     xyz_rot = rotation_matrix @ xyz
 
     _, phi, theta = cart2sphere(*xyz_rot)
@@ -228,6 +228,8 @@ def test_models(h, ModelClass, state_vec, R,
     # (without noise)
     meas_pred_wo_noise = model.function(state)
     eval_m = h(state_vec, mapping, model.translation_offset, model.rotation_offset)
+    if not np.array_equal(meas_pred_wo_noise, eval_m):
+        pause=0
     assert np.array_equal(meas_pred_wo_noise, eval_m)
 
     # Ensure ```lg.transfer_function()``` returns H
@@ -338,7 +340,77 @@ position_measurement_sets = [((0, 1, 0, 0, 0, 0), (1, 0, 0, 0, 0, 0),
                              ((0, 1, 0, 0, 0, 0), (10, 0, 0, 0, -10, 0),
                               (-np.pi / 4, 0, np.sqrt(200), -1 / np.sqrt(2))),
                              ((0, 0, 0, 0, 0, 1), (0, 0, 0, 0, 10, 0),
-                              (0, 0, 10, -1)),
+                              (0, 0, 10, -1)),    # original tests up to here
+                             ((0, 2, 0, 0, 0, 1),(1, 2, 0, 0, 1, 1),
+                              (np.pi/4-np.arctan(0.5), 0, np.sqrt(2), 0)),
+                             ((0, 2, 0, 0, 0, -1),(1, 2, 0, 0, 1, -1),
+                              (np.pi/4+np.arctan(0.5), 0, np.sqrt(2), 0)),
+                             ((0, -2, 0, 0, 0, 1), (1, -2, 0, 0, 1, 1),
+                              (np.pi/4+np.arctan(0.5), np.pi, np.sqrt(2), 0)),
+                             ((0, -2, 0, 0, 0, -1), (1, -2, 0, 0, 1, -1),
+                              (np.pi/4-np.arctan(0.5), np.pi, np.sqrt(2), 0)),
+                             ((0, 2, 0, 0, 0, 1), (1, 2, 0, 0, -1, 1),
+                              (-np.pi/4-np.arctan(0.5), 0, np.sqrt(2), 0)),
+                             ((0, 2, 0, 0, 0, -1), (1, 2, 0, 0, -1, -1),
+                              (-np.pi/4+np.arctan(0.5), 0, np.sqrt(2), 0)),
+                             ((0, -2, 0, 0, 0, 1), (1, -2, 0, 0, -1, 1),
+                              (-np.pi/4+np.arctan(0.5), np.pi, np.sqrt(2), 0)),
+                             ((0, -2, 0, 0, 0, -1), (1, -2, 0, 0, -1, -1),
+                              (-np.pi/4-np.arctan(0.5), np.pi, np.sqrt(2), 0)),
+                             ((0, 2, 0, 0, 0, 1), (-1, 2, 0, 0, 1, 1),
+                              (np.pi/4+np.arctan(0.5), np.pi, np.sqrt(2), 0)),
+                             ((0, 2, 0, 0, 0, -1), (-1, 2, 0, 0, 1, -1),
+                              (np.pi/4-np.arctan(0.5), np.pi, np.sqrt(2), 0)),
+                             ((0, -2, 0, 0, 0, 1), (-1, -2, 0, 0, 1, 1),
+                              (np.pi/4-np.arctan(0.5), 0, np.sqrt(2), 0)),
+                             ((0, -2, 0, 0, 0, -1), (-1, -2, 0, 0, 1, -1),
+                              (np.pi/4+np.arctan(0.5), 0, np.sqrt(2), 0)),
+                             ((0, 2, 0, 0, 0, 1), (-1, 2, 0, 0, -1, 1),
+                              (-np.pi/4+np.arctan(0.5), np.pi, np.sqrt(2), 0)),
+                             ((0, 2, 0, 0, 0, -1), (-1, 2, 0, 0, -1, -1),
+                              (-np.pi/4-np.arctan(0.5), np.pi, np.sqrt(2), 0)),
+                             ((0, -2, 0, 0, 0, 1), (-1, -2, 0, 0, -1, 1),
+                              (-np.pi/4-np.arctan(0.5), 0, np.sqrt(2), 0)),
+                             ((0, -2, 0, 0, 0, -1), (-1, -2, 0, 0, -1, -1),
+                              (-np.pi/4+np.arctan(0.5), 0, np.sqrt(2), 0)),
+                             ((0, 2, 0, 1, 0, 0), (1, 2, 1, 1, 0, 0),
+                              (0, np.pi / 4 - np.arctan(0.5), np.sqrt(2), 0)),
+                             ((0, 2, 0, -1, 0, 0), (1, 2, 1, -1, 0, 0),
+                              (0, np.pi / 4 + np.arctan(0.5), np.sqrt(2), 0)),
+                             ((0, -2, 0, 1, 0, 0), (1, -2, 1, 1, 0, 0),
+                              (0, -np.pi*3/4 + np.arctan(0.5), np.sqrt(2), 0)),
+                             ((0, -2, 0, -1, 0, 0), (1, -2, 1, -1, 0, 0),
+                              (0, -np.pi*3/4-np.arctan(0.5), np.sqrt(2), 0)),
+                             ((0, 2, 0, 1, 0, 0), (1, 2, -1, 1, 0, 0),
+                              (0, -np.pi/4-np.arctan(0.5), np.sqrt(2), 0)),
+                             ((0, 2, 0, -1, 0, 0), (1, 2, -1, -1, 0, 0),
+                              (0, -np.pi/4+np.arctan(0.5), np.sqrt(2), 0)),
+                             ((0, -2, 0, 1, 0, 0), (1, -2, -1, 1, 0, 0),
+                              (0, np.pi*3/4+np.arctan(0.5), np.sqrt(2), 0)),
+                             ((0, -2, 0, -1, 0, 0), (1, -2, -1, -1, 0, 0),
+                              (0, np.pi*3/4-np.arctan(0.5), np.sqrt(2), 0)),
+                             ((0, 2, 0, 1, 0, 0), (-1, 2, 1, 1, 0, 0),
+                              (0, np.pi*3/4-np.arctan(0.5), np.sqrt(2), 0)),
+                             ((0, 2, 0, -1, 0, 0), (-1, 2, 1, -1, 0, 0),
+                              (0, np.pi*3/4+np.arctan(0.5), np.sqrt(2), 0)),
+                             ((0, -2, 0, 1, 0, 0), (-1, -2, 1, 1, 0, 0),
+                              (0, -np.pi/4+np.arctan(0.5), np.sqrt(2), 0)),
+                             ((0, -2, 0, -1, 0, 0), (-1, -2, 1, -1, 0, 0),
+                              (0, -np.pi/4-np.arctan(0.5), np.sqrt(2), 0)),
+                             ((0, 2, 0, 1, 0, 0), (-1, 2, -1, 1, 0, 0),
+                              (0, -np.pi*3/4-np.arctan(0.5), np.sqrt(2), 0)),
+                             ((0, 2, 0, -1, 0, 0), (-1, 2, -1, -1, 0, 0),
+                              (0, -np.pi*3/4+np.arctan(0.5), np.sqrt(2), 0)),
+                             ((0, -2, 0, 1, 0, 0), (-1, -2, -1, 1, 0, 0),
+                              (0, np.pi/4+np.arctan(0.5), np.sqrt(2), 0)),
+                             ((0, -2, 0, -1, 0, 0), (-1, -2, -1, -1, 0, 0),
+                              (0, np.pi/4-np.arctan(0.5), np.sqrt(2), 0)),
+                             ((1, -1, 0, 1, 0, 1),(0, -1, 0, 1, 0, 1),
+                              (-np.arccos((np.sqrt((np.cos(np.arctan(1/np.sqrt(2)))**2)+1))/np.sqrt(2)), np.pi/2-np.arctan(np.cos(np.arctan(1/np.sqrt(2)))), 1, 0)),
+                             ((0, 1, 0, 1, 0, 1),(1, 1, 0, 1, 0, 1),
+                              (-np.arccos((np.sqrt((np.cos(np.arctan(1/np.sqrt(2)))**2)+1))/np.sqrt(2)), -(np.pi/2-np.arctan(np.cos(np.arctan(1/np.sqrt(2))))), 1, 0)),
+                             ((0, 1, 0, 0 ,0 ,0),(1, 1, 1, 0, 1, 0),
+                              (np.arctan(1/np.sqrt(2)), np.pi/4, np.sqrt(3), 0))
                              ]
 
 
@@ -369,7 +441,12 @@ def test_model_predictions(sensor_state, target_state, expected_measurement, mod
     if use_velocity:
         model.velocity = sensor_velocity
     actual_measurement = model.function(target_state, noise=False)
-    assert np.allclose(actual_measurement, expected_measurement[measure_mapping])
+    expected_values = expected_measurement[measure_mapping]
+    for i, v in enumerate(expected_values):
+        if isinstance(v, Bearing):
+            expected_values[i] = v._value
+    #assert np.allclose(actual_measurement, expected_measurement[measure_mapping])
+    assert np.allclose(actual_measurement, expected_values)
 
 
 def test_angle_pdf():
@@ -969,7 +1046,11 @@ def test_noiseless_binning_predictions(sensor_state, target_state, expected_meas
         velocity=sensor_velocity)
     actual_measurement = model.function(target_state, noise=False)
     measure_mapping = [0, 1, 2, 3]
-    assert np.allclose(actual_measurement, expected_measurement[measure_mapping])
+    expected_values = expected_measurement[measure_mapping]
+    for i, v in enumerate(expected_values):
+        if isinstance(v, Bearing):
+            expected_values[i] = v._value
+    assert np.allclose(actual_measurement, expected_values)
 
 
 def test_compare_rrrb_to_ctebrr():

--- a/stonesoup/platform/tests/test_platform_base.py
+++ b/stonesoup/platform/tests/test_platform_base.py
@@ -649,6 +649,10 @@ def test_range_and_angles_to_other(first_state, second_state, expected_measureme
                                transition_model=None)
 
     range_, azimuth, elevation = platform1.range_and_angles_to_other(platform2)
+    if azimuth == -np.pi:
+        azimuth = np.pi
+    if expected_measurement[1] == -np.pi:
+        expected_measurement[1] = np.pi
     assert np.allclose((elevation, azimuth, range_), expected_measurement[0:3])
 
 

--- a/stonesoup/platform/tests/test_platform_base.py
+++ b/stonesoup/platform/tests/test_platform_base.py
@@ -649,6 +649,7 @@ def test_range_and_angles_to_other(first_state, second_state, expected_measureme
                                transition_model=None)
 
     range_, azimuth, elevation = platform1.range_and_angles_to_other(platform2)
+    # Allow azimuth of -pi to equal pi, to avoid unnecessary assert failures
     if azimuth == -np.pi:
         azimuth = np.pi
     if expected_measurement[1] == -np.pi:


### PR DESCRIPTION
The rotation matrix is currently formed backwards as rotz(theta_z) @ roty(theta_y) @ rotx(theta_x). It needs to be in reverse order: x, y, z. This is because matrix @ operations are carried out from right to left and we need to rotate about z first, because only then can we know which way to rotate about y. This branch implements that and adds some test cases to prove it (some of which fail with the previous code). 

This does lead to a problem with Bearing, as discussed in Issue #749.