### PR TITLE
Enable Forward Declaration of Type Hints for Properties

### DIFF
--- a/stonesoup/base.py
+++ b/stonesoup/base.py
@@ -60,6 +60,7 @@ from abc import ABCMeta
 from collections import OrderedDict
 from copy import copy
 from types import MappingProxyType
+from typing import TYPE_CHECKING
 
 from ._util import cached_property
 
@@ -294,7 +295,8 @@ class BaseMeta(ABCMeta):
 
                 if not (isinstance(value.cls, type)
                         or getattr(value.cls, '__module__', "") == 'typing'
-                        or value.cls == name):
+                        or value.cls == name
+                        or isinstance(value.cls, str)): # forward declaration for type hinting
                     raise ValueError(f'Invalid type specification ({str(value.cls)}) '
                                      f'for property {key} of class {name}')
 

--- a/stonesoup/base.py
+++ b/stonesoup/base.py
@@ -60,7 +60,6 @@ from abc import ABCMeta
 from collections import OrderedDict
 from copy import copy
 from types import MappingProxyType
-from typing import TYPE_CHECKING
 
 from ._util import cached_property
 
@@ -296,7 +295,7 @@ class BaseMeta(ABCMeta):
                 if not (isinstance(value.cls, type)
                         or getattr(value.cls, '__module__', "") == 'typing'
                         or value.cls == name
-                        or isinstance(value.cls, str)): # forward declaration for type hinting
+                        or isinstance(value.cls, str)):  # Forward declaration for type hinting
                     raise ValueError(f'Invalid type specification ({str(value.cls)}) '
                                      f'for property {key} of class {name}')
 

--- a/stonesoup/tests/test_declarative.py
+++ b/stonesoup/tests/test_declarative.py
@@ -332,16 +332,6 @@ def test_type_hint_checking():
         i = Property(List[int], doc='Test')
     _ = TestClass(i=1)
 
-    with pytest.raises(ValueError):
-        class TestClass(Base):
-            i: 'string' = Property(doc='Test')  # noqa: F821
-        _ = TestClass(i=1)
-
-    with pytest.raises(ValueError):
-        class TestClass(Base):
-            i = Property('string', doc='Test')
-        _ = TestClass(i=1)
-
     # errors for any
     with pytest.raises(ValueError):
         class TestClass(Base):


### PR DESCRIPTION
Forward declaration of type hints is a method to allow type checking in instances where a full import would cause a problem, for example commonly an error due to a circular import. See `typing.TYPE_CHECKING` on the [python docs](https://docs.python.org/3/library/typing.html) for more information. 

This may not be the neatest solution, as it allows any type hint declared as a string. Ideas for improvement are welcome, but this is functional at least. 