### PR TITLE
Progress Trackers Manually: Option B

### DIFF
--- a/docs/demos/UAV_tutorial.py
+++ b/docs/demos/UAV_tutorial.py
@@ -210,11 +210,11 @@ hypothesiser = DistanceHypothesiser(predictor, updater, meas)
 associator = NearestNeighbour(hypothesiser)
 
 
-tracker = SingleTargetTracker(initiator,
-                              deleter,
-                              detector,
-                              associator,
-                              updater)
+tracker = SingleTargetTracker(initiator=initiator,
+                              deleter=deleter,
+                              detector=detector,
+                              data_associator=associator,
+                              updater=updater)
 
 # %%
 # Run the Tracker

--- a/docs/examples/Classifying_Using_HMM.py
+++ b/docs/examples/Classifying_Using_HMM.py
@@ -200,7 +200,8 @@ deleter = UpdateTimeStepsDeleter(2)
 # We can use a standard :class:`~.MultiTargetTracker`.
 from stonesoup.tracker.simple import MultiTargetTracker
 
-tracker = MultiTargetTracker(initiator, deleter, measurements, data_associator, updater)
+tracker = MultiTargetTracker(initiator=initiator, deleter=deleter, detector=measurements,
+                             data_associator=data_associator, updater=updater)
 
 # %%
 # Tracking

--- a/docs/examples/Disjoint_Tracking_Classification.py
+++ b/docs/examples/Disjoint_Tracking_Classification.py
@@ -471,7 +471,8 @@ deleter = UpdateTimeStepsDeleter(2)
 
 from stonesoup.tracker.simple import MultiTargetTracker
 
-tracker = MultiTargetTracker(initiator, deleter, all_measurements, data_associator, updater)
+tracker = MultiTargetTracker(initiator=initiator, deleter=deleter, detector=all_measurements,
+                             data_associator=data_associator, updater=updater)
 
 # %%
 # Tracking

--- a/stonesoup/tracker/pointprocess.py
+++ b/stonesoup/tracker/pointprocess.py
@@ -1,22 +1,23 @@
-from .base import Tracker
+import datetime
+from typing import Tuple, Set
+
+from .base import TrackerWithDetector
 from ..base import Property
-from ..reader import DetectionReader
-from ..types.state import TaggedWeightedGaussianState
-from ..types.mixture import GaussianMixture
-from ..types.numeric import Probability
-from ..types.track import Track
-from ..updater import Updater
 from ..hypothesiser.gaussianmixture import GaussianMixtureHypothesiser
 from ..mixturereducer.gaussianmixture import GaussianMixtureReducer
+from ..types.detection import Detection
+from ..types.mixture import GaussianMixture
+from ..types.numeric import Probability
+from ..types.state import TaggedWeightedGaussianState
+from ..types.track import Track
+from ..updater import Updater
 
 
-class PointProcessMultiTargetTracker(Tracker):
+class PointProcessMultiTargetTracker(TrackerWithDetector):
     """
     Base class for Gaussian Mixture (GM) style implementations of
     point process derived filters
     """
-    detector: DetectionReader = Property(
-        doc="Detector used to generate detection objects.")
     updater: Updater = Property(
         doc="Updater used to update the objects to their new state.")
     hypothesiser: GaussianMixtureHypothesiser = Property(
@@ -40,15 +41,11 @@ class PointProcessMultiTargetTracker(Tracker):
         self.gaussian_mixture = GaussianMixture()
 
     @property
-    def tracks(self):
+    def tracks(self) -> Set[Track]:
         tracks = set()
         for track in self.target_tracks.values():
             tracks.add(track)
         return tracks
-
-    def __iter__(self):
-        self.detector_iter = iter(self.detector)
-        return super().__iter__()
 
     def update_tracks(self):
         """
@@ -77,8 +74,8 @@ class PointProcessMultiTargetTracker(Tracker):
                             self.extraction_threshold:
                         self.target_tracks[tag] = Track([component], id=tag)
 
-    def __next__(self):
-        time, detections = next(self.detector_iter)
+    def update_tracker(self, time: datetime.datetime, detections: Set[Detection]) \
+            -> Tuple[datetime.datetime, Set[Track]]:
         # Add birth component
         self.birth_component.timestamp = time
         self.gaussian_mixture.append(self.birth_component)

--- a/stonesoup/tracker/tests/test_simple.py
+++ b/stonesoup/tracker/tests/test_simple.py
@@ -5,8 +5,9 @@ from ..simple import SingleTargetTracker, MultiTargetTracker, \
 
 def test_single_target_tracker(
         initiator, deleter, detector, data_associator, updater):
-    tracker = SingleTargetTracker(
-        initiator, deleter, detector, data_associator, updater)
+
+    tracker = SingleTargetTracker(initiator=initiator, deleter=deleter, detector=detector,
+                                  data_associator=data_associator, updater=updater)
 
     previous_time = datetime.datetime(2018, 1, 1, 13, 59)
     total_tracks = set()
@@ -24,8 +25,9 @@ def test_single_target_tracker(
 
 def test_multi_target_tracker(
         initiator, deleter, detector, data_associator, updater):
-    tracker = MultiTargetTracker(
-        initiator, deleter, detector, data_associator, updater)
+
+    tracker = MultiTargetTracker(initiator=initiator, deleter=deleter, detector=detector,
+                                 data_associator=data_associator, updater=updater)
 
     previous_time = datetime.datetime(2018, 1, 1, 13, 59)
     max_tracks = 0
@@ -51,8 +53,9 @@ def test_multi_target_tracker(
 
 def test_multi_target_mixture_tracker(
         initiator, deleter, detector, data_mixture_associator, updater):
-    tracker = MultiTargetMixtureTracker(
-        initiator, deleter, detector, data_mixture_associator, updater)
+
+    tracker = MultiTargetMixtureTracker(initiator=initiator, deleter=deleter, detector=detector,
+                                        data_associator=data_mixture_associator, updater=updater)
 
     previous_time = datetime.datetime(2018, 1, 1, 13, 59)
     max_tracks = 0


### PR DESCRIPTION
All current trackers require a detection feeder. It can be useful to progress a tracker manually without a detection feeder (see Multi-Sensor Fusion: Covariance Intersection Using Tracks as Measurements example). 

All current trackers and start their `__next__` function with:
```
time, detections = next(self.detector_iter)
# Some tracking logic
```

I've moved this line to the new `Tracker`  baseclass and added an `update_tracker` function which takes the time and detections from the detection feeder as an input. With this being a separate function, you can access it directly and bypass the detection feeder which may be easier in instances