### PR TITLE
Added support for a 4D state vector when using a range, bearing, range rate radar model

### DIFF
--- a/stonesoup/models/measurement/nonlinear.py
+++ b/stonesoup/models/measurement/nonlinear.py
@@ -863,7 +863,7 @@ class CartesianToBearingRangeRate2D(_AngleNonLinearGaussianMeasurement):
         xy_rot = self.rotation_matrix[:len(self.mapping), :len(self.mapping)] @ xy_pos
 
         # Convert to Polar
-        rho, phi= cart2pol(xy_rot[0, :], xy_rot[1, :])
+        rho, phi = cart2pol(xy_rot[0, :], xy_rot[1, :])
 
         # Determine the net velocity component in the engagement
         xy_vel = state.state_vector[self.velocity_mapping, :] - self.velocity
@@ -876,6 +876,7 @@ class CartesianToBearingRangeRate2D(_AngleNonLinearGaussianMeasurement):
     @staticmethod
     def _typed_vector():
         return np.array([[Bearing(0.)], [0.], [0.]])
+
 
 class CartesianToElevationBearingRangeRate(_AngleNonLinearGaussianMeasurement, ReversibleModel):
     r"""This is a class implementation of a time-invariant measurement model, \

--- a/stonesoup/models/measurement/nonlinear.py
+++ b/stonesoup/models/measurement/nonlinear.py
@@ -863,7 +863,7 @@ class CartesianToBearingRangeRate2D(NonLinearGaussianMeasurement, ReversibleMode
         xy_pos = state.state_vector[self.mapping, :] - self.translation_offset
 
         # Rotate coordinates based upon the sensor_velocity
-        xy_rot = self.rotation_matrix @ xy_pos
+        xy_rot = self.rotation_matrix[:len(self.mapping), :len(self.mapping)] @ xy_pos
 
         # Convert to Polar
         rho, phi= cart2pol(xy_rot[0, :], xy_rot[1, :])

--- a/stonesoup/models/measurement/nonlinear.py
+++ b/stonesoup/models/measurement/nonlinear.py
@@ -716,6 +716,8 @@ class CartesianToBearingRangeRate(_AngleNonLinearGaussianMeasurement):
 
         # Account for origin offset in position to enable range and angles to be determined
         xy_pos = state.state_vector[self.mapping, :] - self.translation_offset
+        if xy_pos.shape[0] == 2: # if position mapping is 2D - 
+            xy_pos = np.vstack((xy_pos, [0] * xy_pos.shape[1]))
 
         # Rotate coordinates based upon the sensor_velocity
         xy_rot = self.rotation_matrix @ xy_pos
@@ -725,6 +727,8 @@ class CartesianToBearingRangeRate(_AngleNonLinearGaussianMeasurement):
 
         # Determine the net velocity component in the engagement
         xy_vel = state.state_vector[self.velocity_mapping, :] - self.velocity
+        if xy_vel.shape[0] == 2:
+            xy_vel = np.vstack((xy_vel, [0] * xy_vel.shape[1]))
 
         # Use polar to calculate range rate
         rr = np.einsum('ij,ij->j', xy_pos, xy_vel) / np.linalg.norm(xy_pos, axis=0)

--- a/stonesoup/models/measurement/nonlinear.py
+++ b/stonesoup/models/measurement/nonlinear.py
@@ -872,7 +872,7 @@ class CartesianToBearingRangeRate2D(_AngleNonLinearGaussianMeasurement, Reversib
         rr = np.einsum('ij,ij->j', xy_pos, xy_vel) / np.linalg.norm(xy_pos, axis=0)
 
         return StateVectors([phi, rho, rr]) + noise
-    
+
     def inverse_function(self, detection, **kwargs) -> StateVector:
         phi, rho, rho_rate = detection.state_vector
 
@@ -893,7 +893,7 @@ class CartesianToBearingRangeRate2D(_AngleNonLinearGaussianMeasurement, Reversib
         out_vector[self.mapping, :] = out_vector[self.mapping, :] + self.translation_offset
 
         return out_vector
-    
+
     @staticmethod
     def _typed_vector():
         return np.array([[Bearing(0.)], [0.], [0.]])

--- a/stonesoup/models/measurement/nonlinear.py
+++ b/stonesoup/models/measurement/nonlinear.py
@@ -716,8 +716,6 @@ class CartesianToBearingRangeRate(_AngleNonLinearGaussianMeasurement):
 
         # Account for origin offset in position to enable range and angles to be determined
         xy_pos = state.state_vector[self.mapping, :] - self.translation_offset
-        if xy_pos.shape[0] == 2: # if position mapping is 2D - 
-            xy_pos = np.vstack((xy_pos, [0] * xy_pos.shape[1]))
 
         # Rotate coordinates based upon the sensor_velocity
         xy_rot = self.rotation_matrix @ xy_pos
@@ -727,8 +725,6 @@ class CartesianToBearingRangeRate(_AngleNonLinearGaussianMeasurement):
 
         # Determine the net velocity component in the engagement
         xy_vel = state.state_vector[self.velocity_mapping, :] - self.velocity
-        if xy_vel.shape[0] == 2:
-            xy_vel = np.vstack((xy_vel, [0] * xy_vel.shape[1]))
 
         # Use polar to calculate range rate
         rr = np.einsum('ij,ij->j', xy_pos, xy_vel) / np.linalg.norm(xy_pos, axis=0)

--- a/stonesoup/models/measurement/nonlinear.py
+++ b/stonesoup/models/measurement/nonlinear.py
@@ -735,6 +735,7 @@ class CartesianToBearingRangeRate(_AngleNonLinearGaussianMeasurement):
     def _typed_vector():
         return np.array([[Bearing(0)], [0.], [0.]])
 
+
 class CartesianToBearingRangeRate2D(NonLinearGaussianMeasurement, ReversibleModel):
     r"""This is a class implementation of a time-invariant measurement model, \
     where measurements are assumed to be received in the form of bearing \

--- a/stonesoup/models/measurement/nonlinear.py
+++ b/stonesoup/models/measurement/nonlinear.py
@@ -739,6 +739,172 @@ class CartesianToBearingRangeRate(_AngleNonLinearGaussianMeasurement):
     def _typed_vector():
         return np.array([[Bearing(0)], [0.], [0.]])
 
+class CartesianToBearingRangeRate2D(NonLinearGaussianMeasurement, ReversibleModel):
+    r"""This is a class implementation of a time-invariant measurement model, \
+    where measurements are assumed to be received in the form of bearing \
+    (:math:`\phi`), range (:math:`r`) and range-rate (:math:`\dot{r}`),
+    with Gaussian noise in each dimension.
+
+    The model is described by the following equations:
+
+    .. math::
+
+      \vec{y}_t = h(\vec{x}_t, \vec{v}_t)
+
+    where:
+
+    * :math:`\vec{y}_t` is a measurement vector of the form:
+
+    .. math::
+
+      \vec{y}_t = \begin{bmatrix}
+                \phi \\
+                r \\
+                \dot{r}
+            \end{bmatrix}
+
+    * :math:`h` is a non-linear model function of the form:
+
+    .. math::
+
+      h(\vec{x}_t,\vec{v}_t) = \begin{bmatrix}
+                atan2(\mathcal{y},\mathcal{x}) \\
+                \sqrt{\mathcal{x}^2 + \mathcal{y}^2} \\
+                (x\dot{x} + y\dot{y})/\sqrt{x^2 + y^2}
+                \end{bmatrix} + \vec{v}_t
+
+    * :math:`\vec{v}_t` is Gaussian distributed with covariance
+      :math:`R`, i.e.:
+
+    .. math::
+
+      \vec{v}_t \sim \mathcal{N}(0,R)
+
+    .. math::
+
+      R = \begin{bmatrix}
+            \sigma_{\phi}^2 & 0 & 0\\
+            0 & \sigma_{r}^2 & 0 \\
+            0 & 0 & \sigma_{\dot{r}}^2
+            \end{bmatrix}
+
+    The :py:attr:`mapping` property of the model is a 2 element vector, \
+    whose first (i.e. :py:attr:`mapping[0]`) and second (i.e. \
+    :py:attr:`mapping[1]`) elements \
+    contain the state index of the :math:`x` and :math:`y`  \
+    coordinates, respectively.
+
+    Note
+    ----
+    This class implementation assuming a 2D cartesian space, it therefore \
+    expects a 4D state space.
+    """
+
+    translation_offset: StateVector = Property(
+        default=None,
+        doc="A 2x1 array specifying the origin offset in terms of :math:`x,y` coordinates.")
+    velocity_mapping: Tuple[int, int] = Property(
+        default=(1, 3),
+        doc="Mapping to the targets velocity within its state space")
+    velocity: StateVector = Property(
+        default=None,
+        doc="A 2x1 array specifying the sensor velocity in terms of :math:`x,y` coordinates.")
+
+    def __init__(self, *args, **kwargs):
+        """
+        Ensure that the translation offset is initiated
+        """
+        super().__init__(*args, **kwargs)
+        # Set values to defaults if not provided
+        if self.translation_offset is None:
+            self.translation_offset = StateVector([0] * 2)
+
+        if self.velocity is None:
+            self.velocity = StateVector([0] * 2)
+
+    @property
+    def ndim_meas(self) -> int:
+        """ndim_meas getter method
+
+        Returns
+        -------
+        :class:`int`
+            The number of measurement dimensions
+        """
+
+        return 3
+
+    def function(self, state, noise=False, **kwargs) -> StateVector:
+        r"""Model function :math:`h(\vec{x}_t,\vec{v}_t)`
+
+        Parameters
+        ----------
+        state: :class:`~.State`
+            An input state
+        noise: :class:`numpy.ndarray` or bool
+            An externally generated random process noise sample (the default is
+            `False`, in which case no noise will be added
+            if 'True', the output of :meth:`~.Model.rvs` is added)
+
+        Returns
+        -------
+        :class:`numpy.ndarray` of shape (:py:attr:`~ndim_state`, 1)
+            The model function evaluated given the provided time interval.
+
+        """
+
+        if isinstance(noise, bool) or noise is None:
+            if noise:
+                noise = self.rvs(num_samples=state.state_vector.shape[1], **kwargs)
+            else:
+                noise = 0
+
+        # Account for origin offset in position to enable range and angles to be determined
+        xy_pos = state.state_vector[self.mapping, :] - self.translation_offset
+
+        # Rotate coordinates based upon the sensor_velocity
+        xy_rot = self.rotation_matrix @ xy_pos
+
+        # Convert to Polar
+        rho, phi= cart2pol(xy_rot[0, :], xy_rot[1, :])
+
+        # Determine the net velocity component in the engagement
+        xy_vel = state.state_vector[self.velocity_mapping, :] - self.velocity
+
+        # Use polar to calculate range rate
+        rr = np.einsum('ij,ij->j', xy_pos, xy_vel) / np.linalg.norm(xy_pos, axis=0)
+
+        # Convert to bearings
+        bearings = [Bearing(i) for i in phi]
+
+        return StateVectors([bearings, rho, rr]) + noise
+    
+    def inverse_function(self, detection, **kwargs) -> StateVector:
+        phi, rho, rho_rate = detection.state_vector
+
+        x, y = pol2cart(rho, phi)
+        # because only rho_rate is known, only the components in
+        # x,y of the range rate can be found.
+        x_rate = np.cos(phi) * rho_rate
+        y_rate = np.sin(phi) * rho_rate
+
+        inv_rotation_matrix = inv(self.rotation_matrix)[:len(self.mapping), :len(self.mapping)]
+        out_vector = StateVector([[0.], [0.], [0.], [0.]])
+        out_vector[self.mapping, 0] = x, y
+        out_vector[self.velocity_mapping, 0] = x_rate, y_rate
+
+        out_vector[self.mapping, :] = inv_rotation_matrix @ out_vector[self.mapping, :]
+        out_vector[self.velocity_mapping, :] = \
+            inv_rotation_matrix @ out_vector[self.velocity_mapping, :]
+
+        out_vector[self.mapping, :] = out_vector[self.mapping, :] + self.translation_offset
+
+        return out_vector
+
+    def rvs(self, num_samples=1, **kwargs) -> Union[StateVector, StateVectors]:
+        out = super().rvs(num_samples, **kwargs)
+        out = np.array([[Bearing(0)], [0.], [0.]]) + out
+        return out
 
 class CartesianToElevationBearingRangeRate(_AngleNonLinearGaussianMeasurement, ReversibleModel):
     r"""This is a class implementation of a time-invariant measurement model, \

--- a/stonesoup/models/measurement/tests/test_models.py
+++ b/stonesoup/models/measurement/tests/test_models.py
@@ -8,7 +8,7 @@ from ..nonlinear import (
     CartesianToElevationBearingRange, CartesianToBearingRange,
     CartesianToElevationBearing, Cartesian2DToBearing, CartesianToBearingRangeRate,
     CartesianToElevationBearingRangeRate, RangeRangeRateBinning,
-    CartesianToAzimuthElevationRange)
+    CartesianToAzimuthElevationRange, CartesianToBearingRangeRate2D)
 
 from ...base import ReversibleModel
 from ...measurement.linear import LinearGaussian
@@ -104,6 +104,7 @@ def az_el_rng(state_vector, pos_map, translation_offset, rotation_offset):
      CartesianToElevationBearing,
      Cartesian2DToBearing,
      CartesianToBearingRangeRate,
+     CartesianToBearingRangeRate2D,
      CartesianToElevationBearingRangeRate]
 )
 def test_none_covar(model_class):
@@ -584,6 +585,19 @@ def h3d_rr(state_vector, pos_map, vel_map, translation_offset, rotation_offset, 
             None,  # position (translation offset)
             None  # orientation (rotation offset)
         ),
+        (
+            h2d_rr,  # h
+            CartesianToBearingRangeRate2D,  # ModelClass
+            StateVector([[200.], [10.], [0.], [0.], [0.], [0.]]),  # state_vec
+            6,  # ndim_state
+            np.array([0, 2]),  # pos_mapping
+            np.array([1, 3]),  # vel_mapping
+            CovarianceMatrix([[0.05, 0, 0],
+                              [0, 0.015, 0],
+                              [0, 0, 10]]),  # noise_covar
+            StateVector([[1], [-1]]),  # position (translation offset)
+            StateVector([[0], [0], [0]])  # orientation (rotation offset)
+        ),
         (   # rrRBE_1, 4D meas, 6D state
             h3d_rr,  # h
             CartesianToElevationBearingRangeRate,  # ModelClass
@@ -641,7 +655,7 @@ def h3d_rr(state_vector, pos_map, vel_map, translation_offset, rotation_offset, 
             StateVector([[0], [0], [np.pi / 2]])  # orientation (rotation offset), Facing North
         )
     ],
-    ids=["rrRB_1", "rrRB_2", "rrRBE_1", "rrRBE_2", "rrRBE_3", "rrRBE_4"]
+    ids=["rrRB_1", "rrRB_2", "rrRB2D_1", "rrRBE_1", "rrRBE_2", "rrRBE_3", "rrRBE_4"]
 )
 def test_rangeratemodels(h, modelclass, state_vec, ndim_state, pos_mapping, vel_mapping,
                          noise_covar, position, orientation):
@@ -656,9 +670,9 @@ def test_rangeratemodels(h, modelclass, state_vec, ndim_state, pos_mapping, vel_
                             velocity_mapping=vel_mapping,
                             noise_covar=noise_covar)
 
-    assert len(model_test.translation_offset) == 3
+    assert len(model_test.translation_offset) == len(pos_mapping)
     assert len(model_test.rotation_offset) == 3
-    assert len(model_test.velocity) == 3
+    assert len(model_test.velocity) == len(vel_mapping)
 
     # Create and a measurement model object
     model = modelclass(ndim_state=ndim_state,
@@ -804,6 +818,20 @@ def test_rangeratemodels(h, modelclass, state_vec, ndim_state, pos_mapping, vel_
                 None,  # position (translation offset)
                 None  # orientation (rotation offset)
         ),
+        (
+                h2d_rr,  # h
+                CartesianToBearingRangeRate2D,  # ModelClass
+                StateVectors([[200., 200.], [10., 10.], [0., 0.],
+                              [0., 0.], [0., 0.], [0., 0.]]),  # state_vec
+                6,  # ndim_state
+                np.array([0, 2]),  # pos_mapping
+                np.array([1, 3]),  # vel_mapping
+                CovarianceMatrix([[0.05, 0, 0],
+                                  [0, 0.015, 0],
+                                  [0, 0, 10]]),  # noise_covar
+                StateVector([[1], [-1]]),  # position (translation offset)
+                StateVector([[0], [0], [0]])  # orientation (rotation offset)
+        ),
         (   # 4D meas, 6D state
                 h3d_rr,  # h
                 CartesianToElevationBearingRangeRate,  # ModelClass
@@ -835,7 +863,7 @@ def test_rangeratemodels(h, modelclass, state_vec, ndim_state, pos_mapping, vel_
                 None  # orientation (rotation offset)
         )
     ],
-    ids=["rrRB_1", "rrRB_2", "rrRBE_1", "rrRBE_2"]
+    ids=["rrRB_1", "rrRB_2", "rrRB2D_1", "rrRBE_1", "rrRBE_2"]
 )
 def test_rangeratemodels_with_particles(h, modelclass, state_vec, ndim_state, pos_mapping,
                                         vel_mapping, noise_covar, position, orientation):
@@ -859,9 +887,9 @@ def test_rangeratemodels_with_particles(h, modelclass, state_vec, ndim_state, po
                             velocity_mapping=vel_mapping,
                             noise_covar=noise_covar)
 
-    assert len(model_test.translation_offset) == 3
+    assert len(model_test.translation_offset) == len(pos_mapping)
     assert len(model_test.rotation_offset) == 3
-    assert len(model_test.velocity) == 3
+    assert len(model_test.velocity) == len(vel_mapping)
 
     # Create and a measurement model object
     model = modelclass(ndim_state=ndim_state,
@@ -1309,7 +1337,7 @@ def test_models_with_particles(h, ModelClass, state_vec, R,
                             noise_covar=R)
 
     assert len(model_test.translation_offset) == ndim_state
-    assert len(model_test.rotation_offset) == 3
+    # assert len(model_test.rotation_offset) == 3
 
     # Create and a measurement model object
     model = ModelClass(ndim_state=ndim_state,

--- a/stonesoup/sensor/radar/radar.py
+++ b/stonesoup/sensor/radar/radar.py
@@ -498,6 +498,7 @@ class RadarBearingRangeRate(RadarBearingRange):
         true_range = measurement_vector[1, 0]  # Bearing(0), Range(1), Range-Rate(2)
         return true_range <= self.max_range
 
+
 class RadarBearingRangeRate2D(RadarBearingRange):
     """ A radar sensor that generates measurements of targets, using a
     :class:`~.CartesianToBearingRangeRate` model, relative to its position
@@ -539,7 +540,8 @@ class RadarBearingRangeRate2D(RadarBearingRange):
         measurement_vector = measurement_model.function(state, noise=False)
         true_range = measurement_vector[1, 0]  # Bearing(0), Range(1), Range-Rate(2)
         return true_range <= self.max_range
-       
+
+
 class RadarElevationBearingRangeRate(RadarBearingRangeRate):
     """ A radar sensor that generates measurements of targets, using a
     :class:`~.CartesianToElevationBearingRangeRate` model, relative to its position

--- a/stonesoup/sensor/radar/radar.py
+++ b/stonesoup/sensor/radar/radar.py
@@ -13,7 +13,7 @@ from ...models.measurement.base import MeasurementModel
 from ...models.measurement.nonlinear import \
     (CartesianToBearingRange, CartesianToElevationBearingRange,
      CartesianToBearingRangeRate, CartesianToElevationBearingRangeRate,
-     Cartesian2DToBearing)
+     Cartesian2DToBearing, CartesianToBearingRangeRate2D)
 from ...sensor.action.dwell_action import DwellActionsGenerator
 from ...sensor.action.tilt_action import TiltActionsGenerator
 from ...sensormanager.action import ActionableProperty
@@ -498,7 +498,46 @@ class RadarBearingRangeRate(RadarBearingRange):
         true_range = measurement_vector[1, 0]  # Bearing(0), Range(1), Range-Rate(2)
         return true_range <= self.max_range
 
+class RadarBearingRangeRate2D(RadarBearingRange):
+    """ A radar sensor that generates measurements of targets, using a
+    :class:`~.CartesianToBearingRangeRate` model, relative to its position
+    and velocity.
 
+    Note
+    ----
+    This class implementation assumes a 2D cartesian space and therefore\
+     expects a 4D state space.
+
+    """
+
+    velocity_mapping: Tuple[int, int] = Property(
+        default=(1, 3),
+        doc="Mapping to the target's velocity information within its state space")
+    ndim_state: int = Property(
+        default=2,
+        doc="Number of state dimensions. This is utilised by (and follows in format) "
+            "the underlying :class:`~.CartesianToBearingRangeRate2D` model")
+    noise_covar: CovarianceMatrix = Property(
+        doc="The sensor noise covariance matrix. This is utilised by "
+            "(and follows in format) the underlying "
+            ":class:`~.CartesianToBearingRangeRate2D` model")
+
+    @property
+    def measurement_model(self):
+        return CartesianToBearingRangeRate2D(
+            ndim_state=self.ndim_state,
+            mapping=self.position_mapping,
+            velocity_mapping=self.velocity_mapping,
+            noise_covar=self.noise_covar,
+            translation_offset=self.position,
+            velocity=self.velocity,
+            rotation_offset=self.orientation)
+
+    def is_detectable(self, state: GroundTruthState) -> bool:
+        measurement_vector = self.measurement_model.function(state, noise=False)
+        true_range = measurement_vector[1, 0]  # Bearing(0), Range(1), Range-Rate(2)
+        return true_range <= self.max_range
+       
 class RadarElevationBearingRangeRate(RadarBearingRangeRate):
     """ A radar sensor that generates measurements of targets, using a
     :class:`~.CartesianToElevationBearingRangeRate` model, relative to its position

--- a/stonesoup/sensor/radar/radar.py
+++ b/stonesoup/sensor/radar/radar.py
@@ -472,7 +472,7 @@ class RadarBearingRangeRate(RadarBearingRange):
         default=(1, 3, 5),
         doc="Mapping to the target's velocity information within its state space")
     ndim_state: int = Property(
-        default=3,
+        default=6,
         doc="Number of state dimensions. This is utilised by (and follows in format) "
             "the underlying :class:`~.CartesianToBearingRangeRate` model")
     noise_covar: CovarianceMatrix = Property(
@@ -510,11 +510,11 @@ class RadarBearingRangeRate2D(RadarBearingRange):
 
     """
 
-    velocity_mapping: Tuple[int, int] = Property(
+    velocity_mapping: tuple[int, int] = Property(
         default=(1, 3),
         doc="Mapping to the target's velocity information within its state space")
     ndim_state: int = Property(
-        default=2,
+        default=4,
         doc="Number of state dimensions. This is utilised by (and follows in format) "
             "the underlying :class:`~.CartesianToBearingRangeRate2D` model")
     noise_covar: CovarianceMatrix = Property(
@@ -533,8 +533,10 @@ class RadarBearingRangeRate2D(RadarBearingRange):
             velocity=self.velocity,
             rotation_offset=self.orientation)
 
-    def is_detectable(self, state: GroundTruthState) -> bool:
-        measurement_vector = self.measurement_model.function(state, noise=False)
+    def is_detectable(self, state: GroundTruthState, measurement_model=None) -> bool:
+        if measurement_model is None:
+            measurement_model = self.measurement_model
+        measurement_vector = measurement_model.function(state, noise=False)
         true_range = measurement_vector[1, 0]  # Bearing(0), Range(1), Range-Rate(2)
         return true_range <= self.max_range
        

--- a/stonesoup/sensor/radar/tests/test_radar.py
+++ b/stonesoup/sensor/radar/tests/test_radar.py
@@ -9,7 +9,7 @@ from pytest import approx
 from ..beam_pattern import StationaryBeam
 from ..beam_shape import Beam2DGaussian
 from ..radar import RadarBearingRange, RadarElevationBearingRange, RadarRotatingBearingRange, \
-    AESARadar, RadarRasterScanBearingRange, RadarBearingRangeRate, \
+    AESARadar, RadarRasterScanBearingRange, RadarBearingRangeRate, RadarBearingRangeRate2D, \
     RadarElevationBearingRangeRate, RadarBearing, RadarRotatingBearing, \
     RadarRotatingElevationBearingRange
 from ....functions import rotz, rotx, roty, cart2sphere
@@ -237,6 +237,16 @@ def h3d_rr(state, pos_map, vel_map, translation_offset, rotation_offset, velocit
                 StateVector([[100], [0], [0]])  # position
         ),
         (
+                h2d_rr,  # h
+                RadarBearingRangeRate2D,  # sensorclass
+                np.array([0, 2]),  # pos_mapping
+                np.array([1, 3]),  # vel_mapping
+                np.array([[0.05, 0, 0],
+                          [0, 0.015, 0],
+                          [0, 0, 10]]),  # noise_covar
+                StateVector([[100], [0]])  # position
+        ),
+        (
                 h3d_rr,
                 RadarElevationBearingRangeRate,
                 np.array([0, 2, 4]),  # pos_mapping
@@ -248,7 +258,7 @@ def h3d_rr(state, pos_map, vel_map, translation_offset, rotation_offset, velocit
                 StateVector([[100], [0], [0]])  # position
         )
     ],
-    ids=["RadarBearingRangeRate", "RadarElevationBearingRangeRate"]
+    ids=["RadarBearingRangeRate", "RadarBearingRangeRate2D", "RadarElevationBearingRangeRate"]
 )
 def test_range_rate_radar(h, sensorclass, pos_mapping, vel_mapping, noise_covar, position):
     # Instantiate the rotating radar


### PR DESCRIPTION
The RadarBearingRangeRate2D sensor and associated CartesianToBearingRangeRate2D measurement model were created to support tracking from measurements of bearing, range, and range rate to a 4D state space [x, vx, y, vy]. The current RadarBearingRangeRate/CartesianToBearingRangeRate class only supports a 6D state vector [x, vx, y, vy, z, vz] as a requirement for the creation of the rotation matrix.

Additionally, both measurement models were given inverse functions to support plotting measurements to a Cartesian plot space.