### PR TITLE
Modify SystematicResampler to enable down/upsampling

### DIFF
--- a/stonesoup/resampler/particle.py
+++ b/stonesoup/resampler/particle.py
@@ -8,13 +8,15 @@ from ..types.state import ParticleState
 
 class SystematicResampler(Resampler):
 
-    def resample(self, particles):
+    def resample(self, particles, nparts=None):
         """Resample the particles
 
         Parameters
         ----------
         particles : :class:`~.ParticleState` or list of :class:`~.Particle`
             The particles or particle state to be resampled according to their weights
+        nparts : int
+            The number of particles to be returned from resampling
 
         Returns
         -------
@@ -24,8 +26,10 @@ class SystematicResampler(Resampler):
 
         if not isinstance(particles, ParticleState):
             particles = ParticleState(None, particle_list=particles)
-        n_particles = len(particles)
-        weight = Probability(1 / n_particles)
+        if nparts is None:
+            nparts = len(particles)
+
+        weight = Probability(1 / nparts)
 
         log_weights = np.asfarray(np.log(particles.weight))
         weight_order = np.argsort(log_weights, kind='stable')
@@ -35,15 +39,16 @@ class SystematicResampler(Resampler):
         cdf += max_log_value
 
         # Pick random starting point
-        u_i = np.random.uniform(0, 1 / n_particles)
+        u_i = np.random.uniform(0, 1 / nparts)
 
         # Cycle through the cumulative distribution and copy the particle
         # that pushed the score over the current value
-        u_j = u_i + (1 / n_particles) * np.arange(n_particles)
+        u_j = u_i + (1 / nparts) * np.arange(nparts)
         index = weight_order[np.searchsorted(cdf, np.log(u_j))]
 
-        new_particles = particles[index]
-        new_particles.weight = np.full((n_particles, ), weight)
+        new_particles = particles[np.array(index)]
+        new_particles.weight = np.full((nparts, ), weight)
+
         return new_particles
 
 

--- a/stonesoup/resampler/tests/test_particle.py
+++ b/stonesoup/resampler/tests/test_particle.py
@@ -45,6 +45,17 @@ def test_systematic_even():
                for i, new_particle in enumerate(new_particles))
 
 
+def test_systematic_downsample():
+    particles = [Particle(np.array([[i]]), weight=1/40) for i in range(40)]
+
+    resampler = SystematicResampler()
+
+    new_particles = resampler.resample(particles, 20)
+
+    # Check that the resampler downsamples the particles correctly
+    assert len(new_particles) == 20
+
+
 def test_ess_zero():
     particles = [Particle(np.array([[i]]), weight=(i+1) / 55)
                  for i in range(10)]


### PR DESCRIPTION
Added a modification to SystematicResampler to allow an optional argument "nparts" to be added to the resample method of the class. If this is not defined or equal to the length of the input ParticleState object, the resampler will function in the same way. If it is larger/smaller than the length of the input ParticleState object, the resampler will down/up sample to return the desired output.