### PR TITLE
Do not draw line between not_update states.

### DIFF
--- a/stonesoup/plotter.py
+++ b/stonesoup/plotter.py
@@ -354,6 +354,7 @@ class Plotter(_Plotter):
                 artists.extend(self.ax.plot(
                     *data[:, not_update_indexes],
                     marker="o" if "marker" not in kwargs else kwargs['marker'],
+                    linestyle='',
                     color=plt.getp(line[0], 'color')))
             track_colors[track] = plt.getp(line[0], 'color')
 


### PR DESCRIPTION
When plotting tracks, the previous behavior would draw a line between all of the states that weren't of type Update.