### PR TITLE
Cast noise_covar value to a CovarianceMatrix when initialising a MeasurementModel 

### DIFF
--- a/docs/examples/Creating_Actionable_Sensor.py
+++ b/docs/examples/Creating_Actionable_Sensor.py
@@ -243,7 +243,7 @@ class DirectedSensor(Sensor):
 
             bearing_calculator = Cartesian2DToBearing(ndim_state=4,
                                                       mapping=(0, 2),
-                                                      noise_covar=None,
+                                                      noise_covar=np.diag([0, 0]),
                                                       translation_offset=self.position,
                                                       rotation_offset=self.direction_angle)
             bearing = bearing_calculator.function(truth, noise=False)

--- a/docs/examples/range_range_rate_binning.py
+++ b/docs/examples/range_range_rate_binning.py
@@ -57,7 +57,7 @@ measurement_model = RangeRangeRateBinning(
     ndim_state=6,
     mapping=[0, 2, 4],
     velocity_mapping=[1, 3, 5],
-    noise_covar=np.array([0., 0., 0., 0.]))
+    noise_covar=np.diag([0., 0., 0., 0.]))
 
 # %%
 # Create target

--- a/docs/tutorials/filters/ASDFilter.py
+++ b/docs/tutorials/filters/ASDFilter.py
@@ -60,7 +60,7 @@ for state in truth:
         [x, y], timestamp=state.timestamp))
 
 # Plot the result
-plotter.plot_measurements(measurements, [0, 1], LinearGaussian(2, (0, 1), None))
+plotter.plot_measurements(measurements, [0, 1], LinearGaussian(2, (0, 1), np.diag([0, 0])))
 plotter.fig
 
 # %%

--- a/stonesoup/models/measurement/linear.py
+++ b/stonesoup/models/measurement/linear.py
@@ -24,6 +24,11 @@ class LinearGaussian(MeasurementModel, LinearModel, GaussianModel):
 
     noise_covar: CovarianceMatrix = Property(doc="Noise covariance")
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if not isinstance(self.noise_covar, CovarianceMatrix):
+            self.noise_covar = CovarianceMatrix(self.noise_covar)
+
     @property
     def ndim_meas(self):
         """ndim_meas getter method

--- a/stonesoup/models/measurement/tests/test_combined.py
+++ b/stonesoup/models/measurement/tests/test_combined.py
@@ -112,8 +112,7 @@ def test_mismatch_ndim_state():
 
 def test_none_covar():
     with pytest.raises(ValueError, match="Covariance should have ndim of 2: got 0"):
-        new_model = CombinedReversibleGaussianMeasurementModel([
+        CombinedReversibleGaussianMeasurementModel([
             CartesianToBearingRange(4, [0, 1], None),
             CartesianToBearingRange(4, [0, 1], np.diag([1, 10]))
         ])
-

--- a/stonesoup/models/measurement/tests/test_combined.py
+++ b/stonesoup/models/measurement/tests/test_combined.py
@@ -111,12 +111,9 @@ def test_mismatch_ndim_state():
 
 
 def test_none_covar():
-    new_model = CombinedReversibleGaussianMeasurementModel([
-        CartesianToBearingRange(4, [0, 1], None),
-        CartesianToBearingRange(4, [0, 1], np.diag([1, 10]))
-    ])
+    with pytest.raises(ValueError, match="Covariance should have ndim of 2: got 0"):
+        new_model = CombinedReversibleGaussianMeasurementModel([
+            CartesianToBearingRange(4, [0, 1], None),
+            CartesianToBearingRange(4, [0, 1], np.diag([1, 10]))
+        ])
 
-    with pytest.raises(ValueError, match="Cannot generate rvs from None-type covariance"):
-        new_model.rvs()
-    with pytest.raises(ValueError, match="Cannot generate pdf from None-type covariance"):
-        new_model.pdf(State([0, 0, 0, 0]), State([0, 0, 0, 0]))

--- a/stonesoup/models/measurement/tests/test_models.py
+++ b/stonesoup/models/measurement/tests/test_models.py
@@ -91,7 +91,7 @@ def hbearing(state_vector, pos_map, translation_offset, rotation_offset):
      CartesianToElevationBearingRangeRate]
 )
 def test_none_covar(model_class):
-    with pytest.raises(ValueError):  # todo add match
+    with pytest.raises(ValueError, match="Covariance should have ndim of 2: got 0"):
         model_class(ndim_state=0, mapping=[0, 1, 2], noise_covar=None)
 
 
@@ -222,6 +222,14 @@ def test_models(h, ModelClass, state_vec, R,
                        noise_covar=R,
                        translation_offset=translation_offset,
                        rotation_offset=rotation_offset)
+
+    R_flat = R.flat  # Create flat 1-D array of R
+    with pytest.raises(ValueError, match="Covariance should have ndim of 2: got 1"):
+        ModelClass(ndim_state=ndim_state,
+                   mapping=mapping,
+                   noise_covar=R_flat,
+                   translation_offset=translation_offset,
+                   rotation_offset=rotation_offset)
 
     # Project a state through the model
     # (without noise)

--- a/stonesoup/models/measurement/tests/test_models.py
+++ b/stonesoup/models/measurement/tests/test_models.py
@@ -91,9 +91,8 @@ def hbearing(state_vector, pos_map, translation_offset, rotation_offset):
      CartesianToElevationBearingRangeRate]
 )
 def test_none_covar(model_class):
-    model = model_class(ndim_state=0, mapping=[0, 1, 2], noise_covar=None)
-    with pytest.raises(ValueError, match="Cannot generate pdf from None-type covariance"):
-        model.pdf(State([0]), State([0]))
+    with pytest.raises(ValueError):  # todo add match
+        model_class(ndim_state=0, mapping=[0, 1, 2], noise_covar=None)
 
 
 @pytest.mark.parametrize(
@@ -997,10 +996,10 @@ def test_binning():
                                               ndim_state=6,
                                               mapping=[0, 2, 4],
                                               velocity_mapping=[1, 3, 5],
-                                              noise_covar=np.array([np.pi/18,
-                                                                    np.pi/18,
-                                                                    100,
-                                                                    10]))
+                                              noise_covar=np.diag([np.pi/18,
+                                                                   np.pi/18,
+                                                                   100,
+                                                                   10]))
 
     measured = measurement_model.function(real_state, noise=True)
     assert ((measured[2, 0]-measurement_model.range_res/2) /
@@ -1017,10 +1016,10 @@ def test_binning_pdf():
                                               ndim_state=6,
                                               mapping=[0, 2, 4],
                                               velocity_mapping=[1, 3, 5],
-                                              noise_covar=np.array([np.pi/18,
-                                                                    np.pi/18,
-                                                                    100,
-                                                                    10]))
+                                              noise_covar=np.diag([np.pi/18,
+                                                                   np.pi/18,
+                                                                   100,
+                                                                   10]))
 
     measured = measurement_model.function(real_state, noise=True)
     pdf = measurement_model.pdf(State(measured), real_state)
@@ -1038,24 +1037,19 @@ def test_binning_pdf():
 
 
 def test_binning_integral():
-    measurement_model = RangeRangeRateBinning(range_res=None,
-                                              range_rate_res=None,
-                                              ndim_state=None,
-                                              mapping=[],
-                                              velocity_mapping=[],
-                                              noise_covar=None)
 
     mean = 33.33333
     a = 40
     b = 30
     cov = 10
     expected_integral = 0.8365720412132509
-    assert approx(measurement_model._gaussian_integral(a, b, mean, cov), 0.02) == expected_integral
+    assert approx(RangeRangeRateBinning._gaussian_integral(a, b, mean, cov), 0.02) == \
+           expected_integral
 
     bin_sizes = 10
     state_vector1 = 35
     expected_pdf = 0.08365720412132509
-    assert (approx(measurement_model._binned_pdf(state_vector1, mean, bin_sizes, cov)) ==
+    assert (approx(RangeRangeRateBinning._binned_pdf(state_vector1, mean, bin_sizes, cov)) ==
             expected_pdf)
 
 
@@ -1079,7 +1073,7 @@ def test_noiseless_binning_predictions(sensor_state, target_state, expected_meas
         ndim_state=6,
         mapping=pos_mapping,
         velocity_mapping=vel_mapping,
-        noise_covar=np.array([0., 0., 0., 0.]),
+        noise_covar=np.diag([0., 0., 0., 0.]),
         translation_offset=sensor_state[pos_mapping],
         rotation_offset=orientation,
         velocity=sensor_velocity)
@@ -1095,7 +1089,7 @@ def test_compare_rrrb_to_ctebrr():
         ndim_state=6,
         mapping=[0, 2, 4],
         velocity_mapping=[1, 3, 5],
-        noise_covar=np.array([1., 1., 1., 1.]))
+        noise_covar=np.diag([1., 1., 1., 1.]))
 
     state = State([50.000005, 50.000005,
                    0., 0.,
@@ -1123,10 +1117,7 @@ def test_calc_pdf():
                                               ndim_state=6,
                                               mapping=[0, 2, 4],
                                               velocity_mapping=[1, 3, 5],
-                                              noise_covar=np.array([1,
-                                                                    1,
-                                                                    10,
-                                                                    10]))
+                                              noise_covar=np.diag([1., 1., 10., 10.]))
 
     act_pdf = measurement_model.pdf(State([0., 0., 10035.0, 135.0]), real_state)
 

--- a/stonesoup/updater/tests/test_alphabeta.py
+++ b/stonesoup/updater/tests/test_alphabeta.py
@@ -16,7 +16,7 @@ from stonesoup.types.hypothesis import SingleHypothesis
     "measurement_model, prediction, measurement, alpha, beta",
     [
         (   # Standard Alpha-Beta
-            LinearGaussian(ndim_state=4, mapping=[0, 2], noise_covar=0),
+            LinearGaussian(ndim_state=4, mapping=[0, 2], noise_covar=np.diag([0, 0])),
             StatePrediction(StateVector([-6.45, 0.7, -6.45, 0.7])),
             Detection(StateVector([-6.23, -6.23])),
             0.9,


### PR DESCRIPTION
Cast the noise_covar value to a CovarianceMatrix when initialising a MeasurementModel in LinearGaussian & NonLinearGaussianMeasurement

Fixed the changes to RangeRangeRateBinning testing