### PR TITLE
Fix Angle.__abs__ such that it always returns a positive value

### DIFF
--- a/stonesoup/types/angle.py
+++ b/stonesoup/types/angle.py
@@ -79,7 +79,24 @@ class Angle(Real):
         return self._value != other
 
     def __abs__(self):
-        return self.__class__(abs(self._value))
+        abs_val = self.__class__(abs(self._value))
+        if abs_val._value < 0:
+            # This condition is hit in the edge case where an angle is exactly pi (or the upper
+            # edge of the Angle's range). The current mod_[class] implementation returns the bottom
+            # end of the range.
+            # That is, the modulo operation is closed at the bottom and open at the top: for a
+            # Bearing the value is in the range [-pi, pi)
+            # As the new object is created *after* the abs operation, the line above is equivalent
+            # to Bearing(pi) which returns a Bearing with _value -3.14....
+            # Below we force that to be the positive value, such that abs(some_angle)._value is
+            # always positive.
+            #
+            # Note that this assures abs(my_angle) > 0 and abs(my_angle) == abs(-my_angle) for all
+            # angles including edge cases.
+            # There is still the oddity that abs(Bearing(-pi)) != Bearing(+pi)) or equivalently
+            # that abs(Bearing(-pi)) != Bearing(abs(-pi)))
+            abs_val._value = abs(abs_val._value)
+        return abs_val
 
     def __le__(self, other):
         return self._value <= other

--- a/stonesoup/types/tests/test_angle.py
+++ b/stonesoup/types/tests/test_angle.py
@@ -4,6 +4,7 @@ from pytest import approx, xfail
 from numpy import deg2rad
 import numpy as np
 
+from stonesoup.types.array import StateVector
 from ..angle import Bearing, Elevation, Latitude, Longitude
 from ...functions import (mod_elevation, mod_bearing)
 
@@ -127,3 +128,29 @@ class TestAngle:
             assert class_.average([b1, b2]) == approx(val)
         else:
             raise xfail("Can't handle average when wrapping over ±pi")
+
+    def test_wrapping_equality_and_abs(self, class_, func):
+        val = class_(np.pi)
+        if class_ in (Bearing, Longitude):
+            wrapped_val = -np.pi
+        elif class_ in (Elevation, Latitude):
+            wrapped_val = 0
+        else:
+            raise NotImplementedError
+        assert val == class_(np.pi)
+        assert abs(val) >= 0
+        assert abs(val) == abs(class_(np.pi))
+        assert val == class_(wrapped_val)
+        assert abs(val) == abs(class_(wrapped_val))
+
+        # Must use a bearing in a StateVector below: the StateVector class overrides ufuncs,
+        # such that isclose works. Raw Angle classes don't (and can't sensibly) override that
+        # behaviour. isclose fails if abs does not return positive values, which is why the test is
+        # here
+        sv = StateVector([val])
+        wrapped_sv = StateVector([wrapped_val])
+        assert np.isclose(sv, sv)
+        assert np.isclose(sv, wrapped_sv)
+
+        assert np.isclose(abs(sv), abs(sv))
+        assert np.isclose(abs(sv), abs(wrapped_sv))


### PR DESCRIPTION
Address part of issue #749 that deals with `Bearing`s not playing nicely with `numpy.isclose`, which is due to `abs(Bearing(-pi))` returning a negative value.