### PR TITLE
Fix issue with failing YAML serialisation tests

### DIFF
--- a/stonesoup/tests/conftest.py
+++ b/stonesoup/tests/conftest.py
@@ -3,10 +3,12 @@ import pytest
 from ..base import Base, Property
 
 
+class _TestBase(Base):
+    property_a: int = Property()
+    property_b: str = Property()
+    property_c: int = Property(default=123)
+
+
 @pytest.fixture(scope='session')
 def base():
-    class _TestBase(Base):
-        property_a: int = Property()
-        property_b: str = Property()
-        property_c: int = Property(default=123)
     return _TestBase


### PR DESCRIPTION
This was caused by update to *ruamel.yaml* that now requires escaped tag names, which only impacts the unusal case of `<local>` defined classes in tests.