### PR TITLE
Use temporary file for FITS Reader tests

### DIFF
--- a/stonesoup/reader/tests/test_astronomical.py
+++ b/stonesoup/reader/tests/test_astronomical.py
@@ -1,16 +1,15 @@
-# -*- coding: utf-8 -*-
 from textwrap import dedent
 from datetime import datetime
 
 import pytest
 import numpy as np
-
-from ..astronomical import FITSReader, TLEFileReader
 from astropy.io import fits
 
+from ..astronomical import FITSReader, TLEFileReader
 
-def test_fits():
-    fits_filename = "test.fits"
+
+def test_fits(tmpdir):
+    fits_filename = str(tmpdir.join("test.fits"))
     n = np.arange(100.0)
     n.shape = (10, 10)
     hdr = fits.Header()
@@ -25,10 +24,6 @@ def test_fits():
     assert np.array_equal(image_data, n)
     assert header['OBSERVER'] == 'Edwin Hubble'
     assert header['COMMENT'] == "Here's some commentary about this FITS file."
-
-
-if __name__ == '__main__':
-    test_fits()
 
 
 @pytest.fixture()


### PR DESCRIPTION
Avoids creating `test.fits` in repo directory when running tests.