### PR TITLE
Add metric MultiManager and MetricPlotter

### DIFF
--- a/docs/examples/MTT_3D_Platform.py
+++ b/docs/examples/MTT_3D_Platform.py
@@ -320,8 +320,11 @@ plotter2.plot_tracks(tracks_plot, [0, 2, 4], uncertainty=True, err_freq=5)
 
 # OSPA metric
 from stonesoup.metricgenerator.ospametric import OSPAMetric
-ospa_generator = OSPAMetric(c=40, p=1, generator_name='OSPA',
-                            tracks_key='tracks', truths_key='truths')
+ospa_generator = OSPAMetric(c=40, p=1,
+                            generator_name='OSPA metrics',
+                            tracks_key='tracks',
+                            truths_key='truths'
+                           )
 
 # SIAP metrics
 from stonesoup.metricgenerator.tracktotruthmetrics import SIAPMetrics
@@ -331,14 +334,15 @@ SIAPvel_measure = Euclidean(mapping=np.array([1, 3]))
 siap_generator = SIAPMetrics(
     position_measure=SIAPpos_measure,
     velocity_measure=SIAPvel_measure,
-    generator_name='SIAP',
-    tracks_key='tracks', truths_key='truths'
+    generator_name='SIAP metrics',
+    tracks_key='tracks',
+    truths_key='truths'
 )
 
 # Uncertainty metric
 from stonesoup.metricgenerator.uncertaintymetric import \
     SumofCovarianceNormsMetric
-uncertainty_generator = SumofCovarianceNormsMetric(generator_name='uncertainty',
+uncertainty_generator = SumofCovarianceNormsMetric(generator_name='Uncertainty metric',
                                                    tracks_key='tracks')
 
 # %%
@@ -365,8 +369,8 @@ metrics = metric_manager.generate_metrics()
 # The first metric we will look at is the OSPA metric.
 from stonesoup.plotter import MetricPlotter
 
-fig = MetricPlotter()
-fig.plot_metrics(metrics, generator_names=['OSPA'])
+fig1 = MetricPlotter()
+fig1.plot_metrics(metrics, generator_names=['OSPA metrics'])
 
 
 # %%
@@ -383,4 +387,6 @@ fig2.plot_metrics(metrics, metric_names=['SIAP Position Accuracy at times',
 # Since the sum is not normalized for the number of estimated states, it is
 # most important to look at the trends of this graph rather than the values.
 fig3 = MetricPlotter()
-fig3.plot_metrics(metrics, generator_names=['uncertainty'])
+fig3.plot_metrics(metrics, generator_names=['Uncertainty metric'])
+fig3.fig.axes[0].set_title(label='Track uncertainty over time')
+plt.show()

--- a/docs/examples/MTT_3D_Platform.py
+++ b/docs/examples/MTT_3D_Platform.py
@@ -379,8 +379,7 @@ fig1.plot_metrics(metrics, generator_names=['OSPA metrics'])
 fig2 = MetricPlotter()
 fig2.plot_metrics(metrics, metric_names=['SIAP Position Accuracy at times',
                                          'SIAP Velocity Accuracy at times'])
-fig2.set_fig_title('SIAP metrics')  # add optional figure title
-plt.show()
+fig2.set_fig_title('SIAP metrics')
 
 
 # %%
@@ -390,5 +389,4 @@ plt.show()
 # most important to look at the trends of this graph rather than the values.
 fig3 = MetricPlotter()
 fig3.plot_metrics(metrics, generator_names=['Uncertainty metric'])
-fig3.set_ax_title(['Track uncertainty over time'])  # change default axis title
-plt.show()
+fig3.set_ax_title(['Track uncertainty over time'])

--- a/docs/examples/MTT_3D_Platform.py
+++ b/docs/examples/MTT_3D_Platform.py
@@ -379,6 +379,8 @@ fig1.plot_metrics(metrics, generator_names=['OSPA metrics'])
 fig2 = MetricPlotter()
 fig2.plot_metrics(metrics, metric_names=['SIAP Position Accuracy at times',
                                          'SIAP Velocity Accuracy at times'])
+fig2.set_fig_title('SIAP metrics')  # add optional figure title
+plt.show()
 
 
 # %%
@@ -388,5 +390,5 @@ fig2.plot_metrics(metrics, metric_names=['SIAP Position Accuracy at times',
 # most important to look at the trends of this graph rather than the values.
 fig3 = MetricPlotter()
 fig3.plot_metrics(metrics, generator_names=['Uncertainty metric'])
-fig3.fig.axes[0].set_title(label='Track uncertainty over time')
+fig3.set_ax_title(['Track uncertainty over time'])  # change default axis title
 plt.show()

--- a/docs/examples/Metrics.py
+++ b/docs/examples/Metrics.py
@@ -425,9 +425,13 @@ siap_table = SIAPTableGenerator(siap_averages_PF).compute_metric()
 #
 # To use :class:`MetricPlotter` we first create an instance of the class. We can then use the .plot_metrics() method to
 # plot the metrics of our choice. Key features of :class:`MetricPlotter`:
-# - You can specify which metrics you want to plot using the generator_names argument. If you don't pass the
-#   generator_names argument, .plot_metrics() will automatically extract all plottable metrics from those you have
-#   generated and plot them.
+# - You can specify exactly which metrics you want to plot by specifying the optional generator_names and metric_names
+#   parameters.
+# - generator_names allows you to specify which generators you want to plot metrics from. If you don't pass the
+#   generator_names argument, .plot_metrics() will automatically extract all plottable metrics from all metric
+#   generators in the :class:`MultiManager` and plot them.
+# - metric_names allows you to specify which specific metrics types you want to plot from the metric generators. This is
+#   mostly relevant for the SIAP metrics. You can view which metrics are plottable with MetricPlotter.plottable_metrics.
 # - .plot_metrics has a combine_plots argument which defaults to True. This means that all metrics of the same type will
 #   be plotted together on a single subplot.
 # - You can specify additional formatting, like colour and linestyle, for the plots produced by using keyword arguments
@@ -443,9 +447,11 @@ graph.plot_metrics(metrics, generator_names=['OSPA_EKF-truth',
                                              'OSPA_EKF-PF',
                                              'SIAP_EKF-truth',
                                              'SIAP_PF-truth'],
+                   # metric_names=['OSPA distances',
+                   #               'SIAP Position Accuracy at times'],  # uncomment and run to see effect
                    color=['orange', 'green', 'blue'])
 
-# update y-axis label and title, other subplots have auto-generated title and labels
+# update y-axis label and title, other subplots are displaying auto-generated title and labels
 graph.axes[0].set(ylabel='OSPA metrics', title='OSPA distances over time')
 graph.fig.show()
 

--- a/docs/examples/Metrics.py
+++ b/docs/examples/Metrics.py
@@ -12,8 +12,8 @@ Metrics example
 # to easily generate metric plots for visualisation.
 #
 # To generate metrics, we need:
-#  - At least one metric generator - these are used to determine the metric type we want to generate and to compute the
-#    metrics themselves.
+#  - At least one :class:`MetricGenerator` - these are used to determine the metric type we want to generate and to
+#    compute the metrics themselves.
 #  - The :class:`MultiManager` metric manager - this is used to hold the metric generator(s) as well as all the ground
 #    truth, track, and detection sets we want to generate our metrics from. We will generate our metrics using the
 #    generate_metrics method of the :class:`MultiManager` class.

--- a/docs/examples/Metrics.py
+++ b/docs/examples/Metrics.py
@@ -174,7 +174,6 @@ from stonesoup.simulator.simple import SwitchMultiTargetGroundTruthSimulator
 from stonesoup.types.state import GaussianState
 
 # generate truths
-
 n_truths = 3
 xmin = 0
 xmax = 40

--- a/docs/examples/Metrics.py
+++ b/docs/examples/Metrics.py
@@ -155,8 +155,8 @@ timestep_size = datetime.timedelta(seconds=5)
 number_steps = 20
 initial_state = GaussianState(initial_state_mean, initial_state_covariance)
 
-from stonesoup.models.transition.linear import (
-    CombinedLinearGaussianTransitionModel, ConstantVelocity, KnownTurnRate)
+from stonesoup.models.transition.linear import \
+    CombinedLinearGaussianTransitionModel, ConstantVelocity, KnownTurnRate
 
 # initialise the transition models the ground truth can use
 constant_velocity = CombinedLinearGaussianTransitionModel(
@@ -295,7 +295,7 @@ kalman_tracker_EKF = MultiTargetTracker(  # Runs the tracker
     deleter=deleter,
     detector=detectors[0],
     data_associator=data_associator_EKF,
-    updater=updater_EKF,
+    updater=updater_EKF
 )
 
 # %%

--- a/docs/examples/Metrics.py
+++ b/docs/examples/Metrics.py
@@ -110,10 +110,10 @@ sum_cov_norms_PF = SumofCovarianceNormsMetric(tracks_key='PF_tracks',
 
 from stonesoup.metricgenerator.plotter import TwoDPlotter
 
-plot_generator_EKF = TwoDPlotter([0, 2], [0, 2], [0, 2], tracks_key='EKF_tracks',
+plot_generator_EKF = TwoDPlotter([0, 2], [0, 2], [0, 2], uncertainty=True, tracks_key='EKF_tracks',
                                  truths_key='truths', detections_key='detections',
                                  generator_name='EKF_plot')
-plot_generator_PF = TwoDPlotter([0, 2], [0, 2], [0, 2], tracks_key='PF_tracks',
+plot_generator_PF = TwoDPlotter([0, 2], [0, 2], [0, 2], uncertainty=True, tracks_key='PF_tracks',
                                 truths_key='truths', detections_key='detections',
                                 generator_name='PF_plot')
 

--- a/docs/examples/Metrics.py
+++ b/docs/examples/Metrics.py
@@ -427,6 +427,7 @@ siap_table = SIAPTableGenerator(siap_averages_PF).compute_metric()
 #
 # To use :class:`~.MetricPlotter` we first create an instance of the class. We can then use the :meth:`plot_metrics()`
 # method to plot the metrics of our choice. Key features of :class:`~.MetricPlotter`:
+#
 # - You can specify exactly which metrics you want to plot by specifying the optional `generator_names` and
 #   `metric_names` parameters.
 # - `generator_names` allows you to specify which generators you want to plot metrics from. If you don't pass the

--- a/docs/examples/Metrics.py
+++ b/docs/examples/Metrics.py
@@ -34,8 +34,9 @@ Metrics example
 # to specify which tracks or truths we want to generate metrics for.
 #
 # NB: in all metrics that take a track and a truth as input, it is possible to input two tracks instead for calculating
-# track to track comparisons. You would still input them as a tracks_key and a truths_key, but they would both be keys
-# for a tracks set.
+# track to track comparisons. This is relevant in scenarios where a second set of tracks is used as a proxy for ground
+# truth. To do this, set the `tracks_key` parameter to the tracks set and the `truths_key` parameter to the second
+# tracks set that is being used as a ground truth proxy.
 
 from stonesoup.metricgenerator.basicmetrics import BasicMetrics
 

--- a/docs/examples/Metrics.py
+++ b/docs/examples/Metrics.py
@@ -344,10 +344,10 @@ tracker_PF = MultiTargetTracker(
 # -----------------------------------------------
 # Now that we have all of our ground truth, detections, and tracks data, we can add it to the metric manager.
 #
-# The MultiManager :meth:`.add_data()` method takes a dictionary of lists/sets of ground truth, detections, and/or tracks data.
-# It can take multiple sets of each type. Each state set must have a unique key assigned to it. The track, truth, and
-# detection keys that we input into the metric generators will be used to extract the corresponding set from the
-# :class:`~.MultiManager` for metric generation.
+# The MultiManager :meth:`~.MultiManager.add_data()` method takes a dictionary of lists/sets of ground truth,
+# detections, and/or tracks data. It can take multiple sets of each type. Each state set must have a unique key assigned
+# to it. The track, truth, and detection keys that we input into the metric generators will be used to extract the
+# corresponding set from the :class:`~.MultiManager` for metric generation.
 #
 # Setting overwrite to False allows new data to be added to the :class:`~.MultiManager` without overwriting data that is
 # already in it, as demonstrated in the code below.

--- a/docs/examples/Metrics.py
+++ b/docs/examples/Metrics.py
@@ -1,212 +1,476 @@
 #!/usr/bin/env python
 
 """
-Metrics Example
 ===============
-This example is going to look at metrics, and how they can be used to assess algorithm performance.
+Metrics example
+===============
 """
 
 # %%
-# Building a Simple Simulation and Tracker
-# ----------------------------------------
-# For simplicity, we are going to quickly build a basic Kalman Tracker, with simple Stone Soup
-# simulators, including clutter. In this case a 2D constant velocity target, with 2D linear
-# measurements of position.
-import datetime
-
-import numpy as np
-import matplotlib.pyplot as plt
-
-from stonesoup.dataassociator.neighbour import GNNWith2DAssignment
-from stonesoup.deleter.error import CovarianceBasedDeleter
-from stonesoup.hypothesiser.distance import DistanceHypothesiser
-from stonesoup.initiator.simple import MultiMeasurementInitiator
-from stonesoup.measures import Mahalanobis
-from stonesoup.models.transition.linear import (
-    CombinedLinearGaussianTransitionModel, ConstantVelocity)
-from stonesoup.models.measurement.linear import LinearGaussian
-from stonesoup.predictor.kalman import KalmanPredictor
-from stonesoup.simulator.simple import MultiTargetGroundTruthSimulator, SimpleDetectionSimulator
-from stonesoup.tracker.simple import MultiTargetTracker
-from stonesoup.types.array import StateVector, CovarianceMatrix
-from stonesoup.types.state import GaussianState
-from stonesoup.updater.kalman import KalmanUpdater
-
-# Models
-transition_model = CombinedLinearGaussianTransitionModel(
-    [ConstantVelocity(1), ConstantVelocity(1)], seed=1)
-
-measurement_model = LinearGaussian(4, [0, 2], np.diag([0.5, 0.5]), seed=2)
-
-# Simulators
-groundtruth_sim = MultiTargetGroundTruthSimulator(
-    transition_model=transition_model,
-    initial_state=GaussianState(
-        StateVector([[0], [0], [0], [0]]),
-        CovarianceMatrix(np.diag([1000, 10, 1000, 10]))),
-    timestep=datetime.timedelta(seconds=5),
-    number_steps=100,
-    birth_rate=0.2,
-    death_probability=0.05,
-    seed=3
-)
-detection_sim = SimpleDetectionSimulator(
-    groundtruth=groundtruth_sim,
-    measurement_model=measurement_model,
-    meas_range=np.array([[-1, 1], [-1, 1]]) * 5000,  # Area to generate clutter
-    detection_probability=0.9,
-    clutter_rate=1,
-    seed=4
-)
-
-# Filter
-predictor = KalmanPredictor(transition_model)
-updater = KalmanUpdater(measurement_model)
-
-# Data Associator
-hypothesiser = DistanceHypothesiser(predictor, updater, Mahalanobis(), missed_distance=3)
-data_associator = GNNWith2DAssignment(hypothesiser)
-
-# Initiator & Deleter
-deleter = CovarianceBasedDeleter(covar_trace_thresh=1E3)
-initiator = MultiMeasurementInitiator(
-    GaussianState(np.array([[0], [0], [0], [0]]), np.diag([0, 100, 0, 1000])),
-    measurement_model=measurement_model,
-    deleter=deleter,
-    data_associator=data_associator,
-    updater=updater,
-    min_points=3,
-)
-
-# Tracker
-tracker = MultiTargetTracker(
-    initiator=initiator,
-    deleter=deleter,
-    detector=detection_sim,
-    data_associator=data_associator,
-    updater=updater,
-)
+# This example demonstrates some of the different metrics available in Stonesoup and how they can be used with the
+# :class:`MultiManager` to assess tracking performance. It also demonstrates how to use the :class:`MetricPlotter` class
+# to easily generate metric plots for visualisation.
+#
+# To generate metrics, we need:
+#  - At least one metric generator - these are used to determine the metric type we want to generate and to compute the
+#    metrics themselves.
+#  - The :class:`MultiManager` metric manager - this is used to hold the metric generator(s) as well as all the ground
+#    truth, track, and detection sets we want to generate our metrics from. We will generate our metrics using the
+#    generate_metrics method of the :class:`MultiManager` class.
+#
+# In this example, we will create a variety of metric generators for different types of metrics. These metrics will be
+# used to assess and compare tracks produced from the same set of ground truth paths and detections by the Extended
+# Kalman Filter and the Particle Filter.
 
 # %%
-# Create Metric Generators
-# ------------------------
-# Here we are going to create a variety of metrics. First up is some "Basic Metrics", that simply
-# computes the number of tracks, number to targets and the ratio of tracks to targets. Basic but
-# useful information, that requires no additional properties.
+# Create metric generators and metric manager
+# -------------------------------------------
+# In this section we create the metric generators in preparation for generating metrics later on.
+#
+# First we create some Basic Metrics generators that will show us the number of tracks, the number of targets and the
+# ratio of tracks to targets. As with all the other metric generators, we must give our generator a unique name to
+# identify it later, and the keys for our tracks and ground truth data (and detections set if relevant). When we
+# generate the metrics, these keys will be used to access the data that we will store in the MultiManager and allow us
+# to specify which tracks or truths we want to generate metrics for.
+#
+# NB: in all metrics that take a track and a truth as input, it is possible to input two tracks instead for calculating
+# track to track comparisons. You would still input them as a tracks_key and a truths_key, but they would both be keys
+# for a tracks set.
+
 from stonesoup.metricgenerator.basicmetrics import BasicMetrics
 
-basic_generator = BasicMetrics()
+basic_EKF = BasicMetrics(generator_name='basic_EKF', tracks_key='EKF_tracks', truths_key='truths')
+basic_PF = BasicMetrics(generator_name='basic_PF', tracks_key='PF_tracks', truths_key='truths')
 
 # %%
-# Next we'll create the Optimal SubPattern Assignment (OSPA) metric generator. This metric is
-# calculated at each time step, giving an overall multi-track to multi-groundtruth missed distance.
-# This has two properties: :math:`p \in [1,\infty]` for outlier sensitivity and :math:`c > 1` for
+# Next we create the Optimal SubPattern Assignment (OSPA) metric generator. This metric is calculated at each time step
+# to show how far the tracks are from the ground truth paths. It returns an overall multi-track to multi-ground-truth
+# missed distance for each time step.
+#
+# The generator has two additional properties: :math:`p \in [1,\infty]` for outlier sensitivity and :math:`c > 1` for
 # cardinality penalty. [#]_
+
 from stonesoup.metricgenerator.ospametric import OSPAMetric
+
+ospa_EKF_truth = OSPAMetric(c=40, p=1, generator_name='OSPA_EKF-truth',
+                            tracks_key='EKF_tracks', truths_key='truths')
+ospa_PF_truth = OSPAMetric(c=40, p=1, generator_name='OSPA_PF-truth',
+                           tracks_key='PF_tracks', truths_key='truths')
+ospa_EKF_PF = OSPAMetric(c=40, p=1, generator_name='OSPA_EKF-PF',
+                         tracks_key='EKF_tracks', truths_key='PF_tracks')
+
+# %%
+# Next we create the Single Integrated Air Picture (SIAP) metric generators. These metrics are applicable to tracking in
+# general and not just in relation to an air picture. [#]_
+#
+# The SIAP generators will generate a series of different individual SIAP metrics that will provide information about
+# the accuracy of the tracking. They will generate different SIAP metrics for each time step, as well as overall
+# averages. You will see the SIAP metric averages and more detail about what the different metrics mean in the table
+# generated towards the end of the notebook.
+#
+# The SIAP Metrics require a way to associate tracks to truth, so we'll use a Track to Truth associator which uses
+# Euclidean distance measure by default.
+
+from stonesoup.metricgenerator.tracktotruthmetrics import SIAPMetrics
 from stonesoup.measures import Euclidean
 
-ospa_generator = OSPAMetric(c=10, p=1, measure=Euclidean([0, 2]))
+siap_EKF_truth = SIAPMetrics(position_measure=Euclidean((0, 2)),
+                             velocity_measure=Euclidean((1, 3)),
+                             generator_name='SIAP_EKF-truth',
+                             tracks_key='EKF_tracks',
+                             truths_key='truths'
+                             )
 
-# %%
-# And finally we create some Single Integrated Air Picture (SIAP) metrics. Despite it's name, this
-# is applicable to tracking in general and not just in relation to an air picture. This is made up
-# of multiple individual metrics. [#]_
-from stonesoup.metricgenerator.tracktotruthmetrics import SIAPMetrics
+siap_PF_truth = SIAPMetrics(position_measure=Euclidean((0, 2)),
+                            velocity_measure=Euclidean((1, 3)),
+                            generator_name='SIAP_PF-truth',
+                            tracks_key='PF_tracks',
+                            truths_key='truths'
+                            )
 
-siap_generator = SIAPMetrics(position_measure=Euclidean((0, 2)),
-                             velocity_measure=Euclidean((1, 3)))
-
-# %%
-# The SIAP Metrics requires a way to associate tracks to truth, so we'll use a Track to Truth
-# associator, which uses Euclidean distance measure by default.
 from stonesoup.dataassociator.tracktotrack import TrackToTruth
 
 associator = TrackToTruth(association_threshold=30)
 
 # %%
-# As a final example of a metric, we'll create a plotting metric, which is a visual way to view the
-# output of our tracker.
+# Next we create metric generators for the Sum of Covariance Norms. They will calculate the sum of the covariance matrix
+# norms of each track state at each time step. These metrics produced will indicate how uncertain the tracks we have
+# produced are. Higher sum of covariance norms means higher uncertainty.
+
+from stonesoup.metricgenerator.uncertaintymetric import SumofCovarianceNormsMetric
+
+sum_cov_norms_EKF = SumofCovarianceNormsMetric(tracks_key='EKF_tracks',
+                                               generator_name='sum_cov_norms_EKF')
+sum_cov_norms_PF = SumofCovarianceNormsMetric(tracks_key='PF_tracks',
+                                              generator_name='sum_cov_norms_PF')
+
+# %%
+# Finally, we create two plot generators - one for each of the two different trackers we are using. These will take in
+# the tracks, ground truths, and detections that we generate and plot them in 2 dimensions.
+
 from stonesoup.metricgenerator.plotter import TwoDPlotter
 
-plot_generator = TwoDPlotter([0, 2], [0, 2], [0, 2])
+plot_generator_EKF = TwoDPlotter([0, 2], [0, 2], [0, 2], tracks_key='EKF_tracks',
+                                 truths_key='truths', detections_key='detections',
+                                 generator_name='EKF_plot')
+plot_generator_PF = TwoDPlotter([0, 2], [0, 2], [0, 2], tracks_key='PF_tracks',
+                                truths_key='truths', detections_key='detections',
+                                generator_name='PF_plot')
 
 # %%
-# Once we've created a set of metrics, these are added to a Metric Manager, along with the
-# associator. The associator can be used by multiple metric generators, only being run once as this
-# can be a computationally expensive process; in this case, only SIAP Metrics requires it.
-from stonesoup.metricgenerator.manager import SimpleManager
+# Now we add all of our metric generators to the :class:`MultiManager`.
 
-metric_manager = SimpleManager([basic_generator, ospa_generator, siap_generator, plot_generator],
-                               associator=associator)
+from stonesoup.metricgenerator.manager import MultiManager
 
-# %%
-# Tracking and Generating Metrics
-# -------------------------------
-# With this basic tracker built and metrics ready, we'll now run the tracker, adding the sets of
-# :class:`~.GroundTruthPath`, :class:`~.Detection` and :class:`~.Track` objects: to the metric
-# manager.
-for time, tracks in tracker:
-    metric_manager.add_data(
-        groundtruth_sim.groundtruth_paths, tracks, detection_sim.detections,
-        overwrite=False,  # Don't overwrite, instead add above as additional data
-    )
+metric_manager = MultiManager([basic_EKF,
+                               basic_PF,
+                               ospa_EKF_truth,
+                               ospa_PF_truth,
+                               ospa_EKF_PF,
+                               siap_EKF_truth,
+                               siap_PF_truth,
+                               sum_cov_norms_EKF,
+                               sum_cov_norms_PF,
+                               plot_generator_EKF,
+                               plot_generator_PF
+                               ], associator)  # associator for generating SIAP metrics
 
 # %%
-# With the tracker run and data in the metric manager, we'll now run the generate metrics method.
-# This will also generate the plot, which will be rendered automatically below, which will give a
-# visual overview
-plt.rcParams["figure.figsize"] = (10, 8)
+# Generate ground truth and detections
+# ------------------------------------
+# In this section, we generate the ground truth paths and the detections to be tracked - we will simulate targets that
+# can turn left or right. Both our Extended Kalman Filter tracker and Particle Filter tracker will be given the same
+# sets of truths and detections to track so that we can fairly compare the results.
+
+import numpy as np
+import datetime
+from stonesoup.types.array import StateVector, CovarianceMatrix
+from stonesoup.types.state import State, GaussianState
+
+start_time = datetime.datetime.now()
+np.random.seed(8)
+initial_state_mean = StateVector([[0], [0], [0], [0]])
+initial_state_covariance = CovarianceMatrix(np.diag([4, 0.5, 4, 0.5]))
+timestep_size = datetime.timedelta(seconds=5)
+number_steps = 20
+initial_state = GaussianState(initial_state_mean, initial_state_covariance)
+
+from stonesoup.models.transition.linear import (
+    CombinedLinearGaussianTransitionModel, ConstantVelocity, KnownTurnRate)
+
+# initialise the transition models the ground truth can use
+constant_velocity = CombinedLinearGaussianTransitionModel(
+    [ConstantVelocity(0.05), ConstantVelocity(0.05)])
+turn_left = KnownTurnRate([0.05, 0.05], np.radians(20))
+turn_right = KnownTurnRate([0.05, 0.05], np.radians(-20))
+
+# create a probability matrix - how likely the ground truth will use each transition model,
+# given its current model
+model_probs = np.array([[0.7, 0.15, 0.15],  # keep straight, turn left, turn right
+                        [0.4, 0.6, 0.0],  # go straight, keep turning left, turn right
+                        [0.4, 0.0, 0.6]])  # go straight, turn left, keep turning right
+
+from stonesoup.simulator.simple import SwitchMultiTargetGroundTruthSimulator
+from stonesoup.types.state import GaussianState
+
+# generate truths
+
+n_truths = 3
+xmin = 0
+xmax = 40
+ymin = 0
+ymax = 40
+preexisting_states = []
+
+for i in range(0, n_truths):
+    x = np.random.randint(xmin, xmax) - 1  # x position of initial state
+    y = np.random.randint(ymin, ymax) - 1  # y position of initial state
+    x_vel = np.random.randint(-20, 20) / 10  # x velocity will start between -2 and 2
+    y_vel = np.random.randint(-20, 20) / 10  # y velocity will start between -2 and 2
+    preexisting_states.append(StateVector([x, x_vel, y, y_vel]))
+
+ground_truth_gen = SwitchMultiTargetGroundTruthSimulator(
+    initial_state=initial_state,
+    transition_models=[constant_velocity, turn_left, turn_right],
+    model_probs=model_probs,  # put in matrix from above
+    number_steps=number_steps,  # how long we want each track to be
+    birth_rate=0,
+    death_probability=0,
+    preexisting_states=preexisting_states
+)
+
+# %%
+# Next we create a sensor and use it to generate detections from the targets. The sensor we use in this example is a
+# radar with imperfect measurements in bearing-range space.
+
+from stonesoup.sensor.radar import RadarBearingRange
+
+# Create the sensor
+sensor = RadarBearingRange(
+    ndim_state=4,
+    position_mapping=[0, 2],  # Detecting x and y
+    noise_covar=np.diag([np.radians(0.2), 0.2]),  # Radar doesn't take perfect measurements
+    clutter_model=None,  # Can add clutter model in future if desired
+)
+
+from stonesoup.platform import FixedPlatform
+
+platform = FixedPlatform(State(StateVector([20, 0, 0, 0])), position_mapping=[0, 2],
+                         sensors=[sensor])
+
+# create identical detection sets for each tracker to use
+from itertools import tee
+from stonesoup.simulator.platform import PlatformDetectionSimulator
+
+detector = PlatformDetectionSimulator(ground_truth_gen, platforms=[platform])
+detector, *detectors = tee(detector, 3)
+
+# %%
+# Now we plot the ground truth paths and detections:
+
+detections = set()
+truths = set()
+
+for time, detects in detector:
+    detections |= detects
+    truths |= ground_truth_gen.groundtruth_paths
+
+from stonesoup.plotter import Plotterly
+
+plotter = Plotterly()
+plotter.plot_ground_truths(truths, [0, 2])
+plotter.plot_measurements(detections, [0, 2])
+plotter.plot_sensors(sensor)
+plotter.fig
+
+# %%
+# Create and run the trackers
+# ---------------------------
+# Now we create and run the two different trackers, one with the Extended Kalman Filter (EKF) and one with the Particle
+# Filter (PF). We start first with the EKF tracker.
+
+from stonesoup.predictor.kalman import ExtendedKalmanPredictor
+from stonesoup.updater.kalman import ExtendedKalmanUpdater
+
+transition_model_estimate = CombinedLinearGaussianTransitionModel([ConstantVelocity(0.5),
+                                                                   ConstantVelocity(0.5)])
+predictor_EKF = ExtendedKalmanPredictor(transition_model_estimate)
+updater_EKF = ExtendedKalmanUpdater(sensor)
+
+from stonesoup.hypothesiser.distance import DistanceHypothesiser
+from stonesoup.measures import Mahalanobis
+
+hypothesiser_EKF = DistanceHypothesiser(predictor_EKF, updater_EKF,
+                                        measure=Mahalanobis(), missed_distance=4)
+
+from stonesoup.dataassociator.neighbour import GNNWith2DAssignment
+
+data_associator_EKF = GNNWith2DAssignment(hypothesiser_EKF)
+
+from stonesoup.deleter.time import UpdateTimeDeleter
+
+deleter = UpdateTimeDeleter(datetime.timedelta(seconds=5), delete_last_pred=True)
+
+init_transition_model = CombinedLinearGaussianTransitionModel(
+    (ConstantVelocity(1), ConstantVelocity(1)))
+init_predictor_EKF = ExtendedKalmanPredictor(init_transition_model)
+
+from stonesoup.initiator.simple import MultiMeasurementInitiator
+
+initiator_EKF = MultiMeasurementInitiator(
+    GaussianState(
+        np.array([[20], [0], [10], [0]]),  # Prior State
+        np.diag([1, 1, 1, 1])),
+    measurement_model=None,
+    deleter=deleter,
+    data_associator=GNNWith2DAssignment(
+        DistanceHypothesiser(init_predictor_EKF, updater_EKF, Mahalanobis(), missed_distance=5)),
+    updater=updater_EKF,
+    min_points=2
+)
+
+from stonesoup.tracker.simple import MultiTargetTracker
+
+kalman_tracker_EKF = MultiTargetTracker(  # Runs the tracker
+    initiator=initiator_EKF,
+    deleter=deleter,
+    detector=detectors[0],
+    data_associator=data_associator_EKF,
+    updater=updater_EKF,
+)
+
+# %%
+# Now we create and run the tracker with the Particle Filter:
+
+from stonesoup.predictor.particle import ParticlePredictor
+from stonesoup.resampler.particle import ESSResampler
+
+resampler = ESSResampler()
+from stonesoup.updater.particle import ParticleUpdater
+
+predictor_PF = ParticlePredictor(transition_model_estimate)
+updater_PF = ParticleUpdater(measurement_model=None, resampler=resampler)
+
+hypothesiser_PF = DistanceHypothesiser(predictor_PF, updater_PF,
+                                       measure=Mahalanobis(), missed_distance=4)
+data_associator_PF = GNNWith2DAssignment(hypothesiser_PF)
+
+init_predictor_PF = ParticlePredictor(init_transition_model)
+
+from stonesoup.initiator.simple import GaussianParticleInitiator
+from stonesoup.types.state import GaussianState
+from stonesoup.initiator.simple import SimpleMeasurementInitiator
+
+prior_state = GaussianState(
+    StateVector([20, 0, 10, 0]),
+    np.diag([1, 1, 1, 1]) ** 2)
+
+initiator_Part = SimpleMeasurementInitiator(prior_state, measurement_model=None,
+                                            skip_non_reversible=True)
+initiator_PF = GaussianParticleInitiator(number_particles=2000,
+                                         initiator=initiator_Part,
+                                         use_fixed_covar=False)
+
+tracker_PF = MultiTargetTracker(
+    initiator=initiator_PF,
+    deleter=deleter,
+    detector=detectors[1],
+    data_associator=data_associator_PF,
+    updater=updater_PF,
+)
+
+# %%
+# Add data to metric manager and generate metrics
+# -----------------------------------------------
+# Now that we have all of our ground truth, detections, and tracks data, we can add it to the metric manager.
+#
+# The MultiManager .add_data() method takes a dictionary of lists/sets of ground truth, detections, and/or tracks data.
+# It can take multiple sets of each type. Each state set must have a unique key assigned to it. The track, truth, and
+# detection keys that we input into the metric generators will be used to extract the corresponding set from the
+# :class:`MultiManager` for metric generation.
+#
+# Setting overwrite to False allows new data to be added to the :class:`MultiManager` without overwriting data that is
+# already in it, as demonstrated in the code below.
+
+
+# add tracks data to metric manager
+for step, (time, current_tracks) in enumerate(kalman_tracker_EKF, 1):
+    metric_manager.add_data({'EKF_tracks': current_tracks}, overwrite=False)
+
+for step, (time, current_tracks) in enumerate(tracker_PF, 1):
+    metric_manager.add_data({'PF_tracks': current_tracks}, overwrite=False)
+
+# then add truths and detections
+metric_manager.add_data({'truths': truths,
+                         'detections': detections}, overwrite=False)
+
+
+# %%
+# Generate metrics
+# ----------------
+# We are now ready to generate and view all the metrics from our MultiManager.
+#
+# Because we have two plot generators in our metric manager, two plots will be produced and displayed when we generate
+# the metrics. They will show the ground truth paths, detections, and tracks. One will display the tracks produced by
+# the EKF tracker and the other will display the tracks from the PF tracker.
+
 metrics = metric_manager.generate_metrics()
 
 # %%
-# So first we'll loop through the metrics and print out the basic metrics, which simply gives
-# details on number of tracks versus targets.
-for metric in metrics:
-    if not any(s in metric for s in ('SIAP', 'OSPA', 'plot')):
-        print(f"{metric} : {metrics.get(metric).value}")
+# We can see from the plots above that the two trackers exhibit similar performance in tracking the ground truths.
+#
+# Let's look at the metrics we've generated to compare them further. We'll start by printing out the basic metrics with
+# the .display_basic_metrics method, which gives us information on the number of tracks versus targets.
+
+metric_manager.display_basic_metrics()
 
 # %%
-# Next we'll take a look at the OSPA metric, plotting it to show how it varies over time. In this
-# example, targets are created and remove randomly, so expect this to be fairly variable.
-ospa_metric = metrics['OSPA distances']
+# The basic metrics show that both the EKF and the PF have successfully produced tracks for each of the ground truth
+# paths so have a 1:1 track-to-target ratio.
+#
+# Next we'll look at the averages of each of the SIAP metrics to compare.
+#
+# First we extract the SIAP averages from the :class:`MultiManager` using the .get_siap_averages() method. Then we use
+# the :class:`SIAPTableGenerator` to display the average metrics in a table which shows us descriptions for each metric.
+# We will create a table for the EKF SIAPs first.
 
-fig = plt.figure()
-ax = fig.add_subplot(1, 1, 1)
-ax.plot([i.timestamp for i in ospa_metric.value], [i.value for i in ospa_metric.value])
-ax.set_ylabel("OSPA distance")
-ax.tick_params(labelbottom=False)
-_ = ax.set_xlabel("Time")
-
-# %%
-# And finally, we'll look at the SIAP metrics, but to make these easier to visualise and understand
-# we'll use a special SIAP table generator. This will colour code the results for quick visual
-# indication, as well as provide a description for each metric.
 from stonesoup.metricgenerator.metrictables import SIAPTableGenerator
 
-siap_averages = {metrics.get(metric) for metric in metrics
-                 if metric.startswith("SIAP") and not metric.endswith(" at times")}
-siap_time_based = {metrics.get(metric) for metric in metrics if metric.endswith(' at times')}
-
-_ = SIAPTableGenerator(siap_averages).compute_metric()
+siap_averages_EKF = metric_manager.get_siap_averages('SIAP_EKF-truth')
+siap_table = SIAPTableGenerator(siap_averages_EKF).compute_metric()
 
 # %%
-# Plotting appropriate SIAP values at each timestamp gives:
+# Now we produce a table for the PF SIAPs for comparison.
 
-fig2, axes = plt.subplots(5)
+siap_averages_PF = metric_manager.get_siap_averages('SIAP_PF-truth')
+siap_table = SIAPTableGenerator(siap_averages_PF).compute_metric()
 
-fig2.subplots_adjust(hspace=1)
+# %%
+# We can see that the values for most of the SIAP metric averages are not very different between the two trackers, again
+# showing their tracking quality is very similar. Other specific observations include:
+#
+# - SIAP Ambiguity of just above 1 indicates that there are places where multiple tracks overlap the same section of
+#   ground truth path, which we can see is the case from the plots above.
+# - A Longest Track Segment of 0.88 indicates that on average the three different tracks produced are not following 100%
+#   of the ground truth paths. We can see on the lower left area of our plots that the tracks have been confused.
+# - Positional and velocity errors of ~0.80 and 0.66, respectively, indicate that there is some distance between the
+#   tracks and ground truth paths. Again, we can see this from the plots. The range for these errors is 0-infinity so
+#   the errors are not significant.
+# - SIAP Spuriousness of 0 show us no tracks have been created that are not associated to a true object. We might get
+#   higher spuriousness if we added clutter to our detections.
 
-t_siaps = siap_time_based
+# %%
+# Plot metrics
+# ------------
+# We will use :class:`MetricPlotter` to plot some of our metrics below.
+#
+# To use :class:`MetricPlotter` we first create an instance of the class. We can then use the .plot_metrics() method to
+# plot the metrics of our choice. Key features of :class:`MetricPlotter`:
+# - You can specify which metrics you want to plot using the generator_names argument. If you don't pass the
+#   generator_names argument, .plot_metrics() will automatically extract all plottable metrics from those you have
+#   generated and plot them.
+# - .plot_metrics has a combine_plots argument which defaults to True. This means that all metrics of the same type will
+#   be plotted together on a single subplot.
+# - You can specify additional formatting, like colour and linestyle, for the plots produced by using keyword arguments
+#   from matplotlib pyplot.
+#
+# We start by plotting the OSPA distances and SIAP metrics. Plots will be combined for the same metric type.
 
-times = metric_manager.list_timestamps()
+from stonesoup.plotter import MetricPlotter
 
-for siap, axis in zip(t_siaps, axes):
-    siap_type = siap.title[:-13]  # remove the ' at timestamp' part
-    axis.set(title=siap.title, xlabel='Time', ylabel=siap_type)
-    axis.tick_params(length=1)
-    axis.plot(times, [t_siap.value for t_siap in siap.value])
+graph = MetricPlotter()
+graph.plot_metrics(metrics, generator_names=['OSPA_EKF-truth',
+                                             'OSPA_PF-truth',
+                                             'OSPA_EKF-PF',
+                                             'SIAP_EKF-truth',
+                                             'SIAP_PF-truth'],
+                   color=['orange', 'green', 'blue'])
 
-# sphinx_gallery_thumbnail_number = 4
+# update y-axis label and title, other subplots have auto-generated title and labels
+graph.axes[0].set(ylabel='OSPA metrics', title='OSPA distances over time')
+graph.fig.show()
+
+# %%
+# From these plots, we can see that towards the end of the time frame is where we lose some accuracy of our tracks and
+# where more errors are introduced. We can once again see how similar the tracking performance is across both trackers.
+# The blue line in the OSPA distances plot indicates the distance between tracks produced by both trackers at each time
+# step.
+#
+# Now we will plot the sum of covariance norms metrics for both trackers. This time we plot the metrics separately and
+# we specify additional keyword arguments to customise the plot.
+
+graph = MetricPlotter()
+graph.plot_metrics(metrics, generator_names=['sum_cov_norms_EKF',
+                                             'sum_cov_norms_PF'],
+                   combine_plots=False,
+                   color='purple', linestyle='--')
+
+# %%
+# For both trackers, we start with the highest uncertainty as tracks are initiated. Uncertainty decreases until just
+# past the middle of our timeframe and begins to increase again as we get further from the start time.
+#
+# You can change the parameters in the ground truth and trackers and see how it affects the different metrics.
+
 
 # %%
 # .. rubric:: Footnotes

--- a/docs/examples/Metrics.py
+++ b/docs/examples/Metrics.py
@@ -473,6 +473,8 @@ graph.plot_metrics(metrics, generator_names=['sum_cov_norms_EKF',
                                              'sum_cov_norms_PF'],
                    combine_plots=False,
                    color='purple', linestyle='--')
+graph.set_fig_title('Sum of Covariance Norms Metric')  # set figure title
+graph.set_ax_title(['Extended Kalman Filter', 'Particle Filter'])  # set title for each axis
 
 # %%
 # For both trackers, we start with the highest uncertainty as tracks are initiated. Uncertainty decreases until just

--- a/docs/examples/Metrics.py
+++ b/docs/examples/Metrics.py
@@ -8,15 +8,15 @@ Metrics example
 
 # %%
 # This example demonstrates some of the different metrics available in Stonesoup and how they can be used with the
-# :class:`MultiManager` to assess tracking performance. It also demonstrates how to use the :class:`MetricPlotter` class
+# :class:`~.MultiManager` to assess tracking performance. It also demonstrates how to use the :class:`~.MetricPlotter` class
 # to easily generate metric plots for visualisation.
 #
 # To generate metrics, we need:
-#  - At least one :class:`MetricGenerator` - these are used to determine the metric type we want to generate and to
+#  - At least one :class:`~.MetricGenerator` - these are used to determine the metric type we want to generate and to
 #    compute the metrics themselves.
-#  - The :class:`MultiManager` metric manager - this is used to hold the metric generator(s) as well as all the ground
+#  - The :class:`~.MultiManager` metric manager - this is used to hold the metric generator(s) as well as all the ground
 #    truth, track, and detection sets we want to generate our metrics from. We will generate our metrics using the
-#    generate_metrics method of the :class:`MultiManager` class.
+#    generate_metrics method of the :class:`~.MultiManager` class.
 #
 # In this example, we will create a variety of metric generators for different types of metrics. These metrics will be
 # used to assess and compare tracks produced from the same set of ground truth paths and detections by the Extended
@@ -118,7 +118,7 @@ plot_generator_PF = TwoDPlotter([0, 2], [0, 2], [0, 2], tracks_key='PF_tracks',
                                 generator_name='PF_plot')
 
 # %%
-# Now we add all of our metric generators to the :class:`MultiManager`.
+# Now we add all of our metric generators to the :class:`~.MultiManager`.
 
 from stonesoup.metricgenerator.manager import MultiManager
 
@@ -346,9 +346,9 @@ tracker_PF = MultiTargetTracker(
 # The MultiManager .add_data() method takes a dictionary of lists/sets of ground truth, detections, and/or tracks data.
 # It can take multiple sets of each type. Each state set must have a unique key assigned to it. The track, truth, and
 # detection keys that we input into the metric generators will be used to extract the corresponding set from the
-# :class:`MultiManager` for metric generation.
+# :class:`~.MultiManager` for metric generation.
 #
-# Setting overwrite to False allows new data to be added to the :class:`MultiManager` without overwriting data that is
+# Setting overwrite to False allows new data to be added to the :class:`~.MultiManager` without overwriting data that is
 # already in it, as demonstrated in the code below.
 
 
@@ -389,8 +389,8 @@ metric_manager.display_basic_metrics()
 #
 # Next we'll look at the averages of each of the SIAP metrics to compare.
 #
-# First we extract the SIAP averages from the :class:`MultiManager` using the .get_siap_averages() method. Then we use
-# the :class:`SIAPTableGenerator` to display the average metrics in a table which shows us descriptions for each metric.
+# First we extract the SIAP averages from the :class:`~.MultiManager` using the :meth:`get_siap_averages()` method. Then we use
+# the :class:`~.SIAPTableGenerator` to display the average metrics in a table which shows us descriptions for each metric.
 # We will create a table for the EKF SIAPs first.
 
 from stonesoup.metricgenerator.metrictables import SIAPTableGenerator
@@ -421,18 +421,18 @@ siap_table = SIAPTableGenerator(siap_averages_PF).compute_metric()
 # %%
 # Plot metrics
 # ------------
-# We will use :class:`MetricPlotter` to plot some of our metrics below.
+# We will use :class:`~.MetricPlotter` to plot some of our metrics below.
 #
-# To use :class:`MetricPlotter` we first create an instance of the class. We can then use the .plot_metrics() method to
-# plot the metrics of our choice. Key features of :class:`MetricPlotter`:
-# - You can specify exactly which metrics you want to plot by specifying the optional generator_names and metric_names
+# To use :class:`~.MetricPlotter` we first create an instance of the class. We can then use the :meth:`plot_metrics()` method to
+# plot the metrics of our choice. Key features of :class:`~.MetricPlotter`:
+# - You can specify exactly which metrics you want to plot by specifying the optional `generator_names` and `metric_names`
 #   parameters.
-# - generator_names allows you to specify which generators you want to plot metrics from. If you don't pass the
-#   generator_names argument, .plot_metrics() will automatically extract all plottable metrics from all metric
-#   generators in the :class:`MultiManager` and plot them.
-# - metric_names allows you to specify which specific metrics types you want to plot from the metric generators. This is
-#   mostly relevant for the SIAP metrics. You can view which metrics are plottable with MetricPlotter.plottable_metrics.
-# - .plot_metrics has a combine_plots argument which defaults to True. This means that all metrics of the same type will
+# - `generator_names` allows you to specify which generators you want to plot metrics from. If you don't pass the
+#   `generator_names` argument, :meth:`plot_metrics()` will automatically extract all plottable metrics from all metric
+#   generators in the :class:`~.MultiManager` and plot them.
+# - `metric_names` allows you to specify which specific metrics types you want to plot from the metric generators. This is
+#   mostly relevant for the SIAP metrics. You can view which metrics are plottable with :meth:`MetricPlotter.plottable_metrics`.
+# - :meth:`plot_metrics` has a `combine_plots` argument which defaults to True. This means that all metrics of the same type will
 #   be plotted together on a single subplot.
 # - You can specify additional formatting, like colour and linestyle, for the plots produced by using keyword arguments
 #   from matplotlib pyplot.

--- a/docs/examples/Metrics.py
+++ b/docs/examples/Metrics.py
@@ -379,10 +379,14 @@ metrics = metric_manager.generate_metrics()
 # %%
 # We can see from the plots above that the two trackers exhibit similar performance in tracking the ground truths.
 #
-# Let's look at the metrics we've generated to compare them further. We'll start by printing out the basic metrics with
-# the .display_basic_metrics method, which gives us information on the number of tracks versus targets.
+# Let's look at the metrics we've generated to compare them further. We'll start by printing out the basic metrics,
+# which give us information on the number of tracks versus targets.
 
-metric_manager.display_basic_metrics()
+for generator in metrics.keys():
+    if 'basic' in generator:
+        print(f'\n{generator}:')
+        for metric_key, metric in metrics[generator].items():
+            print(f"{metric.title}: {metric.value}")
 
 # %%
 # The basic metrics show that both the EKF and the PF have successfully produced tracks for each of the ground truth
@@ -390,21 +394,24 @@ metric_manager.display_basic_metrics()
 #
 # Next we'll look at the averages of each of the SIAP metrics to compare.
 #
-# First we extract the SIAP averages from the :class:`~.MultiManager` using the :meth:`get_siap_averages()` method. Then
-# we use the :class:`~.SIAPTableGenerator` to display the average metrics in a table which shows us descriptions for
-# each metric.
+# First we extract the SIAP averages from the :class:`~.MultiManager`. Then we use the :class:`~.SIAPTableGenerator` to
+# display the average metrics in a table which shows us descriptions for each metric.
 #
 # We will create a table for the EKF SIAPs first.
 
 from stonesoup.metricgenerator.metrictables import SIAPTableGenerator
 
-siap_averages_EKF = metric_manager.get_siap_averages('SIAP_EKF-truth')
+siap_metrics = metrics['SIAP_EKF-truth']
+siap_averages_EKF = {siap_metrics.get(metric) for metric in siap_metrics
+                     if metric.startswith("SIAP") and not metric.endswith(" at times")}
 siap_table = SIAPTableGenerator(siap_averages_EKF).compute_metric()
 
 # %%
 # Now we produce a table for the PF SIAPs for comparison.
 
-siap_averages_PF = metric_manager.get_siap_averages('SIAP_PF-truth')
+siap_metrics = metrics['SIAP_PF-truth']
+siap_averages_PF = {siap_metrics.get(metric) for metric in siap_metrics
+                    if metric.startswith("SIAP") and not metric.endswith(" at times")}
 siap_table = SIAPTableGenerator(siap_averages_PF).compute_metric()
 
 # %%

--- a/docs/examples/Metrics.py
+++ b/docs/examples/Metrics.py
@@ -8,8 +8,8 @@ Metrics example
 
 # %%
 # This example demonstrates some of the different metrics available in Stonesoup and how they can be used with the
-# :class:`~.MultiManager` to assess tracking performance. It also demonstrates how to use the :class:`~.MetricPlotter` class
-# to easily generate metric plots for visualisation.
+# :class:`~.MultiManager` to assess tracking performance. It also demonstrates how to use the :class:`~.MetricPlotter`
+# class to easily generate metric plots for visualisation.
 #
 # To generate metrics, we need:
 #  - At least one :class:`~.MetricGenerator` - these are used to determine the metric type we want to generate and to
@@ -389,8 +389,10 @@ metric_manager.display_basic_metrics()
 #
 # Next we'll look at the averages of each of the SIAP metrics to compare.
 #
-# First we extract the SIAP averages from the :class:`~.MultiManager` using the :meth:`get_siap_averages()` method. Then we use
-# the :class:`~.SIAPTableGenerator` to display the average metrics in a table which shows us descriptions for each metric.
+# First we extract the SIAP averages from the :class:`~.MultiManager` using the :meth:`get_siap_averages()` method. Then
+# we use the :class:`~.SIAPTableGenerator` to display the average metrics in a table which shows us descriptions for
+# each metric.
+#
 # We will create a table for the EKF SIAPs first.
 
 from stonesoup.metricgenerator.metrictables import SIAPTableGenerator
@@ -423,17 +425,18 @@ siap_table = SIAPTableGenerator(siap_averages_PF).compute_metric()
 # ------------
 # We will use :class:`~.MetricPlotter` to plot some of our metrics below.
 #
-# To use :class:`~.MetricPlotter` we first create an instance of the class. We can then use the :meth:`plot_metrics()` method to
-# plot the metrics of our choice. Key features of :class:`~.MetricPlotter`:
-# - You can specify exactly which metrics you want to plot by specifying the optional `generator_names` and `metric_names`
-#   parameters.
+# To use :class:`~.MetricPlotter` we first create an instance of the class. We can then use the :meth:`plot_metrics()`
+# method to plot the metrics of our choice. Key features of :class:`~.MetricPlotter`:
+# - You can specify exactly which metrics you want to plot by specifying the optional `generator_names` and
+#   `metric_names` parameters.
 # - `generator_names` allows you to specify which generators you want to plot metrics from. If you don't pass the
 #   `generator_names` argument, :meth:`plot_metrics()` will automatically extract all plottable metrics from all metric
 #   generators in the :class:`~.MultiManager` and plot them.
-# - `metric_names` allows you to specify which specific metrics types you want to plot from the metric generators. This is
-#   mostly relevant for the SIAP metrics. You can view which metrics are plottable with :meth:`MetricPlotter.plottable_metrics`.
-# - :meth:`plot_metrics` has a `combine_plots` argument which defaults to True. This means that all metrics of the same type will
-#   be plotted together on a single subplot.
+# - `metric_names` allows you to specify which specific metrics types you want to plot from the metric generators. This
+#   is mostly relevant for the SIAP metrics. You can view which metrics are plottable with
+#   :meth:`MetricPlotter.plottable_metrics`.
+# - :meth:`plot_metrics` has a `combine_plots` argument which defaults to True. This means that all metrics of the same
+#   type will be plotted together on a single subplot.
 # - You can specify additional formatting, like colour and linestyle, for the plots produced by using keyword arguments
 #   from matplotlib pyplot.
 #

--- a/docs/examples/Multi_Tracker_Example.py
+++ b/docs/examples/Multi_Tracker_Example.py
@@ -465,7 +465,9 @@ for tracking_filter in tracking_filters:
 from stonesoup.metricgenerator.metrictables import SIAPTableGenerator
 
 # generate metrics for EKF
-siap_averages_EKF = metric_manager.get_siap_averages(generator_name='EKF SIAP metrics')
+siap_metrics = metrics['EKF SIAP metrics']
+siap_averages_EKF = {siap_metrics.get(metric) for metric in siap_metrics
+                     if metric.startswith("SIAP") and not metric.endswith(" at times")}
 
 _ = SIAPTableGenerator(siap_averages_EKF).compute_metric()
 print("\n\nSIAP metrics for EKF:")

--- a/docs/examples/Track2Track_Fusion_Example.py
+++ b/docs/examples/Track2Track_Fusion_Example.py
@@ -489,7 +489,7 @@ track_fusion_tracker = PointProcessMultiTargetTracker(
 
 # %%
 # 6: Make Metric Manager
-# -----------------------
+# ----------------------
 # We will generate metrics of each of the four trackers for comparison.
 
 # %%

--- a/docs/examples/Track2Track_Fusion_Example.py
+++ b/docs/examples/Track2Track_Fusion_Example.py
@@ -87,7 +87,7 @@ Multi-Sensor Fusion: Covariance Intersection Using Tracks as Measurements
 #     both radars. This is created to compare with the covariance intersection method.
 #   * Create a GM-PHD tracker that will perform track fusion via covariance intersection using
 #     the :class:`ChernoffUpdater` class.
-#   * Create metric managers for each of the four trackers
+#   * Create a metric manager to generate metrics for each of the four trackers
 #   * Set up the detection feeders. Each tracker will receive measurements using a custom
 #     :class:`DummyDetector` class. The track fusion tracker will also use the
 #     :class:`Tracks2GaussianDetectionFeeder` class.
@@ -488,9 +488,9 @@ track_fusion_tracker = PointProcessMultiTargetTracker(
 )
 
 # %%
-# 6: Make Metric Managers
+# 6: Make Metric Manager
 # -----------------------
-# We will track the metrics of each of the four trackers for comparison.
+# We will generate metrics of each of the four trackers for comparison.
 
 # %%
 from stonesoup.metricgenerator.basicmetrics import BasicMetrics
@@ -620,7 +620,7 @@ for t in range(num_steps):
 
     # ----------------------------------------------------------------------
 
-    # Add ground truth data and measurements to metric managers
+    # Add ground truth data and measurements to metric manager
     truths = radar_simulator.groundtruth.current
     detections = s1d[1] | s2d[1]
     metric_manager.add_data({'truths': truths[1], 'detections': detections}, overwrite=False)
@@ -637,7 +637,7 @@ gmlcc_tracks = set([track for track in gmlcc_tracks if len(track) > 1])
 meas_fusion_tracks = set([track for track in meas_fusion_tracks if len(track) > 1])
 track_fusion_tracks = set([track for track in track_fusion_tracks if len(track) > 1])
 
-# Add data to the metric manager
+# Add track data to the metric manager
 metric_manager.add_data({'jpda_tracks': jpda_tracks,
                          'gmlcc_tracks': gmlcc_tracks,
                          'meas_fusion_tracks': meas_fusion_tracks,
@@ -722,7 +722,7 @@ import matplotlib.pyplot as plt
 fig, ax = plt.subplots()
 times = metric_manager.list_timestamps(metric_manager.generators[2])
 
-# Iterate through the metric managers. For each one, go through the list of all timesteps
+# Iterate through the trackers. For each one, go through the list of all timesteps
 # and calculate the ratio at that time
 for track_label, label in zip(track_labels, labels):
     ratios = []

--- a/docs/examples/Track_Stitcher_Example.py
+++ b/docs/examples/Track_Stitcher_Example.py
@@ -392,5 +392,8 @@ metric_manager.add_data({'truths': truths, 'tracks': set(all_tracks)})
 
 # generate metrics and extract SIAP averages to display in SIAP table
 metrics = metric_manager.generate_metrics()
-siap_averages = metric_manager.get_siap_averages(generator_name='SIAPs')
+siap_metrics = metrics['SIAPs']
+siap_averages = {siap_metrics.get(metric) for metric in siap_metrics
+                 if metric.startswith("SIAP") and not metric.endswith(" at times")}
+
 _ = SIAPTableGenerator(siap_averages).compute_metric()

--- a/docs/tutorials/sensormanagement/03_OptimisedSensorManagement.py
+++ b/docs/tutorials/sensormanagement/03_OptimisedSensorManagement.py
@@ -618,6 +618,8 @@ fig2.plot_metrics(metrics, metric_names=['Sum of Covariance Norms Metric'],
 #
 # Now let us compare the calculated runtime of the tracking loop for each of the sensor managers.
 
+import matplotlib.pyplot as plt
+
 fig = plt.figure()
 ax = fig.add_subplot(1, 1, 1)
 ax.set_ylabel('Cell run time (s)')

--- a/docs/tutorials/sensormanagement/03_OptimisedSensorManagement.py
+++ b/docs/tutorials/sensormanagement/03_OptimisedSensorManagement.py
@@ -523,41 +523,60 @@ plotterC.fig
 
 from stonesoup.metricgenerator.tracktotruthmetrics import SIAPMetrics
 from stonesoup.measures import Euclidean
-siap_generator = SIAPMetrics(position_measure=Euclidean((0, 2)),
-                             velocity_measure=Euclidean((1, 3)))
+siap_generatorA = SIAPMetrics(position_measure=Euclidean((0, 2)),
+                              velocity_measure=Euclidean((1, 3)),
+                              generator_name='BruteForceSensorManager',
+                              tracks_key='tracksA',
+                              truths_key='truths')
+
+siap_generatorB = SIAPMetrics(position_measure=Euclidean((0, 2)),
+                              velocity_measure=Euclidean((1, 3)),
+                              generator_name='OptimizeBruteSensorManager',
+                              tracks_key='tracksB',
+                              truths_key='truths')
+
+siap_generatorC = SIAPMetrics(position_measure=Euclidean((0, 2)),
+                              velocity_measure=Euclidean((1, 3)),
+                              generator_name='OptimizeBasinHoppingSensorManager',
+                              tracks_key='tracksC',
+                              truths_key='truths')
 
 from stonesoup.dataassociator.tracktotrack import TrackToTruth
 associator = TrackToTruth(association_threshold=30)
 
 from stonesoup.metricgenerator.uncertaintymetric import SumofCovarianceNormsMetric
-uncertainty_generator = SumofCovarianceNormsMetric()
+uncertainty_generatorA = SumofCovarianceNormsMetric(generator_name="BruteForceSensorManager",
+                                                   tracks_key="tracksA")
+
+uncertainty_generatorB = SumofCovarianceNormsMetric(generator_name="OptimizeBruteSensorManager",
+                                                   tracks_key="tracksB")
+
+uncertainty_generatorC = SumofCovarianceNormsMetric(generator_name="OptimizeBasinHoppingSensorManager",
+                                                   tracks_key="tracksC")
 
 # %%
-# Generate a metric manager for each sensor management method.
+# Generate a metric manager.
 
-from stonesoup.metricgenerator.manager import SimpleManager
+from stonesoup.metricgenerator.manager import MultiManager
 
-metric_managerA = SimpleManager([siap_generator, uncertainty_generator],
-                                associator=associator)
-
-metric_managerB = SimpleManager([siap_generator, uncertainty_generator],
-                                associator=associator)
-
-metric_managerC = SimpleManager([siap_generator, uncertainty_generator],
-                                associator=associator)
+metric_manager = MultiManager([siap_generatorA,
+                               siap_generatorB,
+                               siap_generatorC,
+                               uncertainty_generatorA,
+                               uncertainty_generatorB,
+                               uncertainty_generatorC],
+                              associator=associator)
 
 # %%
 # For each time step, data is added to the metric manager on truths and tracks.
 # The metrics themselves can then be generated from the metric manager.
 
-metric_managerA.add_data(truths, tracksA)
-metric_managerB.add_data(truths, tracksB)
-metric_managerC.add_data(truths, tracksC)
+metric_manager.add_data({'truths': truths,
+                         'tracksA': tracksA,
+                         'tracksB': tracksB,
+                         'tracksC': tracksC})
 
-metricsA = metric_managerA.generate_metrics()
-metricsB = metric_managerB.generate_metrics()
-metricsC = metric_managerC.generate_metrics()
-
+metrics = metric_manager.generate_metrics()
 
 # %%
 # SIAP metrics
@@ -566,38 +585,12 @@ metricsC = metric_managerC.generate_metrics()
 # First we look at SIAP metrics. We are only interested in the positional accuracy (PA) and
 # velocity accuracy (VA). These metrics can be plotted to show how they change over time.
 
-import matplotlib.pyplot as plt
+from stonesoup.plotter import MetricPlotter
 
-fig, axes = plt.subplots(2)
-
-times = metric_managerA.list_timestamps()
-
-pa_metricA = metricsA['SIAP Position Accuracy at times']
-va_metricA = metricsA['SIAP Velocity Accuracy at times']
-
-pa_metricB = metricsB['SIAP Position Accuracy at times']
-va_metricB = metricsB['SIAP Velocity Accuracy at times']
-
-pa_metricC = metricsC['SIAP Position Accuracy at times']
-va_metricC = metricsC['SIAP Velocity Accuracy at times']
-
-axes[0].set(title='Positional Accuracy', xlabel='Time', ylabel='PA')
-axes[0].plot(times, [metric.value for metric in pa_metricA.value],
-             label='BruteForceSensorManager')
-axes[0].plot(times, [metric.value for metric in pa_metricB.value],
-             label='OptimizeBruteSensorManager')
-axes[0].plot(times, [metric.value for metric in pa_metricC.value],
-             label='OptimizeBasinHoppingSensorManager')
-axes[0].legend()
-
-axes[1].set(title='Velocity Accuracy', xlabel='Time', ylabel='VA')
-axes[1].plot(times, [metric.value for metric in va_metricA.value],
-             label='BruteForceSensorManager')
-axes[1].plot(times, [metric.value for metric in va_metricB.value],
-             label='OptimizeBruteSensorManager')
-axes[1].plot(times, [metric.value for metric in va_metricC.value],
-             label='OptimizeBasinHoppingSensorManager')
-axes[1].legend()
+fig = MetricPlotter()
+fig.plot_metrics(metrics, metric_names=['SIAP Position Accuracy at times',
+                                        'SIAP Velocity Accuracy at times'],
+                 color=['blue', 'orange', 'green'])
 
 # %%
 # Both graphs show that there is little performance difference between the different sensor managers.
@@ -610,24 +603,9 @@ axes[1].legend()
 # Next we look at the uncertainty metric which computes the sum of covariance matrix norms of each state at each
 # time step. This is plotted over time for each sensor manager method.
 
-uncertainty_metricA = metricsA['Sum of Covariance Norms Metric']
-uncertainty_metricB = metricsB['Sum of Covariance Norms Metric']
-uncertainty_metricC = metricsC['Sum of Covariance Norms Metric']
-
-fig = plt.figure()
-ax = fig.add_subplot(1, 1, 1)
-ax.plot([i.timestamp for i in uncertainty_metricA.value],
-        [i.value for i in uncertainty_metricA.value],
-        label='BruteForceSensorManager')
-ax.plot([i.timestamp for i in uncertainty_metricB.value],
-        [i.value for i in uncertainty_metricB.value],
-        label='OptimizeBruteSensorManager')
-ax.plot([i.timestamp for i in uncertainty_metricC.value],
-        [i.value for i in uncertainty_metricC.value],
-        label='OptimizeBasinHoppingSensorManager')
-ax.set_ylabel("Sum of covariance matrix norms")
-ax.set_xlabel("Time")
-ax.legend()
+fig2 = MetricPlotter()
+fig2.plot_metrics(metrics, metric_names=['Sum of Covariance Norms Metric'],
+                  color=['blue', 'orange', 'green'])
 
 # %%
 # The uncertainty metric shows some variation between the sensor management methods,

--- a/stonesoup/metricgenerator/basicmetrics.py
+++ b/stonesoup/metricgenerator/basicmetrics.py
@@ -8,10 +8,12 @@ from ..base import Property
 class BasicMetrics(MetricGenerator):
     """Calculates simple metrics like number of tracks, truth and
     ratio of track-to-truth"""
-    generator_name: str = Property(doc="Unique identifier to use when accessing generated metrics from MultiManager")
+    generator_name: str = Property(doc="Unique identifier to use when accessing generated "
+                                       "metrics from MultiManager")
     tracks_key: str = Property(doc='Key to access set of tracks added to MultiManager')
-    truths_key: str = Property(doc="Key to access set of ground truths added to MultiManager. Or key to access a second"
-                                   " set of tracks for track-to-track metric generation")
+    truths_key: str = Property(doc="Key to access set of ground truths added to MultiManager. "
+                                   "Or key to access a second set of tracks for track-to-track "
+                                   "metric generation")
 
     def compute_metric(self, manager, *args, **kwargs):
         """Compute the metric using the data in the metric manager

--- a/stonesoup/metricgenerator/basicmetrics.py
+++ b/stonesoup/metricgenerator/basicmetrics.py
@@ -9,11 +9,14 @@ class BasicMetrics(MetricGenerator):
     """Calculates simple metrics like number of tracks, truth and
     ratio of track-to-truth"""
     generator_name: str = Property(doc="Unique identifier to use when accessing generated "
-                                       "metrics from MultiManager")
-    tracks_key: str = Property(doc='Key to access set of tracks added to MultiManager')
-    truths_key: str = Property(doc="Key to access set of ground truths added to MultiManager. "
+                                       "metrics from MultiManager",
+                                   default='basic_generator')
+    tracks_key: str = Property(doc='Key to access set of tracks added to MetricManager',
+                               default='tracks')
+    truths_key: str = Property(doc="Key to access set of ground truths added to MetricManager. "
                                    "Or key to access a second set of tracks for track-to-track "
-                                   "metric generation")
+                                   "metric generation",
+                               default='groundtruth_paths')
 
     def compute_metric(self, manager, *args, **kwargs):
         """Compute the metric using the data in the metric manager
@@ -24,7 +27,7 @@ class BasicMetrics(MetricGenerator):
             containing the data to be used to create the metric(s)
 
         Returns
-        ----------
+        -------
         : list of :class:`~.Metric`
             Contains the metric information
         """

--- a/stonesoup/metricgenerator/manager.py
+++ b/stonesoup/metricgenerator/manager.py
@@ -4,7 +4,6 @@ from typing import Sequence, Dict, Iterable, Union
 from .base import MetricManager, MetricGenerator
 from ..base import Property
 from ..dataassociator import Associator
-from .basicmetrics import BasicMetrics
 
 from ..types.groundtruth import GroundTruthPath
 from ..types.track import Track

--- a/stonesoup/metricgenerator/manager.py
+++ b/stonesoup/metricgenerator/manager.py
@@ -5,7 +5,7 @@ from .base import MetricManager, MetricGenerator
 from ..base import Property
 from ..dataassociator import Associator
 from .tracktotruthmetrics import SIAPMetrics
-
+from .basicmetrics import BasicMetrics
 
 class MultiManager(MetricManager):
     """MultiManager class for metric management
@@ -21,6 +21,7 @@ class MultiManager(MetricManager):
         super().__init__(*args, **kwargs)
         self.states_sets = dict()
         self.association_set = None
+        self.metrics = None
 
     def add_data(self, metric_data: Dict = None, overwrite=True):
         """Adds data to the metric generator
@@ -64,7 +65,10 @@ class MultiManager(MetricManager):
         """
 
         metrics = {}
-        for generator in self.generators:
+
+        generators = self.generators if isinstance(self.generators, list) else [self.generators]
+
+        for generator in generators:
             if isinstance(generator, SIAPMetrics):
                 if self.associator is not None and self.association_set is None:
                     self.associate_tracks(generator)
@@ -78,7 +82,7 @@ class MultiManager(MetricManager):
                 else:
                     metrics[generator.generator_name][metric.title] = metric
 
-        return metrics
+        self.metrics = metrics
 
     def list_timestamps(self, generator):
         """List all the timestamps used in the tracks and truth, in order
@@ -95,3 +99,13 @@ class MultiManager(MetricManager):
                       for state in sequence}
 
         return sorted(timestamps)
+
+    def display_basic_metrics(self):
+        """
+        Print basic metrics generated for each :class:`BasicMetrics` generator.
+        """
+        for generator_name, generator in self.metrics.items():
+            print(f'Generator: {generator_name}')
+            for metric_key, metric in generator.items():
+                if isinstance(metric.generator, BasicMetrics):
+                    print(f"{metric.title}: {metric.value}")

--- a/stonesoup/metricgenerator/manager.py
+++ b/stonesoup/metricgenerator/manager.py
@@ -85,6 +85,8 @@ class MultiManager(MetricManager):
 
         self.metrics = metrics
 
+        return self.metrics
+
     def list_timestamps(self, generator):
         """List all the timestamps used in the tracks and truth, in order
 

--- a/stonesoup/metricgenerator/manager.py
+++ b/stonesoup/metricgenerator/manager.py
@@ -7,6 +7,7 @@ from ..dataassociator import Associator
 from .tracktotruthmetrics import SIAPMetrics
 from .basicmetrics import BasicMetrics
 
+
 class MultiManager(MetricManager):
     """MultiManager class for metric management
 

--- a/stonesoup/metricgenerator/manager.py
+++ b/stonesoup/metricgenerator/manager.py
@@ -106,7 +106,8 @@ class MultiManager(MetricManager):
         Print basic metrics generated for each :class:`BasicMetrics` generator.
         """
         for generator_name, generator in self.metrics.items():
-            print(f'Generator: {generator_name}')
-            for metric_key, metric in generator.items():
-                if isinstance(metric.generator, BasicMetrics):
-                    print(f"{metric.title}: {metric.value}")
+            if "Number of targets" in generator.keys():
+                print(f'\nGenerator: {generator_name}')
+                for metric_key, metric in generator.items():
+                    if isinstance(metric.generator, BasicMetrics):
+                        print(f"{metric.title}: {metric.value}")

--- a/stonesoup/metricgenerator/manager.py
+++ b/stonesoup/metricgenerator/manager.py
@@ -196,13 +196,15 @@ class SimpleManager(MultiManager):
     def _add(self, overwrite, **kwargs):
         if overwrite:
             for key, value in kwargs.items():
-                self.states_sets[key] = set(value)
+                if value is not None:
+                    self.states_sets[key] = set(value)
         else:
             for key, value in kwargs.items():
-                if key not in self.states_sets.keys():
-                    self.states_sets[key] = set(value)
-                else:
-                    self.states_sets[key].update(value)
+                if value is not None:
+                    if key not in self.states_sets.keys():
+                        self.states_sets[key] = set(value)
+                    else:
+                        self.states_sets[key].update(value)
 
     def _get_metrics(self):
         metrics = {}

--- a/stonesoup/metricgenerator/manager.py
+++ b/stonesoup/metricgenerator/manager.py
@@ -126,36 +126,6 @@ class MultiManager(MetricManager):
 
         return sorted(timestamps)
 
-    def display_basic_metrics(self):
-        """
-        Print basic metrics generated for each :class:`BasicMetrics` generator.
-        """
-        for generator_name, generator in self.metrics.items():
-            if "Number of targets" in generator.keys():
-                print(f'\nGenerator: {generator_name}')
-                for metric_key, metric in generator.items():
-                    if isinstance(metric.generator, BasicMetrics):
-                        print(f"{metric.title}: {metric.value}")
-
-    def get_siap_averages(self, generator_name):
-        """
-        Get SIAP averages metrics from SIAP metric generator specified by generator_name
-
-        Parameters
-        ----------
-        generator_name : str
-            Name of SIAP :class:`~.MetricGenerator`
-
-        Returns
-        -------
-        : dict of :class`SIAPMetrics` averages
-        """
-        siap_metrics = self.metrics[generator_name]
-        siap_averages = {siap_metrics.get(metric) for metric in siap_metrics
-                         if metric.startswith("SIAP") and not metric.endswith(" at times")}
-
-        return siap_averages
-
 
 class SimpleManager(MultiManager):
     """SimpleManager class for metric management

--- a/stonesoup/metricgenerator/manager.py
+++ b/stonesoup/metricgenerator/manager.py
@@ -1,106 +1,10 @@
 from itertools import chain
-from typing import Sequence, Iterable, Union, Dict
+from typing import Sequence, Dict
 
 from .base import MetricManager, MetricGenerator
 from ..base import Property
 from ..dataassociator import Associator
-from ..platform import Platform
-from ..types.detection import Detection
-from ..types.groundtruth import GroundTruthPath
-from ..types.track import Track
 from .tracktotruthmetrics import SIAPMetrics
-
-
-class SimpleManager(MetricManager):
-    """SimpleManager class for metric management
-
-    Simple :class:`~.MetricManager` for the generation of metrics on multiple
-    :class:`~.Track`, :class:`~.Detection` and :class:`~.GroundTruthPath`
-    objects.
-    """
-    generators: Sequence[MetricGenerator] = Property(doc='List of generators to use', default=None)
-    associator: Associator = Property(doc="Associator to combine tracks and truth", default=None)
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.tracks = set()
-        self.groundtruth_paths = set()
-        self.detections = set()
-        self.association_set = None
-
-    def add_data(self, groundtruth_paths: Iterable[Union[GroundTruthPath, Platform]] = None,
-                 tracks: Iterable[Track] = None, detections: Iterable[Detection] = None,
-                 overwrite=True):
-        """Adds data to the metric generator
-
-        Parameters
-        ----------
-        groundtruth_paths : list or set of :class:`~.GroundTruthPath`
-            Ground truth paths to be added to the manager.
-        tracks : list or set of :class:`~.Track`
-            Tracks objects to be added to the manager.
-        detections : list or set of :class:`~.Detection`
-            Detections to be added to the manager.
-        overwrite: bool
-            declaring whether pre-existing data will be overwritten. Note that
-            overwriting one field (e.g. tracks) does not affect the others
-        """
-
-        self._add(overwrite, groundtruth_paths=groundtruth_paths,
-                  tracks=tracks, detections=detections)
-
-    def _add(self, overwrite, **kwargs):
-        for key, value in kwargs.items():
-            if value is not None:
-                if overwrite:
-                    setattr(self, key, set(value))
-                else:
-                    getattr(self, key).update(value)
-
-    def associate_tracks(self):
-        """Associate tracks to truth using the associator
-
-        The resultant :class:`~.AssociationSet` internally.
-        """
-        self.association_set = self.associator.associate_tracks(
-            self.tracks, self.groundtruth_paths)
-
-    def generate_metrics(self):
-        """Generate metrics using the generators and data that has been added
-
-        Returns
-        ----------
-        : set of :class:`~.Metric`
-            Metrics generated
-        """
-
-        if self.associator is not None and self.association_set is None:
-            self.associate_tracks()
-
-        metrics = {}
-        for generator in self.generators:
-            metric_list = generator.compute_metric(self)
-            # If not already a list, force it to be one below
-            if not isinstance(metric_list, list):
-                metric_list = [metric_list]
-            for metric in metric_list:
-                metrics[metric.title] = metric
-        return metrics
-
-    def list_timestamps(self):
-        """List all the timestamps used in the tracks and truth, in order
-
-        Returns
-        ----------
-        : list of :class:`datetime.datetime`
-            unique timestamps present in the internal tracks and truths.
-        """
-        # Make a list of all the unique timestamps used
-        timestamps = {state.timestamp
-                      for sequence in chain(self.tracks, self.groundtruth_paths)
-                      for state in sequence}
-
-        return sorted(timestamps)
 
 
 class MultiManager(MetricManager):
@@ -116,11 +20,6 @@ class MultiManager(MetricManager):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.states_sets = dict()
-        for generator in self.generators:
-            if generator.generator_name is None:
-                # attribute
-                raise ValueError("""generator_name argument required for all MetricGenerators passed to """
-                                 """generators argument""")
         self.association_set = None
 
     def add_data(self, metric_data: Dict = None, overwrite=True):

--- a/stonesoup/metricgenerator/manager.py
+++ b/stonesoup/metricgenerator/manager.py
@@ -71,7 +71,7 @@ class MultiManager(MetricManager):
 
         for generator in generators:
             if isinstance(generator, SIAPMetrics):
-                if self.associator is not None and self.association_set is None:
+                if self.associator is not None:
                     self.associate_tracks(generator)
             metric_list = generator.compute_metric(self)
             # If not already a list, force it to be one below
@@ -113,3 +113,17 @@ class MultiManager(MetricManager):
                 for metric_key, metric in generator.items():
                     if isinstance(metric.generator, BasicMetrics):
                         print(f"{metric.title}: {metric.value}")
+
+    def get_siap_averages(self, generator_name):
+        """
+        Get SIAP averages metrics from SIAP metric generator specified by generator_name
+
+        Returns
+        ----------
+        : dict of :class`SIAPMetrics` averages
+        """
+        siap_metrics = self.metrics[generator_name]
+        siap_averages = {siap_metrics.get(metric) for metric in siap_metrics
+                         if metric.startswith("SIAP") and not metric.endswith(" at times")}
+
+        return siap_averages

--- a/stonesoup/metricgenerator/manager.py
+++ b/stonesoup/metricgenerator/manager.py
@@ -29,12 +29,13 @@ class MultiManager(MetricManager):
 
         Parameters
         ----------
-        metric_data : dict of lists or dict of sets of :class:`~.GroundTruthPath`,
+        metric_data : dict of lists or dict of sets of :class:`~.GroundTruthPath`, \
         :class:`~.Track`, and/or :class:`~.Detection`
             Ground truth paths, Tracks, and/or detections to be added to the manager.
         overwrite: bool
-            declaring whether pre-existing data will be overwritten. Note that
-            overwriting one field (e.g. tracks) does not affect the others
+            Declaring whether pre-existing data will be overwritten. Note that
+            overwriting one key-value pair (e.g. 'tracks') does not affect the others.
+
         """
         self._add(overwrite, metric_data=metric_data)
 

--- a/stonesoup/metricgenerator/manager.py
+++ b/stonesoup/metricgenerator/manager.py
@@ -40,7 +40,8 @@ class MultiManager(MetricManager):
 
     def _add(self, overwrite, metric_data):
         if overwrite:
-            self.states_sets = metric_data
+            for key, value in metric_data.items():
+                self.states_sets[key] = set(value)
         else:
             for key, value in metric_data.items():
                 if key not in self.states_sets.keys():

--- a/stonesoup/metricgenerator/manager.py
+++ b/stonesoup/metricgenerator/manager.py
@@ -84,7 +84,8 @@ class MultiManager(MetricManager):
         generators = self.generators if isinstance(self.generators, list) else [self.generators]
 
         for generator in generators:
-            if self.associator is not None and hasattr(generator, 'tracks_key') and hasattr(generator, 'truths_key'):
+            if self.associator is not None and \
+                    hasattr(generator, 'tracks_key') and hasattr(generator, 'truths_key'):
                 self.associate_tracks(generator)
             metric_list = generator.compute_metric(self)
             if not isinstance(metric_list, list):  # If not already a list, force it to be one

--- a/stonesoup/metricgenerator/manager.py
+++ b/stonesoup/metricgenerator/manager.py
@@ -29,8 +29,8 @@ class MultiManager(MetricManager):
 
         Parameters
         ----------
-        metric_data : dict of lists or dict of sets of :class:`~.GroundTruthPath`, :class:`~.Track`, and/or
-        :class:`~.Detection`
+        metric_data : dict of lists or dict of sets of :class:`~.GroundTruthPath`,
+        :class:`~.Track`, and/or :class:`~.Detection`
             Ground truth paths, Tracks, and/or detections to be added to the manager.
         overwrite: bool
             declaring whether pre-existing data will be overwritten. Note that

--- a/stonesoup/metricgenerator/metrictables.py
+++ b/stonesoup/metricgenerator/metrictables.py
@@ -114,7 +114,7 @@ class SIAPTableGenerator(RedGreenTableGenerator):
             "SIAP Position Accuracy": 0,
             "SIAP Velocity Accuracy": 0,
             "SIAP Rate of Track Number Change": 0,
-            "SIAP Longest Track Segment": None,
+            "SIAP Longest Track Segment": 1,
             "SIAP ID Completeness": 1,
             "SIAP ID Correctness": 1,
             "SIAP ID Ambiguity": 0

--- a/stonesoup/metricgenerator/metrictables.py
+++ b/stonesoup/metricgenerator/metrictables.py
@@ -100,7 +100,7 @@ class SIAPTableGenerator(RedGreenTableGenerator):
             "SIAP Position Accuracy": (0, np.inf),
             "SIAP Velocity Accuracy": (0, np.inf),
             "SIAP Rate of Track Number Change": (0, np.inf),
-            "SIAP Longest Track Segment": (0, np.inf),
+            "SIAP Longest Track Segment": (0, 1),
             "SIAP ID Completeness": (0, 1),
             "SIAP ID Correctness": (0, 1),
             "SIAP ID Ambiguity": (0, 1)

--- a/stonesoup/metricgenerator/ospametric.py
+++ b/stonesoup/metricgenerator/ospametric.py
@@ -31,11 +31,14 @@ class GOSPAMetric(MetricGenerator):
         default=Euclidean(),
         doc="Distance measure to use. Default :class:`~.measures.Euclidean()`")
     generator_name: str = Property(doc="Unique identifier to use when accessing generated metrics "
-                                       "from MultiManager")
-    tracks_key: str = Property(doc='Key to access set of tracks added to MultiManager')
-    truths_key: str = Property(doc="Key to access set of ground truths added to MultiManager. "
+                                       "from MultiManager",
+                                   default='gospa_generator')
+    tracks_key: str = Property(doc='Key to access set of tracks added to MetricManager',
+                               default='tracks')
+    truths_key: str = Property(doc="Key to access set of ground truths added to MetricManager. "
                                    "Or key to access a second set of tracks for track-to-track"
-                                   " metric generation")
+                                   " metric generation",
+                               default='groundtruth_paths')
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -382,6 +385,9 @@ class OSPAMetric(GOSPAMetric):
     """
     c: float = Property(doc='Maximum distance for possible association')
     p: float = Property(doc='Norm associated to distance')
+    generator_name: str = Property(doc="Unique identifier to use when accessing generated metrics "
+                                       "from MultiManager",
+                                   default='ospa_generator')
 
     def compute_over_time(self, measured_states, truth_states):
         """Compute the OSPA metric at every timestep from a list of measured

--- a/stonesoup/metricgenerator/ospametric.py
+++ b/stonesoup/metricgenerator/ospametric.py
@@ -30,10 +30,12 @@ class GOSPAMetric(MetricGenerator):
     measure: Measure = Property(
         default=Euclidean(),
         doc="Distance measure to use. Default :class:`~.measures.Euclidean()`")
-    generator_name: str = Property(doc="Unique identifier to use when accessing generated metrics from MultiManager")
+    generator_name: str = Property(doc="Unique identifier to use when accessing generated metrics "
+                                       "from MultiManager")
     tracks_key: str = Property(doc='Key to access set of tracks added to MultiManager')
-    truths_key: str = Property(doc="Key to access set of ground truths added to MultiManager. Or key to access a second"
-                                   " set of tracks for track-to-track metric generation")
+    truths_key: str = Property(doc="Key to access set of ground truths added to MultiManager. "
+                                   "Or key to access a second set of tracks for track-to-track"
+                                   " metric generation")
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -381,7 +383,6 @@ class OSPAMetric(GOSPAMetric):
     c: float = Property(doc='Maximum distance for possible association')
     p: float = Property(doc='Norm associated to distance')
 
-    # RG update documentation to clarify that compute_over_time can take 2 tracks or track and truth
     def compute_over_time(self, measured_states, truth_states):
         """Compute the OSPA metric at every timestep from a list of measured
         states and truth states

--- a/stonesoup/metricgenerator/ospametric.py
+++ b/stonesoup/metricgenerator/ospametric.py
@@ -147,7 +147,7 @@ class GOSPAMetric(MetricGenerator):
         max_iter: Maximum number of iterations to perform
 
         Returns
-        ---------
+        -------
         truth_to_measured: np.ndarray
             Vector of size m, which has indices of the measured objects or '-1' if unassigned.
         measured_to_truth: np.ndarray
@@ -250,7 +250,7 @@ class GOSPAMetric(MetricGenerator):
             there is a mismatch in cardinality
 
         Returns
-        ----------
+        -------
         cost_matrix: np.ndarray
             Matrix of distance between each element in each list of states
         """

--- a/stonesoup/metricgenerator/pcrbmetric.py
+++ b/stonesoup/metricgenerator/pcrbmetric.py
@@ -44,9 +44,11 @@ class PCRBMetric(MetricGenerator):
         doc="Mapping for velocity coordinates. Default `None`, in which case velocity RMSE is not "
             "computed")
     irf: float = Property(doc="Information reduction factor. Default is 1", default=1.)
-    truths_key: str = Property(doc="Key to access set of ground truths added to MultiManager")
+    truths_key: str = Property(doc="Key to access set of ground truths added to MetricManager",
+                               default='groundtruth_paths')
     generator_name: str = Property(doc="Unique identifier to use when accessing generated "
-                                       "metrics from MultiManager")
+                                       "metrics from MultiManager",
+                                   default='pcrb_generator')
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/stonesoup/metricgenerator/pcrbmetric.py
+++ b/stonesoup/metricgenerator/pcrbmetric.py
@@ -6,7 +6,7 @@ from typing import Sequence
 from .base import MetricGenerator
 from ..base import Property
 from ..types.state import GaussianState
-from ..types.groundtruth import GroundTruthPath
+from ..types.groundtruth import GroundTruthState, GroundTruthPath
 from ..types.array import StateVectors
 from ..models.transition import TransitionModel
 from ..models.measurement import MeasurementModel
@@ -56,6 +56,12 @@ class PCRBMetric(MetricGenerator):
     def compute_metric(self, manager, **kwargs):
         groundtruth_paths = self._get_data(manager, self.truths_key)
         pcrb_metrics = []
+
+        # if groundtruth is a set of states not paths, make states into a path
+        if isinstance(next(iter(groundtruth_paths)), GroundTruthState):
+            groundtruth_paths = sorted(list(groundtruth_paths), key=lambda x: x.timestamp)
+            groundtruth_paths = [GroundTruthPath(groundtruth_paths)]
+
         for gnd_path in groundtruth_paths:
             pcrb_metric = self._compute_pcrb_single(self.prior, self.transition_model,
                                                     self.measurement_model, gnd_path,

--- a/stonesoup/metricgenerator/pcrbmetric.py
+++ b/stonesoup/metricgenerator/pcrbmetric.py
@@ -45,7 +45,8 @@ class PCRBMetric(MetricGenerator):
             "computed")
     irf: float = Property(doc="Information reduction factor. Default is 1", default=1.)
     truths_key: str = Property(doc="Key to access set of ground truths added to MultiManager")
-    generator_name: str = Property(doc="Unique identifier to use when accessing generated metrics from MultiManager")
+    generator_name: str = Property(doc="Unique identifier to use when accessing generated "
+                                       "metrics from MultiManager")
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/stonesoup/metricgenerator/plotter.py
+++ b/stonesoup/metricgenerator/plotter.py
@@ -24,17 +24,18 @@ class TwoDPlotter(PlotGenerator):
                                  doc='If True the plot includes uncertainty ellipses')
     particle: bool = Property(default=False,
                               doc='If True the plot includes particles')
-    tracks_key: str = Property(doc='Key to access set of tracks added to MultiManager',
-                               default=None)
-    truths_key: str = Property(doc="Key to access set of ground truths added to MultiManager. "
+    tracks_key: str = Property(doc='Key to access set of tracks added to MetricManager',
+                               default='tracks')
+    truths_key: str = Property(doc="Key to access set of ground truths added to MetricManager. "
                                    "Or key to access a second set of tracks for track-to-track "
                                    "metric generation",
-                               default=None)
+                               default='groundtruth_paths')
     detections_key: str = Property(doc="Key to access desired set of detections added "
-                                       "to MultiManager",
-                                   default=None)
+                                       "to MetricManager",
+                                   default='detections')
     generator_name: str = Property(doc="Unique identifier to use when accessing generated "
-                                       "metrics from MultiManager")
+                                       "plots from MultiManager",
+                                   default='tracker_plot')
 
     def compute_metric(self, manager, *args, **kwargs):
         """Compute the metric using the data in the metric manager
@@ -50,11 +51,11 @@ class TwoDPlotter(PlotGenerator):
             Contains a matplotlib figure
         """
 
-        if self.truths_key is not None:
+        if self.truths_key in manager.states_sets.keys():
             groundtruth_paths = self._get_data(manager, self.truths_key)
-        if self.tracks_key is not None:
+        if self.tracks_key in manager.states_sets.keys():
             tracks = self._get_data(manager, self.tracks_key)
-        if self.detections_key is not None:
+        if self.detections_key in manager.states_sets.keys():
             detections = self._get_data(manager, self.detections_key)
 
         metric = self.plot_tracks_truth_detections(tracks,
@@ -91,9 +92,12 @@ class TwoDPlotter(PlotGenerator):
 
         plotter.ax.set_title(self.generator_name)
 
-        plotter.plot_measurements(detections, [self.detection_indices[0],
-                                               self.detection_indices[1]],
-                                  color='tab:blue')
+        if detections is not None:
+            plotter.plot_measurements(detections, [self.detection_indices[0],
+                                                   self.detection_indices[1]],
+                                      color='tab:blue')
+        else:
+            detections = []
 
         if groundtruth_paths is not None:
             plotter.plot_ground_truths(groundtruth_paths, [self.gtruth_indices[0],

--- a/stonesoup/metricgenerator/plotter.py
+++ b/stonesoup/metricgenerator/plotter.py
@@ -24,11 +24,17 @@ class TwoDPlotter(PlotGenerator):
                                  doc='If True the plot includes uncertainty ellipses')
     particle: bool = Property(default=False,
                               doc='If True the plot includes particles')
-    tracks_key: str = Property(doc='Key to access set of tracks added to MultiManager')
-    truths_key: str = Property(doc="Key to access set of ground truths added to MultiManager. Or key to access a second"
-                                   " set of tracks for track-to-track metric generation")
-    detections_key: str = Property(doc="Key to access desired set of detections added to MultiManager")
-    generator_name: str = Property(doc="Unique identifier to use when accessing generated metrics from MultiManager")
+    tracks_key: str = Property(doc='Key to access set of tracks added to MultiManager',
+                               default=None)
+    truths_key: str = Property(doc="Key to access set of ground truths added to MultiManager. "
+                                   "Or key to access a second set of tracks for track-to-track "
+                                   "metric generation",
+                               default=None)
+    detections_key: str = Property(doc="Key to access desired set of detections added "
+                                       "to MultiManager",
+                                   default=None)
+    generator_name: str = Property(doc="Unique identifier to use when accessing generated "
+                                       "metrics from MultiManager")
 
     def compute_metric(self, manager, *args, **kwargs):
         """Compute the metric using the data in the metric manager
@@ -44,9 +50,12 @@ class TwoDPlotter(PlotGenerator):
             Contains a matplotlib figure
         """
 
-        groundtruth_paths = self._get_data(manager, self.truths_key)
-        tracks = self._get_data(manager, self.tracks_key)
-        detections = self._get_data(manager, self.detections_key)
+        if self.truths_key is not None:
+            groundtruth_paths = self._get_data(manager, self.truths_key)
+        if self.tracks_key is not None:
+            tracks = self._get_data(manager, self.tracks_key)
+        if self.detections_key is not None:
+            detections = self._get_data(manager, self.detections_key)
 
         metric = self.plot_tracks_truth_detections(tracks,
                                                    groundtruth_paths,
@@ -86,14 +95,14 @@ class TwoDPlotter(PlotGenerator):
                                                self.detection_indices[1]],
                                   color='tab:blue')
 
-        if groundtruth_paths:
+        if groundtruth_paths is not None:
             plotter.plot_ground_truths(groundtruth_paths, [self.gtruth_indices[0],
                                                            self.gtruth_indices[1]],
                                        linestyle=':')
         else:
             groundtruth_paths = []
 
-        if tracks:
+        if tracks is not None:
             plotting_tracks = set()
             for track in tracks:
                 if len([state for state in track.states if not isinstance(

--- a/stonesoup/metricgenerator/plotter.py
+++ b/stonesoup/metricgenerator/plotter.py
@@ -61,7 +61,7 @@ class TwoDPlotter(PlotGenerator):
 
         Parameters
         ----------
-        tracks: set of :class:`~.Track`
+        tracks: list of set of :class:`~.Track`
             Objects to be plotted as tracks
         groundtruth_paths: set of :class:`~.GroundTruthPath`
             Objects to be plotted as truths
@@ -79,6 +79,8 @@ class TwoDPlotter(PlotGenerator):
         """
 
         plotter = Plotter()  # initialises axes using Plotter class
+
+        plotter.ax.set_title(self.generator_name)
 
         plotter.plot_measurements(detections, [self.detection_indices[0],
                                                self.detection_indices[1]],
@@ -104,16 +106,19 @@ class TwoDPlotter(PlotGenerator):
             if uncertainty:
                 plotter.plot_tracks(plotting_tracks, [self.track_indices[0],
                                                       self.track_indices[1]],
-                                    uncertainty=True)
+                                    uncertainty=True,
+                                    track_label=self.tracks_key)
 
             elif particle:
                 plotter.plot_tracks(plotting_tracks, [self.track_indices[0],
                                                       self.track_indices[1]],
-                                    particle=True)
+                                    particle=True,
+                                    track_label=self.tracks_key)
 
             else:
                 plotter.plot_tracks(plotting_tracks, [self.track_indices[0],
-                                                      self.track_indices[1]])
+                                                      self.track_indices[1]],
+                                    track_label=self.tracks_key)
         else:
             tracks = []
 

--- a/stonesoup/metricgenerator/plotter.py
+++ b/stonesoup/metricgenerator/plotter.py
@@ -82,7 +82,7 @@ class TwoDPlotter(PlotGenerator):
             If True, function plots particles.
 
         Returns
-        ----------
+        -------
         TimeRangePlottingMetric
             Contains the produced plot
         """

--- a/stonesoup/metricgenerator/tests/conftest.py
+++ b/stonesoup/metricgenerator/tests/conftest.py
@@ -3,7 +3,7 @@ from datetime import datetime, timedelta
 import numpy as np
 import pytest
 
-from ...metricgenerator.manager import SimpleManager
+from ...metricgenerator.manager import MultiManager
 from ...types.association import TimeRangeAssociation, AssociationSet
 from ...types.detection import Detection
 from ...types.groundtruth import GroundTruthPath, GroundTruthState
@@ -210,8 +210,9 @@ def trial_associations(trial_truths, trial_tracks, trial_timestamps):
 
 @pytest.fixture()
 def trial_manager(trial_truths, trial_tracks, trial_associations):
-    manager = SimpleManager()
-    manager.add_data(trial_truths, trial_tracks)
+    manager = MultiManager()
+    manager.add_data({'truths': trial_truths,
+                      'tracks': trial_tracks})
     manager.association_set = trial_associations
 
     return manager

--- a/stonesoup/metricgenerator/tests/conftest.py
+++ b/stonesoup/metricgenerator/tests/conftest.py
@@ -211,7 +211,7 @@ def trial_associations(trial_truths, trial_tracks, trial_timestamps):
 @pytest.fixture()
 def trial_manager(trial_truths, trial_tracks, trial_associations):
     manager = MultiManager()
-    manager.add_data({'truths': trial_truths,
+    manager.add_data({'groundtruth_paths': trial_truths,
                       'tracks': trial_tracks})
     manager.association_set = trial_associations
 

--- a/stonesoup/metricgenerator/tests/test_basicmetrics.py
+++ b/stonesoup/metricgenerator/tests/test_basicmetrics.py
@@ -12,10 +12,7 @@ from ...types.track import Track
 
 
 def test_basicmetrics():
-    generator = BasicMetrics(generator_name='test_basic',
-                             tracks_key='tracks',
-                             truths_key='truths'
-                             )
+    generator = BasicMetrics()
     manager = MultiManager([generator])
 
     start_time = datetime.datetime.now()
@@ -29,7 +26,7 @@ def test_basicmetrics():
                       timestamp=start_time + datetime.timedelta(seconds=i))
                 for i in range(5)]) for j in range(3))
 
-    manager.add_data({'truths': truths, 'tracks': tracks})
+    manager.add_data({'groundtruth_paths': truths, 'tracks': tracks})
 
     metrics = manager.generate_metrics()
 
@@ -57,7 +54,7 @@ def test_basicmetrics():
     for metric_name in ["Number of targets",
                         "Number of tracks", "Track-to-target ratio"]:
         calc_metric = [i for i in correct_metrics if i.title == metric_name][0]
-        meas_metric = metrics['test_basic'].get(metric_name)
+        meas_metric = metrics['basic_generator'].get(metric_name)
         assert calc_metric.value == meas_metric.value
         assert calc_metric.time_range.start_timestamp == \
             meas_metric.time_range.start_timestamp

--- a/stonesoup/metricgenerator/tests/test_basicmetrics.py
+++ b/stonesoup/metricgenerator/tests/test_basicmetrics.py
@@ -57,7 +57,7 @@ def test_basicmetrics():
     for metric_name in ["Number of targets",
                         "Number of tracks", "Track-to-target ratio"]:
         calc_metric = [i for i in correct_metrics if i.title == metric_name][0]
-        meas_metric = metrics.get(metric_name)
+        meas_metric = metrics['test_basic'].get(metric_name)
         assert calc_metric.value == meas_metric.value
         assert calc_metric.time_range.start_timestamp == \
             meas_metric.time_range.start_timestamp

--- a/stonesoup/metricgenerator/tests/test_basicmetrics.py
+++ b/stonesoup/metricgenerator/tests/test_basicmetrics.py
@@ -2,7 +2,7 @@ import datetime
 
 import numpy as np
 
-from ..manager import SimpleManager
+from ..manager import MultiManager
 from ..basicmetrics import BasicMetrics
 from ...types.groundtruth import GroundTruthPath
 from ...types.metric import TimeRangeMetric
@@ -12,8 +12,11 @@ from ...types.track import Track
 
 
 def test_basicmetrics():
-    generator = BasicMetrics()
-    manager = SimpleManager([generator])
+    generator = BasicMetrics(generator_name='test_basic',
+                             tracks_key='tracks',
+                             truths_key='truths'
+                             )
+    manager = MultiManager([generator])
 
     start_time = datetime.datetime.now()
     tracks = set(Track(
@@ -26,7 +29,7 @@ def test_basicmetrics():
                       timestamp=start_time + datetime.timedelta(seconds=i))
                 for i in range(5)]) for j in range(3))
 
-    manager.add_data(truths, tracks)
+    manager.add_data({'truths': truths, 'tracks': tracks})
 
     metrics = manager.generate_metrics()
 

--- a/stonesoup/metricgenerator/tests/test_manager.py
+++ b/stonesoup/metricgenerator/tests/test_manager.py
@@ -146,8 +146,6 @@ def test_generate_metrics():
     metrics = manager.generate_metrics()
     metric1 = metrics['generator1']
     metric2 = metrics['generator2']
-    # metric1 = [metrics.get(i) for i in metrics if metrics[i].generator == generator1][0]
-    # metric2 = [metrics.get(i) for i in metrics if metrics[i].generator == generator2][0]
 
     assert len(metrics) == 2
     assert list(metric1.keys())[0] == "Test metric2"

--- a/stonesoup/metricgenerator/tests/test_manager.py
+++ b/stonesoup/metricgenerator/tests/test_manager.py
@@ -1,6 +1,5 @@
 import datetime
 import numpy as np
-import pytest
 
 from ..manager import MultiManager, SimpleManager
 from ..base import MetricGenerator
@@ -19,19 +18,9 @@ class DummyMetricGenerator(MetricGenerator):
     tracks_key: str = Property(default='tracks')
     truths_key: str = Property(default='groundtruth_paths')
 
-    def compute_metric1(self, manager, *args, **kwargs):
+    def compute_metric(self, manager, *args, **kwargs):
         return Metric(title="Test metric1",
                       value=25,
-                      generator=self)
-
-    def compute_metric2(self, manager, *args, **kwargs):
-        return Metric(title="Test metric2",
-                      value=25,
-                      generator=self)
-
-    def compute_metric3(self, manager, *args, **kwargs):
-        return Metric(title="Test metric3 at times",
-                      value=50,
                       generator=self)
 
 
@@ -235,14 +224,14 @@ def test_generate_metrics_multimanager():
     metric3 = metrics['generator2']
 
     # test metric content generated correctly from generator1
-    assert isinstance(metric2, Metric)
+    assert isinstance(metric2['Test metric2'], Metric)
     assert list(metric2.keys()) == ["Test metric2"]
     assert metrics['generator1'].get("Test metric2") == metric2['Test metric2']
     assert np.array_equal(metric2['Test metric2'].value, 25)
     assert metric2['Test metric2'].generator == generator1
 
     # test metric content generated correctly from generator2
-    assert isinstance(metric3, Metric)
+    assert isinstance(metric3['Test metric3 at times'], Metric)
     assert list(metric3.keys()) == ["Test metric3 at times"]
     assert metrics['generator2'].get("Test metric3 at times") == metric3['Test metric3 at times']
     assert np.array_equal(metric3['Test metric3 at times'].value, 50)

--- a/stonesoup/metricgenerator/tests/test_manager.py
+++ b/stonesoup/metricgenerator/tests/test_manager.py
@@ -23,6 +23,7 @@ class DummyMetricGenerator(MetricGenerator):
                       value=25,
                       generator=self)
 
+
 def test_add_data():
     manager = MultiManager([])
 
@@ -56,8 +57,8 @@ def test_add_data():
     # Check adding additional data including repeated data
     manager = MultiManager([])
     manager.add_data({'truths': truths, 'tracks': tracks, 'detections': dets})
-    manager.add_data({'truths': truths + truths2, 'tracks': tracks + tracks2, 'detections': dets + dets2},
-                     overwrite=True)
+    manager.add_data({'truths': truths + truths2, 'tracks': tracks + tracks2,
+                      'detections': dets + dets2}, overwrite=True)
 
     assert manager.states_sets['tracks'] == set(tracks2 + tracks)
     assert manager.states_sets['truths'] == set(truths2 + truths)

--- a/stonesoup/metricgenerator/tests/test_manager.py
+++ b/stonesoup/metricgenerator/tests/test_manager.py
@@ -1,7 +1,8 @@
 import datetime
 import numpy as np
+import pytest
 
-from ..manager import MultiManager
+from ..manager import MultiManager, SimpleManager
 from ..base import MetricGenerator
 from ...dataassociator import Associator
 from ...types.association import Association
@@ -14,17 +15,39 @@ from ...base import Property
 
 
 class DummyMetricGenerator(MetricGenerator):
-    generator_name: str = Property()
-    tracks_key: str = Property()
-    truths_key: str = Property()
+    generator_name: str = Property(default='test_generator')
+    tracks_key: str = Property(default='tracks')
+    truths_key: str = Property(default='groundtruth_paths')
 
-    def compute_metric(self, manager, *args, **kwargs):
+    def compute_metric1(self, manager, *args, **kwargs):
         return Metric(title="Test metric1",
                       value=25,
                       generator=self)
 
+    def compute_metric2(self, manager, *args, **kwargs):
+        return Metric(title="Test metric2",
+                      value=25,
+                      generator=self)
 
-def test_add_data():
+    def compute_metric3(self, manager, *args, **kwargs):
+        return Metric(title="Test metric3 at times",
+                      value=50,
+                      generator=self)
+
+
+class DummyAssociator(Associator):
+
+    @staticmethod
+    def associate_tracks(tracks, truths):
+
+        associations = set()
+        for track in tracks:
+            for truth in truths:
+                associations.add(Association({track, truth}))
+        return associations
+
+
+def test_add_data_multimanager():
     manager = MultiManager([])
 
     # Check adding data to empty manager
@@ -41,7 +64,6 @@ def test_add_data():
     assert manager.states_sets['detections'] == set(dets)
 
     # Check not overwriting data (flag is true by default)
-
     tracks2 = [Track(
         states=State(np.array([[21]]), timestamp=datetime.datetime.now()))]
     truths2 = [GroundTruthPath(
@@ -54,28 +76,68 @@ def test_add_data():
     assert manager.states_sets['truths'] == set(truths + truths2)
     assert manager.states_sets['detections'] == set(dets + dets2)
 
+    # Check overwriting data correctly and check multiple tracks added
+    manager.add_data({'truths': truths2,
+                      'tracks': tracks,
+                      'tracks2': tracks2,
+                      'detections': dets2}, overwrite=True)
+
+    assert manager.states_sets['tracks'] == set(tracks)
+    assert manager.states_sets['tracks2'] == set(tracks2)
+    assert manager.states_sets['truths'] == set(truths2)
+    assert manager.states_sets['detections'] == set(dets2)
+
     # Check adding additional data including repeated data
-    manager = MultiManager([])
     manager.add_data({'truths': truths, 'tracks': tracks, 'detections': dets})
     manager.add_data({'truths': truths + truths2, 'tracks': tracks + tracks2,
-                      'detections': dets + dets2}, overwrite=True)
+                      'detections': dets + dets2}, overwrite=False)
 
     assert manager.states_sets['tracks'] == set(tracks2 + tracks)
     assert manager.states_sets['truths'] == set(truths2 + truths)
     assert manager.states_sets['detections'] == set(dets2 + dets)
 
 
-def test_associate_tracks():
-    class DummyAssociator(Associator):
+def test_add_data_simplemanager():
+    manager = SimpleManager([])
 
-        def associate_tracks(self, tracks, truths):
+    # Check adding data to empty manager
+    tracks = [Track(
+        states=State(np.array([[1]]), timestamp=datetime.datetime.now()))]
+    truths = [GroundTruthPath(
+        states=State(np.array([[2]]), timestamp=datetime.datetime.now()))]
+    dets = [Detection(np.array([[3]]), timestamp=datetime.datetime.now())]
 
-            associations = set()
-            for track in tracks:
-                for truth in truths:
-                    associations.add(Association({track, truth}))
-            return associations
+    manager.add_data(truths, tracks, dets)
 
+    assert manager.states_sets['tracks'] == set(tracks)
+    assert manager.states_sets['groundtruth_paths'] == set(truths)
+    assert manager.states_sets['detections'] == set(dets)
+
+    # Check not overwriting data (flag is true by default)
+
+    tracks2 = [Track(
+        states=State(np.array([[21]]), timestamp=datetime.datetime.now()))]
+    truths2 = [GroundTruthPath(
+        states=State(np.array([[22]]), timestamp=datetime.datetime.now()))]
+    dets2 = [Detection(np.array([[23]]), timestamp=datetime.datetime.now())]
+
+    manager.add_data(truths2, tracks2, dets2, overwrite=False)
+
+    assert manager.states_sets['tracks'] == set(tracks + tracks2)
+    assert manager.states_sets['groundtruth_paths'] == set(truths + truths2)
+    assert manager.states_sets['detections'] == set(dets + dets2)
+
+    # Check adding additional data including repeated data
+    manager = SimpleManager([])
+    manager.add_data(truths, tracks, dets)
+    manager.add_data(truths + truths2, tracks + tracks2, dets + dets2, overwrite=False)
+
+    assert manager.states_sets['tracks'] == set(tracks2 + tracks)
+    assert manager.states_sets['groundtruth_paths'] == set(truths2 + truths)
+    assert manager.states_sets['detections'] == set(dets2 + dets)
+
+
+def test_associate_tracks_multimanager():
     generator = DummyMetricGenerator(generator_name='test_generator',
                                      tracks_key='tracks',
                                      truths_key='truths'
@@ -93,7 +155,21 @@ def test_associate_tracks():
     assert manager.association_set.pop().objects == tracks | truths
 
 
-def test_list_timestamps():
+def test_associate_tracks_simplemanager():
+    generator = DummyMetricGenerator()
+    manager = SimpleManager(associator=DummyAssociator(), generators=[generator])
+    tracks = {Track(
+        states=State(np.array([[1]]), timestamp=datetime.datetime.now()))}
+    truths = {GroundTruthPath(
+        states=State(np.array([[2]]), timestamp=datetime.datetime.now()))}
+    manager.add_data(truths, tracks)
+
+    manager.associate_tracks(generator)
+
+    assert manager.association_set.pop().objects == tracks | truths
+
+
+def test_list_timestamps_multimanager():
 
     generator = DummyMetricGenerator(generator_name='test_generator',
                                      tracks_key='tracks',
@@ -112,48 +188,107 @@ def test_list_timestamps():
     assert manager.list_timestamps(generator) == [timestamp1, timestamp2]
 
 
-def test_generate_metrics():
+def test_list_timestamps_simplemanager():
+
+    generator = DummyMetricGenerator()
+
+    timestamp1 = datetime.datetime.now()
+    timestamp2 = timestamp1 + datetime.timedelta(seconds=10)
+    manager = SimpleManager(generators=[generator])
+    tracks = [Track(
+        states=[State(np.array([[1]]), timestamp=timestamp1)])]
+    truths = [GroundTruthPath(
+        states=[State(np.array([[2]]), timestamp=timestamp2)])]
+    manager.add_data(truths, tracks)
+
+    assert manager.list_timestamps(generator) == [timestamp1, timestamp2]
+
+
+def test_generate_metrics_multimanager():
     class DummyGenerator1(MetricGenerator):
         generator_name: str = Property()
-        tracks_key: str = Property()
-        truths_key: str = Property()
 
-        def compute_metric(self, manager, *args, **kwargs):
+        def compute_metric(self, *args, **kwargs):
             return Metric(title="Test metric2",
                           value=25,
                           generator=self)
 
     class DummyGenerator2(MetricGenerator):
         generator_name: str = Property()
-        tracks_key: str = Property()
-        truths_key: str = Property()
 
-        def compute_metric(self, manager, *args, **kwargs):
+        def compute_metric(self, *args, **kwargs):
             return Metric(title="Test metric3 at times",
                           value=50,
                           generator=self)
 
-    generator1 = DummyGenerator1(generator_name='generator1',
-                                 tracks_key='tracks',
-                                 truths_key='truths'
-                                 )
-    generator2 = DummyGenerator2(generator_name='generator2',
-                                 tracks_key='tracks',
-                                 truths_key='truths'
-                                 )
-
+    generator1 = DummyGenerator1(generator_name='generator1')
+    generator2 = DummyGenerator2(generator_name='generator2')
     manager = MultiManager(generators=[generator1, generator2])
-
     metrics = manager.generate_metrics()
-    metric1 = metrics['generator1']
-    metric2 = metrics['generator2']
 
+    # test metrics returned correctly
+    assert isinstance(metrics, dict)
     assert len(metrics) == 2
-    assert list(metric1.keys())[0] == "Test metric2"
-    assert metrics['generator1'].get("Test metric2") == metric1['Test metric2']
-    assert np.array_equal(metric1['Test metric2'].value, 25)
-    assert np.array_equal(metric1['Test metric2'].generator, generator1)
-    assert list(metric2.keys())[0] == "Test metric3 at times"
-    assert metrics['generator2'].get("Test metric3 at times") == metric2['Test metric3 at times']
-    assert np.array_equal(metric2['Test metric3 at times'].value, 50)
-    assert np.array_equal(metric2['Test metric3 at times'].generator, generator2)
+    assert list(metrics.keys()) == ['generator1', 'generator2']
+
+    metric2 = metrics['generator1']
+    metric3 = metrics['generator2']
+
+    # test metric content generated correctly from generator1
+    assert isinstance(metric2, Metric)
+    assert list(metric2.keys()) == ["Test metric2"]
+    assert metrics['generator1'].get("Test metric2") == metric2['Test metric2']
+    assert np.array_equal(metric2['Test metric2'].value, 25)
+    assert metric2['Test metric2'].generator == generator1
+
+    # test metric content generated correctly from generator2
+    assert isinstance(metric3, Metric)
+    assert list(metric3.keys()) == ["Test metric3 at times"]
+    assert metrics['generator2'].get("Test metric3 at times") == metric3['Test metric3 at times']
+    assert np.array_equal(metric3['Test metric3 at times'].value, 50)
+    assert metric3['Test metric3 at times'].generator == generator2
+
+
+def test_generate_metrics_simplemanager():
+    class DummyGenerator1(MetricGenerator):
+        generator_name: str = Property()
+
+        def compute_metric(self, *args, **kwargs):
+            return Metric(title="Test metric4",
+                          value=30,
+                          generator=self)
+
+    class DummyGenerator2(MetricGenerator):
+        generator_name: str = Property()
+
+        def compute_metric(self, *args, **kwargs):
+            return Metric(title="Test metric5 at times",
+                          value=60,
+                          generator=self)
+
+    generator1 = DummyGenerator1(generator_name='generator1')
+    generator2 = DummyGenerator2(generator_name='generator2')
+    manager = SimpleManager(generators=[generator1, generator2])
+    metrics = manager.generate_metrics()
+
+    # test metrics has returned correctly
+    assert isinstance(metrics, dict)
+    assert len(metrics) == 2
+    assert list(metrics.keys()) == ['Test metric4', 'Test metric5 at times']
+
+    metric4 = metrics['Test metric4']
+    metric5 = metrics['Test metric5 at times']
+
+    # test metric content generated correctly from generator1
+    assert isinstance(metric4, Metric)
+    assert metric4.title == 'Test metric4'
+    assert metrics.get("Test metric4") == metric4
+    assert np.array_equal(metric4.value, 30)
+    assert metric4.generator == generator1
+
+    # test metric content generated correctly from generator2
+    assert isinstance(metric5, Metric)
+    assert metric5.title == 'Test metric5 at times'
+    assert metrics.get("Test metric5 at times") == metric5
+    assert np.array_equal(metric5.value, 60)
+    assert metric5.generator == generator2

--- a/stonesoup/metricgenerator/tests/test_manager.py
+++ b/stonesoup/metricgenerator/tests/test_manager.py
@@ -1,7 +1,7 @@
 import datetime
 import numpy as np
 
-from ..manager import SimpleManager
+from ..manager import MultiManager
 from ..base import MetricGenerator
 from ...dataassociator import Associator
 from ...types.association import Association
@@ -10,10 +10,21 @@ from ...types.groundtruth import GroundTruthPath
 from ...types.metric import Metric
 from ...types.state import State
 from ...types.track import Track
+from ...base import Property
 
 
-def test_adddata():
-    manager = SimpleManager([])
+class DummyMetricGenerator(MetricGenerator):
+    generator_name: str = Property()
+    tracks_key: str = Property()
+    truths_key: str = Property()
+
+    def compute_metric(self, manager, *args, **kwargs):
+        return Metric(title="Test metric1",
+                      value=25,
+                      generator=self)
+
+def test_add_data():
+    manager = MultiManager([])
 
     # Check adding data to empty manager
     tracks = [Track(
@@ -22,11 +33,11 @@ def test_adddata():
         states=State(np.array([[2]]), timestamp=datetime.datetime.now()))]
     dets = [Detection(np.array([[3]]), timestamp=datetime.datetime.now())]
 
-    manager.add_data(truths, tracks, dets)
+    manager.add_data({'truths': truths, 'tracks': tracks, 'detections': dets})
 
-    assert manager.tracks == set(tracks)
-    assert manager.groundtruth_paths == set(truths)
-    assert manager.detections == set(dets)
+    assert manager.states_sets['tracks'] == set(tracks)
+    assert manager.states_sets['truths'] == set(truths)
+    assert manager.states_sets['detections'] == set(dets)
 
     # Check not overwriting data (flag is true by default)
 
@@ -36,20 +47,21 @@ def test_adddata():
         states=State(np.array([[22]]), timestamp=datetime.datetime.now()))]
     dets2 = [Detection(np.array([[23]]), timestamp=datetime.datetime.now())]
 
-    manager.add_data(truths2, tracks2, dets2, overwrite=False)
+    manager.add_data({'truths': truths2, 'tracks': tracks2, 'detections': dets2}, overwrite=False)
 
-    assert manager.tracks == set(tracks + tracks2)
-    assert manager.groundtruth_paths == set(truths + truths2)
-    assert manager.detections == set(dets + dets2)
+    assert manager.states_sets['tracks'] == set(tracks + tracks2)
+    assert manager.states_sets['truths'] == set(truths + truths2)
+    assert manager.states_sets['detections'] == set(dets + dets2)
 
     # Check adding additional data including repeated data
-    manager = SimpleManager([])
-    manager.add_data(truths, tracks, dets)
-    manager.add_data(truths + truths2, tracks + tracks2, dets + dets2, overwrite=True)
+    manager = MultiManager([])
+    manager.add_data({'truths': truths, 'tracks': tracks, 'detections': dets})
+    manager.add_data({'truths': truths + truths2, 'tracks': tracks + tracks2, 'detections': dets + dets2},
+                     overwrite=True)
 
-    assert manager.tracks == set(tracks2 + tracks)
-    assert manager.groundtruth_paths == set(truths2 + truths)
-    assert manager.detections == set(dets2 + dets)
+    assert manager.states_sets['tracks'] == set(tracks2 + tracks)
+    assert manager.states_sets['truths'] == set(truths2 + truths)
+    assert manager.states_sets['detections'] == set(dets2 + dets)
 
 
 def test_associate_tracks():
@@ -63,61 +75,86 @@ def test_associate_tracks():
                     associations.add(Association({track, truth}))
             return associations
 
-    manager = SimpleManager(associator=DummyAssociator(), generators=[])
+    generator = DummyMetricGenerator(generator_name='test_generator',
+                                     tracks_key='tracks',
+                                     truths_key='truths'
+                                     )
+
+    manager = MultiManager(associator=DummyAssociator(), generators=[generator])
     tracks = {Track(
         states=State(np.array([[1]]), timestamp=datetime.datetime.now()))}
     truths = {GroundTruthPath(
         states=State(np.array([[2]]), timestamp=datetime.datetime.now()))}
-    manager.add_data(truths, tracks)
+    manager.add_data({'truths': truths, 'tracks': tracks})
 
-    manager.associate_tracks()
+    manager.associate_tracks(generator)
 
     assert manager.association_set.pop().objects == tracks | truths
 
 
-def test_listtimestamps():
+def test_list_timestamps():
+
+    generator = DummyMetricGenerator(generator_name='test_generator',
+                                     tracks_key='tracks',
+                                     truths_key='truths'
+                                     )
+
     timestamp1 = datetime.datetime.now()
     timestamp2 = timestamp1 + datetime.timedelta(seconds=10)
-    manager = SimpleManager(generators=[])
+    manager = MultiManager(generators=[generator])
     tracks = [Track(
         states=[State(np.array([[1]]), timestamp=timestamp1)])]
     truths = [GroundTruthPath(
         states=[State(np.array([[2]]), timestamp=timestamp2)])]
-    manager.add_data(truths, tracks)
+    manager.add_data({'truths': truths, 'tracks': tracks})
 
-    assert manager.list_timestamps() == [timestamp1, timestamp2]
+    assert manager.list_timestamps(generator) == [timestamp1, timestamp2]
 
 
 def test_generate_metrics():
     class DummyGenerator1(MetricGenerator):
+        generator_name: str = Property()
+        tracks_key: str = Property()
+        truths_key: str = Property()
 
         def compute_metric(self, manager, *args, **kwargs):
-            return Metric(title="Test metric1",
+            return Metric(title="Test metric2",
                           value=25,
                           generator=self)
 
     class DummyGenerator2(MetricGenerator):
+        generator_name: str = Property()
+        tracks_key: str = Property()
+        truths_key: str = Property()
 
         def compute_metric(self, manager, *args, **kwargs):
-            return Metric(title="Test metric2 at times",
+            return Metric(title="Test metric3 at times",
                           value=50,
                           generator=self)
 
-    generator1 = DummyGenerator1()
-    generator2 = DummyGenerator2()
+    generator1 = DummyGenerator1(generator_name='generator1',
+                                 tracks_key='tracks',
+                                 truths_key='truths'
+                                 )
+    generator2 = DummyGenerator2(generator_name='generator2',
+                                 tracks_key='tracks',
+                                 truths_key='truths'
+                                 )
 
-    manager = SimpleManager(generators=[generator1, generator2])
+    manager = MultiManager(generators=[generator1, generator2])
 
     metrics = manager.generate_metrics()
-    metric1 = [metrics.get(i) for i in metrics if metrics[i].generator == generator1][0]
-    metric2 = [metrics.get(i) for i in metrics if metrics[i].generator == generator2][0]
+    metric1 = metrics['generator1']
+    metric2 = metrics['generator2']
+    # metric1 = [metrics.get(i) for i in metrics if metrics[i].generator == generator1][0]
+    # metric2 = [metrics.get(i) for i in metrics if metrics[i].generator == generator2][0]
 
     assert len(metrics) == 2
-    assert metric1.title == "Test metric1"
-    assert metrics.get("Test metric1") == metric1
-    assert np.array_equal(metric1.value, 25)
-    assert np.array_equal(metric1.generator, generator1)
-    assert metric2.title == "Test metric2 at times"
-    assert metrics.get("Test metric2 at times") == metric2
-    assert np.array_equal(metric2.value, 50)
-    assert np.array_equal(metric2.generator, generator2)
+    assert list(metric1.keys())[0] == "Test metric2"
+    assert metrics['generator1'].get("Test metric2") == metric1['Test metric2']
+    assert np.array_equal(metric1['Test metric2'].value, 25)
+    assert np.array_equal(metric1['Test metric2'].generator, generator1)
+    assert list(metric2.keys())[0] == "Test metric3 at times"
+    assert metrics['generator2'].get("Test metric3 at times") == metric2['Test metric3 at times']
+    assert np.array_equal(metric2['Test metric3 at times'].value, 50)
+    assert np.array_equal(metric2['Test metric3 at times'].generator, generator2)

--- a/stonesoup/metricgenerator/tests/test_ospametric.py
+++ b/stonesoup/metricgenerator/tests/test_ospametric.py
@@ -4,7 +4,7 @@ import datetime
 import numpy as np
 import pytest
 
-from ..manager import SimpleManager
+from ..manager import MultiManager
 from ..ospametric import GOSPAMetric, OSPAMetric
 from ...types.detection import Detection
 from ...types.groundtruth import GroundTruthPath, GroundTruthState
@@ -16,7 +16,11 @@ def test_gospametric_extractstates():
     """Test GOSPA extract states."""
     generator = GOSPAMetric(
         c=10.0,
-        p=1)
+        p=1,
+        generator_name='GOSPA',
+        tracks_key='tracks',
+        truths_key='truths'
+    )
     # Test state extraction
     time_start = datetime.datetime.now()
     detections = [Detection(state_vector=np.array([[i]]), timestamp=time_start)
@@ -39,7 +43,11 @@ def test_gospametric_compute_assignments(num_states):
     """Test GOSPA assignment algorithm."""
     generator = GOSPAMetric(
         c=10.0,
-        p=1)
+        p=1,
+        generator_name='GOSPA',
+        tracks_key='tracks',
+        truths_key='truths'
+    )
     time_now = datetime.datetime.now()
     track_obj = Track([State(state_vector=[[i]], timestamp=time_now)
                       for i in range(num_states)])
@@ -91,7 +99,11 @@ def test_gospametric_cost_matrix():
     num_states = 5
     generator = GOSPAMetric(
         c=10.0,
-        p=1)
+        p=1,
+        generator_name='GOSPA',
+        tracks_key='tracks',
+        truths_key='truths'
+    )
     time_now = datetime.datetime.now()
     track_obj = Track([State(state_vector=[[i]], timestamp=time_now)
                       for i in range(num_states)])
@@ -115,7 +127,11 @@ def test_gospametric_compute_gospa_metric():
     num_states = 5
     generator = GOSPAMetric(
         c=10.0,
-        p=1)
+        p=1,
+        generator_name='GOSPA',
+        tracks_key='tracks',
+        truths_key='truths'
+    )
     time_now = datetime.datetime.now()
     track_obj = Track([State(state_vector=[[i]], timestamp=time_now)
                       for i in range(num_states)])
@@ -135,7 +151,11 @@ def test_gospametric_computemetric():
     """Test GOSPA compute metric."""
     generator = GOSPAMetric(
         c=10.0,
-        p=1)
+        p=1,
+        generator_name='GOSPA',
+        tracks_key='tracks',
+        truths_key='truths'
+    )
     time = datetime.datetime.now()
     # Multiple tracks and truths present at two timesteps
     tracks = {Track(states=[State(state_vector=[[i + 0.5]], timestamp=time),
@@ -150,8 +170,8 @@ def test_gospametric_computemetric():
                                      seconds=1))])
               for i in range(5)}
 
-    manager = SimpleManager([generator])
-    manager.add_data(truths, tracks)
+    manager = MultiManager([generator])
+    manager.add_data({'truths': truths, 'tracks': tracks})
     main_metric = generator.compute_metric(manager)
 
     assert main_metric.title == "GOSPA Metrics"
@@ -179,7 +199,11 @@ def test_ospametric_extractstates():
     """Test OSPA metric extract states."""
     generator = OSPAMetric(
         c=10,
-        p=1)
+        p=1,
+        generator_name='OSPA',
+        tracks_key='tracks',
+        truths_key='truths'
+    )
 
     # Test state extraction
     time_start = datetime.datetime.now()
@@ -203,7 +227,11 @@ def test_ospametric_computecostmatrix():
     """Test OSPA metric compute cost matrix."""
     generator = OSPAMetric(
         c=10,
-        p=1)
+        p=1,
+        generator_name='OSPA',
+        tracks_key='tracks',
+        truths_key='truths'
+    )
 
     time = datetime.datetime.now()
     track = Track(states=[
@@ -241,7 +269,11 @@ def test_ospametric_computeospadistance():
     """Test OSPA metric compute OSPA distance."""
     generator = OSPAMetric(
         c=10,
-        p=1)
+        p=1,
+        generator_name='OSPA',
+        tracks_key='tracks',
+        truths_key='truths'
+    )
 
     time = datetime.datetime.now()
     track = Track(states=[
@@ -264,7 +296,11 @@ def test_ospametric_computemetric(p):
     """Test OSPA compute metric."""
     generator = OSPAMetric(
         c=10,
-        p=p)
+        p=p,
+        generator_name='OSPA',
+        tracks_key='tracks',
+        truths_key='truths'
+    )
 
     time = datetime.datetime.now()
     # Multiple tracks and truths present at two timesteps
@@ -280,8 +316,8 @@ def test_ospametric_computemetric(p):
                                      seconds=1))])
               for i in range(5)}
 
-    manager = SimpleManager([generator])
-    manager.add_data(truths, tracks)
+    manager = MultiManager([generator])
+    manager.add_data({'truths': truths, 'tracks': tracks})
     main_metric = generator.compute_metric(manager)
     first_association, second_association = main_metric.value
 
@@ -308,7 +344,11 @@ def test_ospametric_computemetric(p):
 def test_ospa_computemetric_cardinality_error(p, first_value, second_value):
     generator = OSPAMetric(
         c=10,
-        p=p)
+        p=p,
+        generator_name='OSPA',
+        tracks_key='tracks',
+        truths_key='truths'
+    )
 
     time = datetime.datetime.now()
     # Multiple tracks and truths present at two timesteps
@@ -322,8 +362,8 @@ def test_ospa_computemetric_cardinality_error(p, first_value, second_value):
                                  timestamp=time+datetime.timedelta(seconds=1))])
               for i in range(5)}
 
-    manager = SimpleManager([generator])
-    manager.add_data(truths, tracks)
+    manager = MultiManager([generator])
+    manager.add_data({'truths': truths, 'tracks': tracks})
     main_metric = generator.compute_metric(manager)
     first_association, second_association = main_metric.value
 

--- a/stonesoup/metricgenerator/tests/test_ospametric.py
+++ b/stonesoup/metricgenerator/tests/test_ospametric.py
@@ -16,10 +16,7 @@ def test_gospametric_extractstates():
     """Test GOSPA extract states."""
     generator = GOSPAMetric(
         c=10.0,
-        p=1,
-        generator_name='GOSPA',
-        tracks_key='tracks',
-        truths_key='truths'
+        p=1
     )
     # Test state extraction
     time_start = datetime.datetime.now()
@@ -43,10 +40,7 @@ def test_gospametric_compute_assignments(num_states):
     """Test GOSPA assignment algorithm."""
     generator = GOSPAMetric(
         c=10.0,
-        p=1,
-        generator_name='GOSPA',
-        tracks_key='tracks',
-        truths_key='truths'
+        p=1
     )
     time_now = datetime.datetime.now()
     track_obj = Track([State(state_vector=[[i]], timestamp=time_now)
@@ -99,10 +93,7 @@ def test_gospametric_cost_matrix():
     num_states = 5
     generator = GOSPAMetric(
         c=10.0,
-        p=1,
-        generator_name='GOSPA',
-        tracks_key='tracks',
-        truths_key='truths'
+        p=1
     )
     time_now = datetime.datetime.now()
     track_obj = Track([State(state_vector=[[i]], timestamp=time_now)
@@ -127,10 +118,7 @@ def test_gospametric_compute_gospa_metric():
     num_states = 5
     generator = GOSPAMetric(
         c=10.0,
-        p=1,
-        generator_name='GOSPA',
-        tracks_key='tracks',
-        truths_key='truths'
+        p=1
     )
     time_now = datetime.datetime.now()
     track_obj = Track([State(state_vector=[[i]], timestamp=time_now)
@@ -151,10 +139,7 @@ def test_gospametric_computemetric():
     """Test GOSPA compute metric."""
     generator = GOSPAMetric(
         c=10.0,
-        p=1,
-        generator_name='GOSPA',
-        tracks_key='tracks',
-        truths_key='truths'
+        p=1
     )
     time = datetime.datetime.now()
     # Multiple tracks and truths present at two timesteps
@@ -171,7 +156,7 @@ def test_gospametric_computemetric():
               for i in range(5)}
 
     manager = MultiManager([generator])
-    manager.add_data({'truths': truths, 'tracks': tracks})
+    manager.add_data({'groundtruth_paths': truths, 'tracks': tracks})
     main_metric = generator.compute_metric(manager)
 
     assert main_metric.title == "GOSPA Metrics"
@@ -199,10 +184,7 @@ def test_ospametric_extractstates():
     """Test OSPA metric extract states."""
     generator = OSPAMetric(
         c=10,
-        p=1,
-        generator_name='OSPA',
-        tracks_key='tracks',
-        truths_key='truths'
+        p=1
     )
 
     # Test state extraction
@@ -227,10 +209,7 @@ def test_ospametric_computecostmatrix():
     """Test OSPA metric compute cost matrix."""
     generator = OSPAMetric(
         c=10,
-        p=1,
-        generator_name='OSPA',
-        tracks_key='tracks',
-        truths_key='truths'
+        p=1
     )
 
     time = datetime.datetime.now()
@@ -269,10 +248,7 @@ def test_ospametric_computeospadistance():
     """Test OSPA metric compute OSPA distance."""
     generator = OSPAMetric(
         c=10,
-        p=1,
-        generator_name='OSPA',
-        tracks_key='tracks',
-        truths_key='truths'
+        p=1
     )
 
     time = datetime.datetime.now()
@@ -296,10 +272,7 @@ def test_ospametric_computemetric(p):
     """Test OSPA compute metric."""
     generator = OSPAMetric(
         c=10,
-        p=p,
-        generator_name='OSPA',
-        tracks_key='tracks',
-        truths_key='truths'
+        p=p
     )
 
     time = datetime.datetime.now()
@@ -317,7 +290,7 @@ def test_ospametric_computemetric(p):
               for i in range(5)}
 
     manager = MultiManager([generator])
-    manager.add_data({'truths': truths, 'tracks': tracks})
+    manager.add_data({'groundtruth_paths': truths, 'tracks': tracks})
     main_metric = generator.compute_metric(manager)
     first_association, second_association = main_metric.value
 
@@ -344,10 +317,7 @@ def test_ospametric_computemetric(p):
 def test_ospa_computemetric_cardinality_error(p, first_value, second_value):
     generator = OSPAMetric(
         c=10,
-        p=p,
-        generator_name='OSPA',
-        tracks_key='tracks',
-        truths_key='truths'
+        p=p
     )
 
     time = datetime.datetime.now()
@@ -363,7 +333,7 @@ def test_ospa_computemetric_cardinality_error(p, first_value, second_value):
               for i in range(5)}
 
     manager = MultiManager([generator])
-    manager.add_data({'truths': truths, 'tracks': tracks})
+    manager.add_data({'groundtruth_paths': truths, 'tracks': tracks})
     main_metric = generator.compute_metric(manager)
     first_association, second_association = main_metric.value
 

--- a/stonesoup/metricgenerator/tests/test_pcrbmetric.py
+++ b/stonesoup/metricgenerator/tests/test_pcrbmetric.py
@@ -135,13 +135,11 @@ def test_computemetric(prior, transition_model, measurement_model, groundtruth,
                       sensor_locations=sensor_locations,
                       position_mapping=position_mapping,
                       velocity_mapping=velocity_mapping,
-                      irf=irf_overall,
-                      truths_key='truths',
-                      generator_name='generator')
+                      irf=irf_overall)
 
     manager = MultiManager([pcrb])
 
-    manager.add_data({'truths': groundtruth})
+    manager.add_data({'groundtruth_paths': groundtruth})
 
     metric = pcrb.compute_metric(manager)[0]
 

--- a/stonesoup/metricgenerator/tests/test_pcrbmetric.py
+++ b/stonesoup/metricgenerator/tests/test_pcrbmetric.py
@@ -3,7 +3,7 @@
 import numpy as np
 import pytest
 
-from ..manager import SimpleManager
+from ..manager import MultiManager
 from ..pcrbmetric import PCRBMetric
 from ...types.groundtruth import GroundTruthState
 from ...types.array import StateVector, StateVectors, CovarianceMatrix
@@ -130,13 +130,15 @@ def test_compute_pcrb_single(prior, transition_model, measurement_model, groundt
 def test_computemetric(prior, transition_model, measurement_model, groundtruth,
                        sensor_locations, irf_overall, position_mapping, velocity_mapping):
     pcrb = PCRBMetric(prior, transition_model, measurement_model, sensor_locations,
-                      position_mapping, velocity_mapping, irf_overall)
+                      position_mapping, velocity_mapping, irf_overall,
+                      generator_name='generator',
+                      truths_key='truths')
 
-    manager = SimpleManager([pcrb])
+    manager = MultiManager([pcrb])
 
-    manager.add_data({groundtruth})
+    manager.add_data({'truths': groundtruth})
 
-    metric = pcrb.compute_metric(manager)[0]
+    metric = pcrb.compute_metric(manager)['generator']['PCRB Metrics']
 
     assert metric.title == 'PCRB Metrics'
     assert metric.time_range.start_timestamp == groundtruth.states[0].timestamp

--- a/stonesoup/metricgenerator/tests/test_pcrbmetric.py
+++ b/stonesoup/metricgenerator/tests/test_pcrbmetric.py
@@ -170,7 +170,6 @@ def test_computemetric(prior, transition_model, measurement_model, groundtruth,
     # NOTE: Checking value of inverse_j is not necessary since rmse values are derived from
     # inverse_j, therefore if they are correct, then inverse_j is also correct.
     assert 'inverse_j' in metric.value
-    # assert metric.value['track'] == groundtruth
     assert metric.value['track'].states == groundtruth.states
     assert np.allclose(metric.value['position_RMSE'], expected_pos_rmse)
     if velocity_mapping is not None:

--- a/stonesoup/metricgenerator/tests/test_pcrbmetric.py
+++ b/stonesoup/metricgenerator/tests/test_pcrbmetric.py
@@ -131,8 +131,8 @@ def test_computemetric(prior, transition_model, measurement_model, groundtruth,
                        sensor_locations, irf_overall, position_mapping, velocity_mapping):
     pcrb = PCRBMetric(prior, transition_model, measurement_model, sensor_locations,
                       position_mapping, velocity_mapping, irf_overall,
-                      generator_name='generator',
-                      truths_key='truths')
+                      truths_key='truths',
+                      generator_name='generator')
 
     manager = MultiManager([pcrb])
 

--- a/stonesoup/metricgenerator/tests/test_pcrbmetric.py
+++ b/stonesoup/metricgenerator/tests/test_pcrbmetric.py
@@ -5,7 +5,7 @@ import pytest
 
 from ..manager import MultiManager
 from ..pcrbmetric import PCRBMetric
-from ...types.groundtruth import GroundTruthState, GroundTruthPath
+from ...types.groundtruth import GroundTruthState
 from ...types.array import StateVector, StateVectors, CovarianceMatrix
 from ...types.state import GaussianState
 

--- a/stonesoup/metricgenerator/tests/test_plotter.py
+++ b/stonesoup/metricgenerator/tests/test_plotter.py
@@ -15,7 +15,8 @@ from ...types.array import StateVectors
 def test_twodplotter():
     plotter = TwoDPlotter(track_indices=[0, 1],
                           detection_indices=[0, 1],
-                          gtruth_indices=[0, 1])
+                          gtruth_indices=[0, 1],
+                          generator_name='test_plotter')
     timestamp1 = datetime.datetime.now()
     timestamp2 = timestamp1 + datetime.timedelta(seconds=10)
 

--- a/stonesoup/metricgenerator/tests/test_plotter.py
+++ b/stonesoup/metricgenerator/tests/test_plotter.py
@@ -15,8 +15,7 @@ from ...types.array import StateVectors
 def test_twodplotter():
     plotter = TwoDPlotter(track_indices=[0, 1],
                           detection_indices=[0, 1],
-                          gtruth_indices=[0, 1],
-                          generator_name='test_plotter')
+                          gtruth_indices=[0, 1])
     timestamp1 = datetime.datetime.now()
     timestamp2 = timestamp1 + datetime.timedelta(seconds=10)
 

--- a/stonesoup/metricgenerator/tests/test_tables.py
+++ b/stonesoup/metricgenerator/tests/test_tables.py
@@ -9,10 +9,7 @@ from ...types.time import TimeRange
 
 def test_siaptable():
     metric_generator = SIAPMetrics(position_measure=Euclidean((0, 2)),
-                                   velocity_measure=Euclidean((1, 3)),
-                                   generator_name='test_SIAP',
-                                   tracks_key='tracks',
-                                   truths_key='truths')
+                                   velocity_measure=Euclidean((1, 3)))
     metrics = set()
     # Add metrics to ensure the generator can handle a full range of values
     metrics.add(TimeRangeMetric(title="SIAP Completeness",

--- a/stonesoup/metricgenerator/tests/test_tables.py
+++ b/stonesoup/metricgenerator/tests/test_tables.py
@@ -9,7 +9,10 @@ from ...types.time import TimeRange
 
 def test_siaptable():
     metric_generator = SIAPMetrics(position_measure=Euclidean((0, 2)),
-                                   velocity_measure=Euclidean((1, 3)))
+                                   velocity_measure=Euclidean((1, 3)),
+                                   generator_name='test_SIAP',
+                                   tracks_key='tracks',
+                                   truths_key='truths')
     metrics = set()
     # Add metrics to ensure the generator can handle a full range of values
     metrics.add(TimeRangeMetric(title="SIAP Completeness",

--- a/stonesoup/metricgenerator/tests/test_tracktotruthmetrics.py
+++ b/stonesoup/metricgenerator/tests/test_tracktotruthmetrics.py
@@ -13,10 +13,7 @@ def test_siap(trial_manager, trial_truths, trial_tracks, trial_associations, mea
     position_measure = measure_class((0, 2))
     velocity_measure = measure_class((1, 3))
     siap_generator = SIAPMetrics(position_measure=position_measure,
-                                 velocity_measure=velocity_measure,
-                                 generator_name='test_SIAP',
-                                 tracks_key='tracks',
-                                 truths_key='truths')
+                                 velocity_measure=velocity_measure)
 
     trial_manager.generators = [siap_generator]
 
@@ -118,9 +115,6 @@ def test_id_siap(trial_manager, trial_truths, trial_tracks, trial_associations, 
     truth_id = track_id = "colour"
     siap_generator = IDSIAPMetrics(position_measure=position_measure,
                                    velocity_measure=velocity_measure,
-                                   generator_name='test_ID_SIAP',
-                                   tracks_key='tracks',
-                                   truths_key='truths',
                                    truth_id=truth_id,
                                    track_id=track_id)
 

--- a/stonesoup/metricgenerator/tests/test_tracktotruthmetrics.py
+++ b/stonesoup/metricgenerator/tests/test_tracktotruthmetrics.py
@@ -13,21 +13,24 @@ def test_siap(trial_manager, trial_truths, trial_tracks, trial_associations, mea
     position_measure = measure_class((0, 2))
     velocity_measure = measure_class((1, 3))
     siap_generator = SIAPMetrics(position_measure=position_measure,
-                                 velocity_measure=velocity_measure)
+                                 velocity_measure=velocity_measure,
+                                 generator_name='test_SIAP',
+                                 tracks_key='tracks',
+                                 truths_key='truths')
 
     trial_manager.generators = [siap_generator]
 
-    timestamps = trial_manager.list_timestamps()
+    timestamps = trial_manager.list_timestamps(siap_generator)
 
     # Test num_tracks_at_time
     for timestamp in timestamps:
-        assert siap_generator.num_tracks_at_time(trial_manager, timestamp) == 3
+        assert siap_generator.num_tracks_at_time(trial_tracks, timestamp) == 3
 
     # Test num_associated_tracks_at_time
-    assert siap_generator.num_associated_tracks_at_time(trial_manager, timestamps[0]) == 2
-    assert siap_generator.num_associated_tracks_at_time(trial_manager, timestamps[1]) == 3
-    assert siap_generator.num_associated_tracks_at_time(trial_manager, timestamps[2]) == 3
-    assert siap_generator.num_associated_tracks_at_time(trial_manager, timestamps[3]) == 2
+    assert siap_generator.num_associated_tracks_at_time(trial_manager, trial_tracks, timestamps[0]) == 2
+    assert siap_generator.num_associated_tracks_at_time(trial_manager, trial_tracks, timestamps[1]) == 3
+    assert siap_generator.num_associated_tracks_at_time(trial_manager, trial_tracks, timestamps[2]) == 3
+    assert siap_generator.num_associated_tracks_at_time(trial_manager, trial_tracks, timestamps[3]) == 2
 
     # Test accuracy_at_time
     assoc0_pos_accuracy = np.sqrt(0.1 ** 2 + 0.1 ** 2)
@@ -62,7 +65,7 @@ def test_siap(trial_manager, trial_truths, trial_tracks, trial_associations, mea
 
     # Test rate_of_track_number_changes
     exp_rate = (2 - 1 + 2 - 1 + 1 - 1) / (3 + 2 + 1)
-    assert siap_generator.rate_of_track_number_changes(trial_manager) == exp_rate
+    assert siap_generator.rate_of_track_number_changes(trial_manager, trial_truths) == exp_rate
 
     # Test truth_lifetime
     for truth in trial_truths:
@@ -111,12 +114,15 @@ def test_id_siap(trial_manager, trial_truths, trial_tracks, trial_associations, 
     truth_id = track_id = "colour"
     siap_generator = IDSIAPMetrics(position_measure=position_measure,
                                    velocity_measure=velocity_measure,
+                                   generator_name='test_ID_SIAP',
+                                   tracks_key='tracks',
+                                   truths_key='truths',
                                    truth_id=truth_id,
                                    track_id=track_id)
 
     trial_manager.generators = [siap_generator]
 
-    timestamps = trial_manager.list_timestamps()
+    timestamps = trial_manager.list_timestamps(siap_generator)
 
     # Test find_track_id
     assert siap_generator.find_track_id(trial_tracks[0], timestamps[0]) == "red"
@@ -135,22 +141,22 @@ def test_id_siap(trial_manager, trial_truths, trial_tracks, trial_associations, 
     assert siap_generator.find_track_id(trial_tracks[2], timestamps[3]) == "green"
 
     # Test num_id_truths_at_time
-    u, c, i = siap_generator.num_id_truths_at_time(trial_manager, timestamps[0])
+    u, c, i = siap_generator.num_id_truths_at_time(trial_manager, trial_truths, timestamps[0])
     assert u == 0
     assert c == 1
     assert i == 1
 
-    u, c, i = siap_generator.num_id_truths_at_time(trial_manager, timestamps[1])
+    u, c, i = siap_generator.num_id_truths_at_time(trial_manager, trial_truths, timestamps[1])
     assert u == 1
     assert c == 0
     assert i == 1
 
-    u, c, i = siap_generator.num_id_truths_at_time(trial_manager, timestamps[2])
+    u, c, i = siap_generator.num_id_truths_at_time(trial_manager, trial_truths, timestamps[2])
     assert u == 0
     assert c == 2
     assert i == 0
 
-    u, c, i = siap_generator.num_id_truths_at_time(trial_manager, timestamps[3])
+    u, c, i = siap_generator.num_id_truths_at_time(trial_manager, trial_truths, timestamps[3])
     assert u == 0
     assert c == 1
     assert i == 1

--- a/stonesoup/metricgenerator/tests/test_tracktotruthmetrics.py
+++ b/stonesoup/metricgenerator/tests/test_tracktotruthmetrics.py
@@ -27,10 +27,14 @@ def test_siap(trial_manager, trial_truths, trial_tracks, trial_associations, mea
         assert siap_generator.num_tracks_at_time(trial_tracks, timestamp) == 3
 
     # Test num_associated_tracks_at_time
-    assert siap_generator.num_associated_tracks_at_time(trial_manager, trial_tracks, timestamps[0]) == 2
-    assert siap_generator.num_associated_tracks_at_time(trial_manager, trial_tracks, timestamps[1]) == 3
-    assert siap_generator.num_associated_tracks_at_time(trial_manager, trial_tracks, timestamps[2]) == 3
-    assert siap_generator.num_associated_tracks_at_time(trial_manager, trial_tracks, timestamps[3]) == 2
+    assert siap_generator.num_associated_tracks_at_time(trial_manager, trial_tracks,
+                                                        timestamps[0]) == 2
+    assert siap_generator.num_associated_tracks_at_time(trial_manager, trial_tracks,
+                                                        timestamps[1]) == 3
+    assert siap_generator.num_associated_tracks_at_time(trial_manager, trial_tracks,
+                                                        timestamps[2]) == 3
+    assert siap_generator.num_associated_tracks_at_time(trial_manager, trial_tracks,
+                                                        timestamps[3]) == 2
 
     # Test accuracy_at_time
     assoc0_pos_accuracy = np.sqrt(0.1 ** 2 + 0.1 ** 2)

--- a/stonesoup/metricgenerator/tests/test_uncertaintymetric.py
+++ b/stonesoup/metricgenerator/tests/test_uncertaintymetric.py
@@ -14,7 +14,9 @@ from ...types.track import Track
 
 @pytest.fixture(params=[SumofCovarianceNormsMetric, MeanofCovarianceNormsMetric])
 def generator(request):
-    return request.param()
+    generator = request.param(tracks_key='tracks',
+                              generator_name='test_generator')
+    return generator
 
 
 def test_covariancenormsmetric_extractstates(generator):

--- a/stonesoup/metricgenerator/tests/test_uncertaintymetric.py
+++ b/stonesoup/metricgenerator/tests/test_uncertaintymetric.py
@@ -14,9 +14,7 @@ from ...types.track import Track
 
 @pytest.fixture(params=[SumofCovarianceNormsMetric, MeanofCovarianceNormsMetric])
 def generator(request):
-    generator = request.param(tracks_key='tracks',
-                              generator_name='test_generator')
-    return generator
+    return request.param()
 
 
 def test_covariancenormsmetric_extractstates(generator):
@@ -71,21 +69,16 @@ def test_covariancenormsmetric_compute_metric(generator):
     """Test Covariance Norms compute metric."""
     time = datetime.datetime.now()
 
-    # Multiple tracks and truths present at two timesteps
+    # Multiple tracks present at two timesteps
     tracks = {Track(states=[GaussianState(state_vector=[[1], [2], [1], [2]], timestamp=time,
                                           covar=np.diag([i, i, i, i])),
                             GaussianState(state_vector=[[1.5], [2.5], [1.5], [2.5]],
                                           timestamp=time + datetime.timedelta(seconds=1),
                                           covar=np.diag([i+0.5, i+0.5, i+0.5, i+0.5]))])
               for i in range(5)}
-    truths = {GroundTruthPath(states=[GroundTruthState(state_vector=[[0], [1], [0], [1]],
-                                                       timestamp=time),
-                                      GroundTruthState(state_vector=[[0.5], [1.5], [0.5], [1.5]],
-                                                       timestamp=time + datetime.timedelta(
-                                                           seconds=1))])}
 
     manager = MultiManager([generator])
-    manager.add_data({'truths': truths, 'tracks': tracks})
+    manager.add_data({'tracks': tracks})
     main_metric = generator.compute_metric(manager)
     first_association, second_association = main_metric.value
 

--- a/stonesoup/metricgenerator/tests/test_uncertaintymetric.py
+++ b/stonesoup/metricgenerator/tests/test_uncertaintymetric.py
@@ -4,7 +4,7 @@ import datetime
 import numpy as np
 import pytest
 
-from ..manager import SimpleManager
+from ..manager import MultiManager
 from ..uncertaintymetric import SumofCovarianceNormsMetric, MeanofCovarianceNormsMetric
 from ...types.detection import Detection
 from ...types.groundtruth import GroundTruthPath, GroundTruthState
@@ -82,8 +82,8 @@ def test_covariancenormsmetric_compute_metric(generator):
                                                        timestamp=time + datetime.timedelta(
                                                            seconds=1))])}
 
-    manager = SimpleManager([generator])
-    manager.add_data(truths, tracks)
+    manager = MultiManager([generator])
+    manager.add_data({'truths': truths, 'tracks': tracks})
     main_metric = generator.compute_metric(manager)
     first_association, second_association = main_metric.value
 

--- a/stonesoup/metricgenerator/tracktotruthmetrics.py
+++ b/stonesoup/metricgenerator/tracktotruthmetrics.py
@@ -48,11 +48,14 @@ class SIAPMetrics(MetricGenerator):
     velocity_measure: Measure = Property(
         doc="Distance measure used in calculating velocity accuracy scores.")
     generator_name: str = Property(doc="Unique identifier to use when accessing generated metrics "
-                                       "from MultiManager")
-    tracks_key: str = Property(doc='Key to access set of tracks added to MultiManager')
-    truths_key: str = Property(doc="Key to access set of ground truths added to MultiManager. "
+                                       "from MultiManager",
+                                   default='siap_generator')
+    tracks_key: str = Property(doc='Key to access set of tracks added to MetricManager',
+                               default='tracks')
+    truths_key: str = Property(doc="Key to access set of ground truths added to MetricManager. "
                                    "Or key to access a second set of tracks for track-to-track "
-                                   "metric generation")
+                                   "metric generation",
+                               default='groundtruth_paths')
 
     def compute_metric(self, manager, **kwargs):
         r"""Compute metrics:
@@ -518,6 +521,9 @@ class IDSIAPMetrics(SIAPMetrics):
 
     truth_id: str = Property(doc="Metadata key for ID of each ground truth path in data-set")
     track_id: str = Property(doc="Metadata key for ID of each track in data-set")
+    generator_name: str = Property(doc="Unique identifier to use when accessing generated metrics "
+                                       "from MultiManager",
+                                   default='Id_siap_generator')
 
     def compute_metric(self, manager, **kwargs):
         r"""Compute metrics:

--- a/stonesoup/metricgenerator/tracktotruthmetrics.py
+++ b/stonesoup/metricgenerator/tracktotruthmetrics.py
@@ -22,7 +22,7 @@ class SIAPMetrics(MetricGenerator):
     implementation, with the assumption being that the fused sensor set is being assessed.
 
     Metrics:
-        * Continuity (C): Fraction of true objects being tracked. The output is in the range
+        * Completeness (C): Fraction of true objects being tracked. The output is in the range
           :math:`0:1`, with a target score of 1.
         * Ambiguity (A): Number of tracks assigned to a true object. The output is unbounded with
           a range of :math:`0:\infty`. The target score is 1.
@@ -35,9 +35,8 @@ class SIAPMetrics(MetricGenerator):
           The output is a distance measure, range :math:`0:\infty`, with a target score of 0.
         * Rate of track number changes (R): SIAP continuity measure. Rate of number of track
           changes per truth. The output is in the range :math:`0:\infty`, with a target score of 0.
-        * Longest track Segment (LS): SIAP continuity measure. Duration of longest associated
-          track segment per truth. The output is a float (seconds), with a target score equal to
-          the sum of all true object lifetimes.
+        * Longest track Segment (LS): SIAP continuity measure. Proportion of longest associated
+          track segment per truth. The output is in the range :math:`0:1`, with a target score of 1.
 
     Reference
         [1] Single Integrated Air Picture (SIAP) Metrics Implementation, Votruba et al, 29-10-2001

--- a/stonesoup/metricgenerator/tracktotruthmetrics.py
+++ b/stonesoup/metricgenerator/tracktotruthmetrics.py
@@ -235,7 +235,7 @@ class SIAPMetrics(MetricGenerator):
         ----------
         manager: MetricManager
             Containing the data to be used
-        ground_truths: set or list of :class:`~.GroundTruthPath` or :class:`~.Track objects
+        ground_truths: set or list of :class:`~.GroundTruthPath` or :class:`~.Track` objects
             Containing the groundtruth or track data to be used
         timestamp: datetime.datetime
             Timestamp at which to compute the value

--- a/stonesoup/metricgenerator/tracktotruthmetrics.py
+++ b/stonesoup/metricgenerator/tracktotruthmetrics.py
@@ -36,7 +36,8 @@ class SIAPMetrics(MetricGenerator):
         * Rate of track number changes (R): SIAP continuity measure. Rate of number of track
           changes per truth. The output is in the range :math:`0:\infty`, with a target score of 0.
         * Longest track Segment (LS): SIAP continuity measure. Proportion of longest associated
-          track segment per truth. The output is in the range :math:`0:1`, with a target score of 1.
+          track segment per truth. The output is in the range :math:`0:1`, with a target score of
+          1.
 
     Reference
         [1] Single Integrated Air Picture (SIAP) Metrics Implementation, Votruba et al, 29-10-2001
@@ -46,10 +47,12 @@ class SIAPMetrics(MetricGenerator):
         doc="Distance measure used in calculating position accuracy scores.")
     velocity_measure: Measure = Property(
         doc="Distance measure used in calculating velocity accuracy scores.")
-    generator_name: str = Property(doc="Unique identifier to use when accessing generated metrics from MultiManager")
+    generator_name: str = Property(doc="Unique identifier to use when accessing generated metrics "
+                                       "from MultiManager")
     tracks_key: str = Property(doc='Key to access set of tracks added to MultiManager')
-    truths_key: str = Property(doc="Key to access set of ground truths added to MultiManager. Or key to access a second"
-                                   " set of tracks for track-to-track metric generation")
+    truths_key: str = Property(doc="Key to access set of ground truths added to MultiManager. "
+                                   "Or key to access a second set of tracks for track-to-track "
+                                   "metric generation")
 
     def compute_metric(self, manager, **kwargs):
         r"""Compute metrics:

--- a/stonesoup/metricgenerator/uncertaintymetric.py
+++ b/stonesoup/metricgenerator/uncertaintymetric.py
@@ -71,7 +71,7 @@ class _CovarianceNormsMetric(MetricGenerator):
             List of states created by a filter
 
         Returns
-        ----------
+        -------
         metric : TimeRangeMetric
             Covering the duration that states exist for in the parameters.
             Metric.value contains a list of the summarised covariance matrix norms

--- a/stonesoup/metricgenerator/uncertaintymetric.py
+++ b/stonesoup/metricgenerator/uncertaintymetric.py
@@ -11,9 +11,11 @@ from ..base import Property
 
 class _CovarianceNormsMetric(MetricGenerator):
     _type = None
-    tracks_key: str = Property(doc='Key to access set of tracks added to MultiManager')
+    tracks_key: str = Property(doc='Key to access set of tracks added to MetricManager',
+                               default='tracks')
     generator_name: str = Property(doc="Unique identifier to use when accessing generated "
-                                       "metrics from MultiManager")
+                                       "metrics from MultiManager",
+                                   default='covNorms_generator')
 
     def compute_metric(self, manager, **kwargs):
         """Computes the metric using the data in the metric manager
@@ -115,6 +117,9 @@ class SumofCovarianceNormsMetric(_CovarianceNormsMetric):
     """
 
     _type = "Sum"
+    generator_name: str = Property(doc="Unique identifier to use when accessing generated "
+                                       "metrics from MultiManager",
+                                   default='sumCovNorms_generator')
 
     def compute_covariancenorms(self, track_states):
         """

--- a/stonesoup/metricgenerator/uncertaintymetric.py
+++ b/stonesoup/metricgenerator/uncertaintymetric.py
@@ -12,7 +12,8 @@ from ..base import Property
 class _CovarianceNormsMetric(MetricGenerator):
     _type = None
     tracks_key: str = Property(doc='Key to access set of tracks added to MultiManager')
-    generator_name: str = Property(doc="Unique identifier to use when accessing generated metrics from MultiManager")
+    generator_name: str = Property(doc="Unique identifier to use when accessing generated "
+                                       "metrics from MultiManager")
 
     def compute_metric(self, manager, **kwargs):
         """Computes the metric using the data in the metric manager

--- a/stonesoup/plotter.py
+++ b/stonesoup/plotter.py
@@ -764,7 +764,11 @@ class MetricPlotter(ABC):
             legend_dict = {}
 
             # generate colour map for lines to be plotted
-            colour_map = iter(plt.cm.rainbow(np.linspace(0, 1, len(metrics_to_plot.keys()))))
+            if 'color' not in metrics_kwargs.keys():
+                colour_map = iter(plt.cm.rainbow(np.linspace(0, 1, len(metrics_to_plot.keys()))))
+            else:
+                colour_map = iter(metrics_kwargs['color'])
+                metrics_kwargs.pop('color')
 
             for generator in metrics_to_plot.keys():
                 for metric in metrics_to_plot[generator].keys():  # can change to a try except block with key error
@@ -811,7 +815,7 @@ class MetricPlotter(ABC):
                       **metrics_kwargs)
 
             # Generate legend
-            metric_handle = Line2D([], [], linestyle=metrics_kwargs['linestyle'])
+            metric_handle = Line2D([], [], linestyle=metrics_kwargs['linestyle'], color=metrics_kwargs['color'])
             axis.legend(handles=[metric_handle],
                         labels=[metric.split(' at times')[0]])
 

--- a/stonesoup/plotter.py
+++ b/stonesoup/plotter.py
@@ -670,7 +670,8 @@ class MetricPlotter(ABC):
                                   "Mean of Covariance Norms Metric"
                                   ]
 
-    def plot_metrics(self, metrics, generator_names=None, metric_names=None, combine_plots=True, **kwargs):
+    def plot_metrics(self, metrics, generator_names=None, metric_names=None,
+                     combine_plots=True, **kwargs):
         """Plots metrics
 
         Plots each plottable metric passed in to :attr:`metrics` across a series of subplots
@@ -708,7 +709,8 @@ class MetricPlotter(ABC):
         if metric_names is not None:
             for metric_name in metric_names:
                 if metric_name not in self.plottable_metrics:
-                    warnings.warn(f"{metric_name} is not a plottable metric and will not be plotted")
+                    warnings.warn(f"{metric_name} "
+                                  f"is not a plottable metric and will not be plotted")
         else:
             metric_names = self.extract_metric_types(metrics)
 
@@ -725,11 +727,14 @@ class MetricPlotter(ABC):
 
         for generator_name in generator_names:
             for metric_name in metric_names:
-                if metric_name in metrics[generator_name].keys() and metric_name in self.plottable_metrics:
+                if metric_name in metrics[generator_name].keys() and \
+                        metric_name in self.plottable_metrics:
                     if generator_name not in metrics_dict.keys():
-                        metrics_dict[generator_name] = {metric_name: metrics[generator_name][metric_name]}
+                        metrics_dict[generator_name] = \
+                            {metric_name: metrics[generator_name][metric_name]}
                     else:
-                        metrics_dict[generator_name][metric_name] = metrics[generator_name][metric_name]
+                        metrics_dict[generator_name][metric_name] = \
+                            metrics[generator_name][metric_name]
 
         return metrics_dict
 
@@ -784,7 +789,7 @@ class MetricPlotter(ABC):
             colour_map_copy = iter(colour_map.copy())
 
             for generator in metrics_to_plot.keys():
-                for metric in metrics_to_plot[generator].keys():  # can change to a try except block with key error
+                for metric in metrics_to_plot[generator].keys():
                     if metric == metric_type:
                         colour = next(colour_map_copy)
                         metric_values = metrics_to_plot[generator][metric].value
@@ -793,7 +798,8 @@ class MetricPlotter(ABC):
                                                  color=colour,
                                                  **metrics_kwargs))
 
-                        metric_handle = Line2D([], [], linestyle=metrics_kwargs['linestyle'], color=colour)
+                        metric_handle = Line2D([], [], linestyle=metrics_kwargs['linestyle'],
+                                               color=colour)
                         legend_dict[generator] = metric_handle
 
             # Generate legend
@@ -801,10 +807,12 @@ class MetricPlotter(ABC):
                                        labels=legend_dict.keys()))
 
             y_label = metric_type.split(' at times')[0]
-            artists.extend(axis.set(title=metric_type.split(' at times')[0], xlabel="Time", ylabel=y_label))
+            artists.extend(axis.set(title=metric_type.split(' at times')[0],
+                                    xlabel="Time", ylabel=y_label))
 
     def plot_separately(self, metrics_to_plot, metrics_kwargs):
-        metrics_kwargs['color'] = metrics_kwargs['color'] if 'color' in metrics_kwargs.keys() else 'blue'
+        metrics_kwargs['color'] = metrics_kwargs['color'] if \
+            'color' in metrics_kwargs.keys() else 'blue'
 
         # determine how many plots required - equal to number of metrics within the generators
         number_of_subplots = self.count_subplots(metrics_to_plot, False)
@@ -830,7 +838,8 @@ class MetricPlotter(ABC):
                       **metrics_kwargs)
 
             # Generate legend
-            metric_handle = Line2D([], [], linestyle=metrics_kwargs['linestyle'], color=metrics_kwargs['color'])
+            metric_handle = Line2D([], [], linestyle=metrics_kwargs['linestyle'],
+                                   color=metrics_kwargs['color'])
             axis.legend(handles=[metric_handle],
                         labels=[metric.split(' at times')[0]])
 

--- a/stonesoup/plotter.py
+++ b/stonesoup/plotter.py
@@ -808,8 +808,8 @@ class MetricPlotter(ABC):
 
     def combine_plots(self, metrics_to_plot, metrics_kwargs):
         """
-        Generates one subplot for each different metric type and plots metrics of the same type on same subplot.
-        Metrics are plotted over time.
+        Generates one subplot for each different metric type and plots metrics of the same
+        type on same subplot. Metrics are plotted over time.
 
         Parameters
         ----------
@@ -872,7 +872,8 @@ class MetricPlotter(ABC):
 
     def plot_separately(self, metrics_to_plot, metrics_kwargs):
         """
-        Generates one subplot for each different individual metric and plots metric values over time.
+        Generates one subplot for each different individual metric and plots metric
+        values over time.
 
         Parameters
         ----------

--- a/stonesoup/plotter.py
+++ b/stonesoup/plotter.py
@@ -919,6 +919,37 @@ class MetricPlotter(ABC):
             axis.legend(handles=[metric_handle],
                         labels=[metric.split(' at times')[0]])
 
+    def set_fig_title(self, title):
+        """
+        Set title for the figure.
+
+        Parameters
+        ----------
+        title: str
+            Figure title text.
+
+        Returns
+        -------
+        Text instance of figure title.
+        """
+        self.fig.suptitle(t=title)
+
+    def set_ax_title(self, titles):
+        """
+        Set axis titles for each axis in figure.
+
+        Parameters
+        ----------
+        titles: list of str
+            List of strings for title text for each axis.
+
+        Returns
+        -------
+        Text instance of axis titles.
+        """
+        for axis, title in zip(self.axes, titles):
+            axis.set(title=title)
+
 
 class Plotterly(_Plotter):
     """Plotting class for building graphs of Stone Soup simulations using plotly

--- a/stonesoup/plotter.py
+++ b/stonesoup/plotter.py
@@ -704,7 +704,9 @@ class MetricPlotter(ABC):
                              "SIAP ID Completeness at times",
                              "SIAP ID Correctness at times",
                              "SIAP ID Ambiguity at times",
-                             "PCRB Metrics"
+                             "PCRB Metrics",
+                             "Sum of Covariance Norms Metric",
+                             "Mean of Covariance Norms Metric"
                              ]
 
         metrics_dict = dict()
@@ -788,6 +790,8 @@ class MetricPlotter(ABC):
             artists.extend(axis.set(title=metric_type.split(' at times')[0], xlabel="Time", ylabel=y_label))
 
     def plot_separately(self, metrics_to_plot, metrics_kwargs):
+        metrics_kwargs['color'] = metrics_kwargs['color'] if 'color' in metrics_kwargs.keys() else 'blue'
+
         # determine how many plots required - equal to number of metrics within the generators
         number_of_subplots = self.count_subplots(metrics_to_plot, False)
 
@@ -799,7 +803,7 @@ class MetricPlotter(ABC):
         all_metrics = {}
         for generator in metrics_to_plot.keys():
             for metric in list(metrics_to_plot[generator].keys()):
-                all_metrics[f'{generator}_{metric}'] = metrics_to_plot[generator][metric]
+                all_metrics[f'{generator}: {metric}'] = metrics_to_plot[generator][metric]
 
         axes = axes if isinstance(axes, Iterable) else [axes]
 

--- a/stonesoup/plotter.py
+++ b/stonesoup/plotter.py
@@ -682,10 +682,7 @@ class MetricPlotter(ABC):
         metrics_kwargs = dict(linestyle="-")
         metrics_kwargs.update(kwargs)
 
-        if generator_names is None:
-            generator_names = list(metrics.keys())
-        else:
-            generator_names = list(generator_names)
+        generator_names = list(metrics.keys()) if generator_names is None else list(generator_names)
 
         metrics_to_plot = self.extract_plottable_metrics(metrics, generator_names)
 
@@ -750,11 +747,11 @@ class MetricPlotter(ABC):
         # determine how many plots required - equal to number of metric types
         number_of_subplots = self.count_subplots(metrics_to_plot, True)
 
-        # initialise each plot
+        # initialise each subplot
         fig, axes = plt.subplots(number_of_subplots, figsize=(10, 6*number_of_subplots))
         fig.subplots_adjust(hspace=0.3)
 
-        # extract data for each plot and plot it
+        # extract data for each subplot and plot it
         metric_types = self.extract_metric_types(metrics_to_plot)
 
         axes = axes if isinstance(axes, Iterable) else [axes]


### PR DESCRIPTION
- Have replaced SimpleManager metric manager with new MultiManager class so this will be a breaking change. 
- MultiManager can take multiple metric generators of the same type and multiple sets of the same type to generate metrics. 
- All metrics that take in track and truth can now also take in 2 tracks.
- Additional functionality added to MultiManager through new methods to help easier extraction of metrics and insights.
- New MetricPlotter class created to make plotting metrics easier.

Update:
- Have added SimpleManager metric manager back in to avert breaking change. It should operate in the same way as before.
