### PR TITLE
Bernoulli Particle Filter

### DIFF
--- a/stonesoup/predictor/particle.py
+++ b/stonesoup/predictor/particle.py
@@ -315,11 +315,7 @@ class BernoulliParticlePredictor(ParticlePredictor):
 
         untransitioned_state = Prediction.from_state(
             new_particle_state,
-            state_vector=new_particle_state.state_vector,
-            existence_probability=new_particle_state.existence_probability,
             parent=prior,
-            particle_list=None,
-            timestamp=new_particle_state.timestamp,
         )
 
         # Predict particles using the transition model

--- a/stonesoup/predictor/particle.py
+++ b/stonesoup/predictor/particle.py
@@ -350,24 +350,24 @@ class BernoulliParticlePredictor(ParticlePredictor):
                              + self.survival_probability * existence_prior
         return existence_estimate
 
-    def predict_weights(self, prior_existence, predicted_existence, surv_part_size, prior_weights,
-                        nbirth_particles):
+    def predict_log_weights(self, prior_existence, predicted_existence, surv_part_size,
+                            prior_log_weights):
 
         # Weight prediction function currently assumes that the chosen importance density is the
         # transition density. This will need to change if implementing a different importance
         # density or incorporating visibility information
 
-        surv_weights = (self.survival_probability*prior_existence)/predicted_existence \
-            * prior_weights[:surv_part_size]
+        surv_weights = np.log((self.survival_probability*prior_existence)/predicted_existence) \
+            + prior_log_weights[:surv_part_size]
 
-        birth_weights = (self.birth_probability*(1-prior_existence))/predicted_existence \
-            * prior_weights[nbirth_particles:]
-        predicted_weights = np.concatenate((surv_weights, birth_weights))
+        birth_weights = np.log((self.birth_probability*(1-prior_existence))/predicted_existence) \
+            + prior_log_weights[surv_part_size:]
+        predicted_log_weights = np.concatenate((surv_weights, birth_weights))
 
         # Normalise weights
-        predicted_weights = predicted_weights / np.sum(predicted_weights)
+        predicted_log_weights -= logsumexp(predicted_log_weights)
 
-        return predicted_weights
+        return predicted_log_weights
 
     @staticmethod
     def get_detections(prior):

--- a/stonesoup/predictor/particle.py
+++ b/stonesoup/predictor/particle.py
@@ -247,17 +247,18 @@ class BernoulliParticlePredictor(ParticlePredictor):
     """Bernoulli Particle Filter Predictor class
 
     An implementation of a particle filter predictor utilising the Bernoulli
-    filter formulation that estimates the spatial distribution of a target and
-    estimates its existence, as described in [1]_.
+    filter formulation that estimates the spatial distribution of a single
+    target and estimates its existence, as described in [2]_.
 
     This should be used in conjunction with the
     :class:`~.BernoulliParticleUpdater`.
 
     References
     ----------
-    .. [1] Ristic, Branko & Vo, Ba-Toung & Vo, Ba-Ngu & Farina, Alfonso, A
-    Tutorial on Bernoulli Filters: Theory, Implementation and Applications,
-    2013, IEEE Transactions on Signal Processing, 61(13), 3406-3430."""
+    .. [2] Ristic, Branko & Vo, Ba-Toung & Vo, Ba-Ngu & Farina, Alfonso, A
+       Tutorial on Bernoulli Filters: Theory, Implementation and Applications,
+       2013, IEEE Transactions on Signal Processing, 61(13), 3406-3430.
+    """
 
     birth_probability: float = Property(
         default=0.01,

--- a/stonesoup/predictor/particle.py
+++ b/stonesoup/predictor/particle.py
@@ -309,10 +309,9 @@ class BernoulliParticlePredictor(ParticlePredictor):
         new_particle_state.state_vector = StateVectors(np.concatenate(
             (new_particle_state.state_vector, birth_part), axis=1))
         # Extend weights to match length of state_vector
-        new_weight_vector = np.concatenate(
-            (new_particle_state.weight, np.array([Probability(1/nbirth_particles)]
-                                                 * nbirth_particles)))
-        new_particle_state.weight = new_weight_vector/sum(new_weight_vector)
+        new_log_weight_vector = np.concatenate(
+            (new_particle_state.log_weight, np.full(nbirth_particles, np.log(1/nbirth_particles))))
+        new_particle_state.log_weight = new_log_weight_vector - logsumexp(new_log_weight_vector)
 
         untransitioned_state = Prediction.from_state(
             new_particle_state,

--- a/stonesoup/predictor/particle.py
+++ b/stonesoup/predictor/particle.py
@@ -15,7 +15,6 @@ from ..types.state import GaussianState
 from ..sampler import Sampler
 
 from ..types.array import StateVectors
-from ..types.numeric import Probability
 
 
 class ParticlePredictor(Predictor):

--- a/stonesoup/predictor/particle.py
+++ b/stonesoup/predictor/particle.py
@@ -2,6 +2,7 @@ import copy
 from typing import Sequence
 
 import numpy as np
+from scipy.special import logsumexp
 from ordered_set import OrderedSet
 
 from .base import Predictor

--- a/stonesoup/predictor/particle.py
+++ b/stonesoup/predictor/particle.py
@@ -330,18 +330,18 @@ class BernoulliParticlePredictor(ParticlePredictor):
         predicted_existence = self.estimate_existence(
             new_particle_state.existence_probability)
 
-        predicted_weights = self.predict_weights(new_particle_state.existence_probability,
-                                                 predicted_existence, nsurv_particles,
-                                                 new_particle_state.weight, nbirth_particles)
-        new_particle_state.weight = predicted_weights
+        predicted_log_weights = self.predict_log_weights(
+            new_particle_state.existence_probability,
+            predicted_existence, nsurv_particles,
+            new_particle_state.log_weight)
 
         # Create the prediction output
         new_particle_state = Prediction.from_state(
             new_particle_state,
             state_vector=new_state_vector,
+            log_weight=predicted_log_weights,
             existence_probability=predicted_existence,
             parent=untransitioned_state,
-            particle_list=None,
             timestamp=timestamp,
         )
         return new_particle_state

--- a/stonesoup/predictor/tests/test_particle.py
+++ b/stonesoup/predictor/tests/test_particle.py
@@ -161,7 +161,7 @@ def test_bernoulli_particle_no_detection():
     # check that the existence estimate is correct
     assert prediction.existence_probability == eval_existence
     # check that the weight prediction is correct
-    assert all(eval_weight == prediction.weight)
+    assert np.allclose(eval_weight, prediction.weight.astype(np.float_))
     # check that the weights are normalised
     assert np.around(float(np.sum(prediction.weight)), decimals=1) == 1
 

--- a/stonesoup/predictor/tests/test_particle.py
+++ b/stonesoup/predictor/tests/test_particle.py
@@ -13,8 +13,8 @@ from ...types.update import BernoulliParticleStateUpdate
 from ...types.state import ParticleState, BernoulliParticleState
 from ...models.measurement.linear import LinearGaussian
 from ...types.detection import Detection
-from ...sampler.particle import ParticleSampler, GaussianDetectionParticleSampler
-from ...sampler.detection import DetectionSampler
+from ...sampler.particle import ParticleSampler
+from ...sampler.detection import SwitchingDetectionSampler, GaussianDetectionParticleSampler
 from ...functions import gm_sample
 from ...types.hypothesis import SingleHypothesis
 from ...types.multihypothesis import MultipleHypothesis
@@ -113,7 +113,8 @@ def test_bernoulli_particle_no_detection():
                                              'size': (nbirth_parts, 2)},
                                      ndim_state=2)
     detection_sampler = GaussianDetectionParticleSampler(nbirth_parts)
-    sampler = DetectionSampler(detection_sampler=detection_sampler, backup_sampler=backup_sampler)
+    sampler = SwitchingDetectionSampler(detection_sampler=detection_sampler,
+                                        backup_sampler=backup_sampler)
 
     np.random.seed(random_seed)
     birth_samples = np.random.uniform(np.array([0, 10]), np.array([30, 30]), (nbirth_parts, 2))
@@ -212,15 +213,16 @@ def test_bernoulli_particle_detection():
                                              'high': np.array([30, 30]),
                                              'size': (nbirth_parts, 2)},
                                      ndim_state=2)
-    sampler = DetectionSampler(detection_sampler=detection_sampler, backup_sampler=backup_sampler)
+    sampler = SwitchingDetectionSampler(detection_sampler=detection_sampler,
+                                        backup_sampler=backup_sampler)
 
     np.random.seed(random_seed)
     birth_samples = gm_sample([np.array([detections[0].state_vector[0], 0]),
                               np.array([detections[1].state_vector[0], 0]),
                               np.array([detections[2].state_vector[0], 0])],
-                              [np.diag([detections[0].measurement_model.noise_covar[0], 0]),
-                              np.diag([detections[1].measurement_model.noise_covar[0], 0]),
-                              np.diag([detections[2].measurement_model.noise_covar[0], 0])],
+                              [np.diag([detections[0].measurement_model.noise_covar[0, 0], 0]),
+                              np.diag([detections[1].measurement_model.noise_covar[0, 0], 0]),
+                              np.diag([detections[2].measurement_model.noise_covar[0, 0], 0])],
                               nbirth_parts,
                               np.array([1/3]*3))
 

--- a/stonesoup/predictor/tests/test_particle.py
+++ b/stonesoup/predictor/tests/test_particle.py
@@ -1,14 +1,23 @@
 import datetime
+import copy
 
 import numpy as np
 import pytest
 
 from ...models.transition.linear import ConstantVelocity
 from ...predictor.particle import (
-    ParticlePredictor, ParticleFlowKalmanPredictor)
+    ParticlePredictor, ParticleFlowKalmanPredictor, BernoulliParticlePredictor)
 from ...types.particle import Particle
-from ...types.prediction import ParticleStatePrediction
-from ...types.state import ParticleState
+from ...types.prediction import ParticleStatePrediction, BernoulliParticleStatePrediction
+from ...types.update import BernoulliParticleStateUpdate
+from ...types.state import ParticleState, BernoulliParticleState
+from ...models.measurement.linear import LinearGaussian
+from ...types.detection import Detection
+from ...sampler.particle import ParticleSampler, GaussianDetectionParticleSampler
+from ...sampler.detection import DetectionSampler
+from ...functions import gm_sample
+from ...types.hypothesis import SingleHypothesis
+from ...types.multihypothesis import MultipleHypothesis
 
 
 @pytest.mark.parametrize(
@@ -65,3 +74,198 @@ def test_particle(predictor_class):
     assert np.all([eval_prediction.state_vector[:, i] ==
                    prediction.state_vector[:, i] for i in range(9)])
     assert np.all([prediction.weight[i] == 1 / 9 for i in range(9)])
+
+
+def test_bernoulli_particle_no_detection():
+    # Initialise transition model
+    cv = ConstantVelocity(noise_diff_coeff=0)
+
+    # Define time related variables
+    timestamp = datetime.datetime.now()
+    timediff = 2
+    new_timestamp = timestamp+datetime.timedelta(seconds=timediff)
+    time_interval = new_timestamp - timestamp
+
+    random_seed = 1990
+    nbirth_parts = 9
+    prior_particles = [Particle(np.array([[10], [10]]), 1 / 9),
+                       Particle(np.array([[10], [20]]), 1 / 9),
+                       Particle(np.array([[10], [30]]), 1 / 9),
+                       Particle(np.array([[20], [10]]), 1 / 9),
+                       Particle(np.array([[20], [20]]), 1 / 9),
+                       Particle(np.array([[20], [30]]), 1 / 9),
+                       Particle(np.array([[30], [10]]), 1 / 9),
+                       Particle(np.array([[30], [20]]), 1 / 9),
+                       Particle(np.array([[30], [30]]), 1 / 9)]
+
+    existence_prob = 0.5
+    birth_prob = 0.01
+    survival_prob = 0.98
+
+    prior = BernoulliParticleState(None,
+                                   particle_list=prior_particles,
+                                   existence_probability=existence_prob,
+                                   timestamp=timestamp)
+
+    backup_sampler = ParticleSampler(distribution_func=np.random.uniform,
+                                     params={'low': np.array([0, 10]),
+                                             'high': np.array([30, 30]),
+                                             'size': (nbirth_parts, 2)},
+                                     ndim_state=2)
+    detection_sampler = GaussianDetectionParticleSampler(nbirth_parts)
+    sampler = DetectionSampler(detection_sampler=detection_sampler, backup_sampler=backup_sampler)
+
+    np.random.seed(random_seed)
+    birth_samples = np.random.uniform(np.array([0, 10]), np.array([30, 30]), (nbirth_parts, 2))
+
+    eval_prior = copy.copy(prior)
+    eval_prior.state_vector = np.concatenate((eval_prior.state_vector,
+                                             birth_samples.T),
+                                             axis=1)
+    eval_prior.weight = np.array([1/18]*18)
+
+    eval_prediction = [Particle(cv.matrix(
+        timestamp=new_timestamp,
+        time_interval=time_interval) @ particle.state_vector,
+        weight=1/18) for particle in eval_prior]
+
+    eval_prediction = BernoulliParticleStatePrediction(None,
+                                                       timestamp=new_timestamp,
+                                                       particle_list=eval_prediction)
+
+    eval_existence = birth_prob * (1 - existence_prob) + survival_prob * existence_prob
+
+    eval_weight = eval_prior.weight
+
+    eval_weight[:9] = survival_prob*existence_prob/eval_existence * eval_weight[:9]
+    eval_weight[9:] = birth_prob*(1-existence_prob)/eval_existence * eval_weight[9:]
+    eval_weight = eval_weight/np.sum(eval_weight)
+
+    np.random.seed(random_seed)
+    predictor = BernoulliParticlePredictor(transition_model=cv,
+                                           birth_sampler=sampler,
+                                           birth_probability=birth_prob,
+                                           survival_probability=survival_prob)
+
+    prediction = predictor.predict(prior, timestamp=new_timestamp)
+
+    # check that the correct number of particles are output
+    assert len(prediction) == len(eval_prediction)
+    # check that the prior is correct
+    assert np.allclose(eval_prior.state_vector, prediction.parent.state_vector)
+    # check that the prediction is correct
+    assert np.allclose(eval_prediction.state_vector, prediction.state_vector)
+    # check timestamp
+    assert prediction.timestamp == new_timestamp
+    # check that the existence estimate is correct
+    assert prediction.existence_probability == eval_existence
+    # check that the weight prediction is correct
+    assert all(eval_weight == prediction.weight)
+    # check that the weights are normalised
+    assert np.around(float(np.sum(prediction.weight)), decimals=1) == 1
+
+
+def test_bernoulli_particle_detection():
+    # Initialise transition model
+    cv = ConstantVelocity(noise_diff_coeff=0)
+    lg = LinearGaussian(ndim_state=2,
+                        mapping=(0,),
+                        noise_covar=np.array([[1]]))
+
+    # Define time related variables
+    timestamp = datetime.datetime.now()
+    timediff = 2
+    new_timestamp = timestamp+datetime.timedelta(seconds=timediff)
+    time_interval = new_timestamp - timestamp
+
+    random_seed = 1990
+    nbirth_parts = 9
+    prior_particles = [Particle(np.array([[10], [10]]), 1 / 9),
+                       Particle(np.array([[10], [20]]), 1 / 9),
+                       Particle(np.array([[10], [30]]), 1 / 9),
+                       Particle(np.array([[20], [10]]), 1 / 9),
+                       Particle(np.array([[20], [20]]), 1 / 9),
+                       Particle(np.array([[20], [30]]), 1 / 9),
+                       Particle(np.array([[30], [10]]), 1 / 9),
+                       Particle(np.array([[30], [20]]), 1 / 9),
+                       Particle(np.array([[30], [30]]), 1 / 9)]
+
+    detections = [Detection(np.array([5]), timestamp, measurement_model=lg),
+                  Detection(np.array([7]), timestamp, measurement_model=lg),
+                  Detection(np.array([15]), timestamp, measurement_model=lg)]
+
+    existence_prob = 0.5
+    birth_prob = 0.01
+    survival_prob = 0.98
+
+    hypotheses = MultipleHypothesis([SingleHypothesis(None, detection)
+                                     for detection in detections])
+    prior = BernoulliParticleStateUpdate(None,
+                                         particle_list=prior_particles,
+                                         existence_probability=existence_prob,
+                                         timestamp=timestamp,
+                                         hypothesis=hypotheses)
+
+    detection_sampler = GaussianDetectionParticleSampler(nbirth_parts)
+    backup_sampler = ParticleSampler(distribution_func=np.random.uniform,
+                                     params={'low': np.array([0, 10]),
+                                             'high': np.array([30, 30]),
+                                             'size': (nbirth_parts, 2)},
+                                     ndim_state=2)
+    sampler = DetectionSampler(detection_sampler=detection_sampler, backup_sampler=backup_sampler)
+
+    np.random.seed(random_seed)
+    birth_samples = gm_sample([np.array([detections[0].state_vector[0], 0]),
+                              np.array([detections[1].state_vector[0], 0]),
+                              np.array([detections[2].state_vector[0], 0])],
+                              [np.diag([detections[0].measurement_model.noise_covar[0], 0]),
+                              np.diag([detections[1].measurement_model.noise_covar[0], 0]),
+                              np.diag([detections[2].measurement_model.noise_covar[0], 0])],
+                              nbirth_parts,
+                              np.array([1/3]*3))
+
+    eval_prior = copy.copy(prior)
+    eval_prior.state_vector = np.concatenate((eval_prior.state_vector,
+                                             birth_samples),
+                                             axis=1)
+    eval_prior.weight = np.array([1/18]*18)
+
+    eval_prediction = [Particle(cv.matrix(
+        timestamp=new_timestamp,
+        time_interval=time_interval) @ particle.state_vector,
+        weight=1/18) for particle in eval_prior]
+
+    eval_prediction = BernoulliParticleStatePrediction(None,
+                                                       timestamp=new_timestamp,
+                                                       particle_list=eval_prediction)
+
+    eval_existence = birth_prob * (1 - existence_prob) + survival_prob * existence_prob
+
+    eval_weight = eval_prior.weight
+
+    eval_weight[:9] = survival_prob*existence_prob/eval_existence * eval_weight[:9]
+    eval_weight[9:] = birth_prob*(1-existence_prob)/eval_existence * eval_weight[9:]
+    eval_weight = eval_weight/np.sum(eval_weight)
+
+    predictor = BernoulliParticlePredictor(transition_model=cv,
+                                           birth_sampler=sampler,
+                                           birth_probability=birth_prob,
+                                           survival_probability=survival_prob)
+
+    np.random.seed(random_seed)
+    prediction = predictor.predict(prior, timestamp=new_timestamp)
+
+    # check that the correct number of particles are output
+    assert len(prediction) == len(eval_prediction)
+    # check that the prior is correct
+    assert np.allclose(eval_prior.state_vector, prediction.parent.state_vector)
+    # check that the prediction is correct
+    assert np.allclose(eval_prediction.state_vector, prediction.state_vector)
+    # check timestamp
+    assert prediction.timestamp == new_timestamp
+    # check that the existence estimate is correct
+    assert prediction.existence_probability == eval_existence
+    # check that the weight prediction is correct
+    assert all(eval_weight == prediction.weight)
+    # check that the weights are normalised
+    assert np.around(float(np.sum(prediction.weight)), decimals=1) == 1

--- a/stonesoup/predictor/tests/test_particle.py
+++ b/stonesoup/predictor/tests/test_particle.py
@@ -268,6 +268,6 @@ def test_bernoulli_particle_detection():
     # check that the existence estimate is correct
     assert prediction.existence_probability == eval_existence
     # check that the weight prediction is correct
-    assert all(eval_weight == prediction.weight)
+    assert np.allclose(eval_weight, prediction.weight.astype(np.float_))
     # check that the weights are normalised
     assert np.around(float(np.sum(prediction.weight)), decimals=1) == 1

--- a/stonesoup/types/orbitalstate.py
+++ b/stonesoup/types/orbitalstate.py
@@ -76,7 +76,7 @@ class Orbital(Type):
         :math:`\omega` the argument of periapsis (radian), and
         :math:`\theta` the true anomaly (radian).
 
-        Coordinates = "TLE" (Two-Line Elements [1]_), initiates using input vector
+        Coordinates = "TLE" (Two-Line Elements [2]_), initiates using input vector
 
             .. math::
 
@@ -90,11 +90,11 @@ class Orbital(Type):
         :math:`n` the mean motion (radian / [time]).
 
         This can also be constructed by passing `state_vector=None` and using the metadata. In this
-        instance the metadata must conform to the TLE standard format [2]_ and be included in the
+        instance the metadata must conform to the TLE standard format [3]_ and be included in the
         metadata dictionary as 'line_1' and 'line_2'. In this latter instance any timestamp passed
         as an argument will be overwritten by the epoch of the TLE.
 
-        Coordinates = "Equinoctial" (equinoctial elements [2]_),
+        Coordinates = "Equinoctial" (equinoctial elements [3]_),
 
             .. math::
 
@@ -110,11 +110,11 @@ class Orbital(Type):
 
     References
     ----------
-    .. [1] NASA, Definition of Two-line Element Set Coordinate System, [spaceflight.nasa.gov](
+    .. [2] NASA, Definition of Two-line Element Set Coordinate System, [spaceflight.nasa.gov](
            https://spaceflight.nasa.gov/realdata/sightings/SSapplications/Post/JavaSSOP/
            SSOP_Help/tle_def.html)
 
-    .. [2] Broucke, R. A. & Cefola, P. J. 1972, Celestial Mechanics, Volume 5, Issue 3, pp. 303-310
+    .. [3] Broucke, R. A. & Cefola, P. J. 1972, Celestial Mechanics, Volume 5, Issue 3, pp. 303-310
 
     """
 
@@ -652,7 +652,7 @@ class Orbital(Type):
         :math:`i` the inclination (radian) :math:`\Omega` is the longitude of the ascending node
         (radian), :math:`e` is the orbital eccentricity (unitless), :math:`\omega` the argument of
         periapsis (radian), :math:`M_0` the mean anomaly (radian) :math:`n` the mean motion
-        (rad/[time]). [2]_"""
+        (rad/[time]). [3]_"""
         return StateVectors([np.array(self.inclination).flatten(),
                              np.array(self.longitude_ascending_node).flatten(),
                              self.eccentricity.flatten(),
@@ -666,7 +666,7 @@ class Orbital(Type):
         semi-major axis ([length]), :math:`h` and :math:`k` are the horizontal and vertical
         components of the eccentricity respectively (unitless), :math:`p` and :math:`q` are the
         horizontal and vertical components of the inclination respectively (radian) and
-        :math:`\lambda` is the mean longitude (radian). [3]_
+        :math:`\lambda` is the mean longitude (radian). [4]_
         """
         return StateVectors([self.semimajor_axis.flatten(),
                              self.equinoctial_h.flatten(),
@@ -736,10 +736,11 @@ class OrbitalState(Orbital, State):
     Vector" (as traditionally understood in orbital mechanics), where :math:`\mathbf{r}` is the
     (3D) Cartesian position in the primary-centered inertial frame, while :math:`\dot{\mathbf{r}}`
     is the corresponding velocity vector. All methods provided by :class:`~.Orbital` are available.
-    Formulae for conversions are generally found in, or derived from [3]_.
+    Formulae for conversions are generally found in, or derived from [4]_.
+
     References
     ----------
-    .. [3] Curtis, H.D. 2010, Orbital Mechanics for Engineering Students (3rd Ed), Elsevier
+    .. [4] Curtis, H.D. 2010, Orbital Mechanics for Engineering Students (3rd Ed), Elsevier
            Aerospace Engineering Series
     """
 

--- a/stonesoup/types/prediction.py
+++ b/stonesoup/types/prediction.py
@@ -6,7 +6,8 @@ from .base import Type
 from .state import (State, GaussianState, EnsembleState,
                     ParticleState, MultiModelParticleState, RaoBlackwellisedParticleState,
                     SqrtGaussianState, InformationState, TaggedWeightedGaussianState,
-                    WeightedGaussianState, CategoricalState, ASDGaussianState)
+                    WeightedGaussianState, CategoricalState, ASDGaussianState,
+                    BernoulliParticleState)
 from ..base import Property
 from ..models.transition.base import TransitionModel
 from ..types.state import CreatableFromState, CompositeState
@@ -148,6 +149,12 @@ class RaoBlackwellisedParticleStatePrediction(Prediction, RaoBlackwellisedPartic
 
     This is a simple Rao Blackwellised Particle state prediction object.
     """
+
+
+class BernoulliParticleStatePrediction(Prediction, BernoulliParticleState):
+    """BernoulliParticleStatePrediction type
+
+    This is a simple Bernoulli Particle state prediction object"""
 
 
 class EnsembleStatePrediction(Prediction, EnsembleState):

--- a/stonesoup/types/state.py
+++ b/stonesoup/types/state.py
@@ -862,6 +862,59 @@ class RaoBlackwellisedParticleState(ParticleState):
         return result
 
 
+class BernoulliParticleState(ParticleState):
+    """Bernoulli Particle State type
+
+    This is a particle state object that describes the target as a distribution of particles and an
+    estimated existence probability according to the Bernoulli Particle Filter [1]_.
+
+    References
+    ----------
+    .. [1] Ristic, Branko & Vo, Ba-Toung & Vo, Ba-Ngu & Farina, Alfonso, A
+    tutorial on Bernoulli filters: theory, implementation and applications,
+    2013, IEEE Transactions on Signal Processing, 61(13), 3406-3430.
+
+    """
+
+    existence_probability: Probability = Property(
+        default=None,
+        doc="Target existence probability estimate"
+    )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def __getitem__(self, item):
+        if self.parent is not None:
+            parent = self.parent[item]
+        else:
+            parent = None
+
+        if self.weight is not None:
+            weight = self.weight[item]
+        else:
+            weight = None
+
+        if self.existence_probability is not None:
+            existence_probability = self.existence_probability
+        else:
+            existence_probability = None
+
+        if isinstance(item, int):
+            result = Particle(state_vector=self.state_vector[:, item],
+                              weight=weight,
+                              parent=parent)
+        else:
+            # Allow for Prediction/Update sub-types
+            result = type(self).from_state(
+                self,
+                state_vector=self.state_vector[:, item],
+                parent=parent,
+                particle_list=None,
+                existence_probability=existence_probability)
+        return result
+
+
 class EnsembleState(State):
     r"""Ensemble State type
 

--- a/stonesoup/types/state.py
+++ b/stonesoup/types/state.py
@@ -865,14 +865,15 @@ class RaoBlackwellisedParticleState(ParticleState):
 class BernoulliParticleState(ParticleState):
     """Bernoulli Particle State type
 
-    This is a particle state object that describes the target as a distribution of particles and an
-    estimated existence probability according to the Bernoulli Particle Filter [1]_.
+    This is a particle state object that describes the target
+    as a distribution of particles and an estimated existence
+    probability according to the Bernoulli particle filter [1]_.
 
     References
     ----------
     .. [1] Ristic, Branko & Vo, Ba-Toung & Vo, Ba-Ngu & Farina, Alfonso, A
-    tutorial on Bernoulli filters: theory, implementation and applications,
-    2013, IEEE Transactions on Signal Processing, 61(13), 3406-3430.
+       Tutorial on Bernoulli Filters: Theory, Implementation and Applications,
+       2013, IEEE Transactions on Signal Processing, 61(13), 3406-3430.
 
     """
 

--- a/stonesoup/types/tests/test_state.py
+++ b/stonesoup/types/tests/test_state.py
@@ -14,7 +14,7 @@ from ..state import CreatableFromState
 from ..state import State, GaussianState, ParticleState, EnsembleState, \
     StateMutableSequence, WeightedGaussianState, SqrtGaussianState, CategoricalState, \
     CompositeState, InformationState, ASDState, ASDGaussianState, ASDWeightedGaussianState, \
-    MultiModelParticleState, RaoBlackwellisedParticleState
+    MultiModelParticleState, RaoBlackwellisedParticleState, BernoulliParticleState
 from ...base import Property
 
 
@@ -243,7 +243,8 @@ def test_particlestate():
 
 
 @pytest.mark.parametrize(
-    'particle_class', [ParticleState, MultiModelParticleState, RaoBlackwellisedParticleState])
+    'particle_class', [ParticleState, MultiModelParticleState, RaoBlackwellisedParticleState,
+                       BernoulliParticleState])
 def test_particle_get_item(particle_class):
     with pytest.raises(TypeError):
         particle_class()

--- a/stonesoup/types/track.py
+++ b/stonesoup/types/track.py
@@ -135,7 +135,7 @@ class Track(StateMutableSequence):
                                 and hypothesis.measurement.metadata is not None:
                             self.metadata.update(hypothesis.measurement.metadata)
                 except TypeError:
-                    self.metadata.update({})
+                    pass
             else:
                 hypothesis = state.hypothesis
                 if hypothesis and hypothesis.measurement.metadata is not None:

--- a/stonesoup/types/track.py
+++ b/stonesoup/types/track.py
@@ -129,10 +129,13 @@ class Track(StateMutableSequence):
                 # from all hypotheses are retained, but more likely
                 # hypotheses will over-write the metadata set by less likely
                 # ones.
-                for hypothesis in sorted(state.hypothesis, reverse=True):
-                    if hypothesis \
-                            and hypothesis.measurement.metadata is not None:
-                        self.metadata.update(hypothesis.measurement.metadata)
+                try:
+                    for hypothesis in sorted(state.hypothesis, reverse=True):
+                        if hypothesis \
+                                and hypothesis.measurement.metadata is not None:
+                            self.metadata.update(hypothesis.measurement.metadata)
+                except TypeError:
+                    self.metadata.update({})
             else:
                 hypothesis = state.hypothesis
                 if hypothesis and hypothesis.measurement.metadata is not None:

--- a/stonesoup/types/update.py
+++ b/stonesoup/types/update.py
@@ -7,7 +7,7 @@ from .state import CreatableFromState, CompositeState
 from .state import State, GaussianState, ParticleState, EnsembleState, \
     SqrtGaussianState, InformationState, CategoricalState, ASDGaussianState, \
     WeightedGaussianState, TaggedWeightedGaussianState, \
-    MultiModelParticleState, RaoBlackwellisedParticleState
+    MultiModelParticleState, RaoBlackwellisedParticleState, BernoulliParticleState
 from ..base import Property
 
 
@@ -96,6 +96,13 @@ class RaoBlackwellisedParticleStateUpdate(Update, RaoBlackwellisedParticleState)
     """RaoBlackwellisedStateUpdate type
 
     This is a simple Rao Blackwellised Particle state update object.
+    """
+
+
+class BernoulliParticleStateUpdate(Update, BernoulliParticleState):
+    """BernoulliStateUpdate type
+
+    This is a simple Bernoulli Particle state update object.
     """
 
 

--- a/stonesoup/updater/particle.py
+++ b/stonesoup/updater/particle.py
@@ -420,15 +420,13 @@ class BernoulliParticleUpdater(ParticleUpdater):
             detections = [single_hypothesis.measurement
                           for single_hypothesis in hypotheses.single_hypotheses]
 
-            if self.measurement_model is None:
-                self.measurement_model = next(iter(detections)).measurement_model
-
             # Evaluate measurement likelihood and approximate integrals
             meas_likelihood = []
             delta_part2 = []
             detection_probability = np.array([self.detection_probability]*len(prediction))
 
             for detection in detections:
+                measurement_model = detection.measurement_model or self.measurement_model
                 meas_likelihood.append(
                     np.exp(
                         self.measurement_model.logpdf(

--- a/stonesoup/updater/particle.py
+++ b/stonesoup/updater/particle.py
@@ -354,12 +354,22 @@ class RaoBlackwellisedParticleUpdater(MultiModelParticleUpdater):
 
 
 class BernoulliParticleUpdater(ParticleUpdater):
-    """Particle updater for the Bernoulli Particle Filter. Both
-    target state and probability of existence are updated based
-    on measurements. Due to the nature of the Bernoulli Particle
-    Filter prediction process, resampling is required at every
+    """Bernoulli Particle Filter Updater class
+
+    An implementation of a particle filter updater utilising the
+    Bernoulli filter formulation that estimates the spatial distribution
+    of a single target and estimates its existence, as described in [1]_.
+
+    Due to the nature of the Bernoulli particle
+    filter prediction process, resampling is required at every
     time step to reduce the number of particles back down to the
     desired size.
+
+    References
+    ----------
+    .. [1] Ristic, Branko & Vo, Ba-Toung & Vo, Ba-Ngu & Farina, Alfonso, A
+       Tutorial on Bernoulli Filters: Theory, Implementation and Applications,
+       2013, IEEE Transactions on Signal Processing, 61(13), 3406-3430.
     """
 
     birth_probability: float = Property(

--- a/stonesoup/updater/particle.py
+++ b/stonesoup/updater/particle.py
@@ -428,7 +428,6 @@ class BernoulliParticleUpdater(ParticleUpdater):
 
             for detection in detections:
                 measurement_model = detection.measurement_model or self.measurement_model
-                measurement_model = detection.measurement_model or self.measurement_model
                 log_meas_likelihood.append(measurement_model.logpdf(detection, updated_state))
                 delta_part2.append(self._log_space_product(
                     log_detection_probability,

--- a/stonesoup/updater/particle.py
+++ b/stonesoup/updater/particle.py
@@ -435,15 +435,15 @@ class BernoulliParticleUpdater(ParticleUpdater):
                     - np.log(self.clutter_rate * self.clutter_distribution)
                     + updated_state.log_weight))
 
-                delta = \
-                    np.exp(self._log_space_product(log_detection_probability,
-                                                   updated_state.log_weight)) \
-                    - np.exp(logsumexp(delta_part2))
+            delta = \
+                np.exp(self._log_space_product(log_detection_probability,
+                                               updated_state.log_weight)) \
+                - np.exp(logsumexp(delta_part2))
 
-                updated_state.existence_probability = \
-                    (1 - delta) \
-                    / (1 - updated_state.existence_probability * delta) \
-                    * updated_state.existence_probability
+            updated_state.existence_probability = \
+                (1 - delta) \
+                / (1 - updated_state.existence_probability * delta) \
+                * updated_state.existence_probability
 
             updated_state.log_weight = \
                 np.logaddexp(log_detection_probability

--- a/stonesoup/updater/tests/test_particle.py
+++ b/stonesoup/updater/tests/test_particle.py
@@ -10,12 +10,19 @@ from ...resampler.particle import SystematicResampler
 from ...types.array import StateVectors
 from ...types.detection import Detection
 from ...types.hypothesis import SingleHypothesis
+from ...types.multihypothesis import MultipleHypothesis
 from ...types.particle import Particle
 from ...types.prediction import (
     ParticleStatePrediction, ParticleMeasurementPrediction)
 from ...updater.particle import (
     ParticleUpdater, GromovFlowParticleUpdater,
-    GromovFlowKalmanParticleUpdater)
+    GromovFlowKalmanParticleUpdater, BernoulliParticleUpdater)
+from ...predictor.particle import BernoulliParticlePredictor
+from ...models.transition.linear import ConstantVelocity
+from ...types.update import BernoulliParticleStateUpdate
+from ...regulariser.particle import MCMCRegulariser
+from ...sampler.particle import ParticleSampler, GaussianDetectionParticleSampler
+from ...sampler.detection import DetectionSampler
 
 
 @pytest.fixture(params=(
@@ -69,3 +76,96 @@ def test_particle(updater):
     assert updated_state.hypothesis.prediction == prediction
     assert updated_state.hypothesis.measurement == measurement
     assert np.allclose(updated_state.mean, StateVectors([[20.0], [20.0]]), rtol=2e-2)
+
+
+def test_bernoulli_particle():
+    timestamp = datetime.datetime.now()
+    timediff = 2
+    new_timestamp = timestamp + datetime.timedelta(seconds=timediff)
+
+    lg = LinearGaussian(ndim_state=2,
+                        mapping=(0,),
+                        noise_covar=np.array([[1]]))
+
+    cv = ConstantVelocity(noise_diff_coeff=0)
+
+    detection_probability = 0.9
+    prior_particles = [Particle([[10], [10]], 1 / 9),
+                       Particle([[10], [20]], 1 / 9),
+                       Particle([[10], [30]], 1 / 9),
+                       Particle([[20], [10]], 1 / 9),
+                       Particle([[20], [20]], 1 / 9),
+                       Particle([[20], [30]], 1 / 9),
+                       Particle([[30], [10]], 1 / 9),
+                       Particle([[30], [20]], 1 / 9),
+                       Particle([[30], [30]], 1 / 9)]
+
+    prior_detections = [Detection(np.array([15]), timestamp, measurement_model=lg),
+                        Detection(np.array([40]), timestamp, measurement_model=lg),
+                        Detection(np.array([5]), timestamp, measurement_model=lg)]
+
+    prior_hypotheses = MultipleHypothesis([SingleHypothesis(None, detection)
+                                          for detection in prior_detections])
+
+    detections = [Detection(np.array([35]), new_timestamp, measurement_model=lg),
+                  Detection(np.array([10]), new_timestamp, measurement_model=lg),
+                  Detection(np.array([20]), new_timestamp, measurement_model=lg),
+                  Detection(np.array([50]), new_timestamp, measurement_model=lg)]
+
+    existence_prob = 0.5
+    birth_prob = 0.01
+    survival_prob = 0.98
+    nbirth_parts = 9
+
+    prior = BernoulliParticleStateUpdate(None,
+                                         particle_list=prior_particles,
+                                         existence_probability=existence_prob,
+                                         timestamp=timestamp,
+                                         hypothesis=prior_hypotheses)
+
+    detection_sampler = GaussianDetectionParticleSampler(nbirth_parts)
+    backup_sampler = ParticleSampler(distribution_func=np.random.uniform,
+                                     params={'low': np.array([0, 10]),
+                                             'high': np.array([30, 30]),
+                                             'size': (nbirth_parts, 2)},
+                                     ndim_state=2)
+    sampler = DetectionSampler(detection_sampler=detection_sampler, backup_sampler=backup_sampler)
+
+    predictor = BernoulliParticlePredictor(transition_model=cv,
+                                           birth_sampler=sampler,
+                                           birth_probability=birth_prob,
+                                           survival_probability=survival_prob)
+
+    prediction = predictor.predict(prior, timestamp=new_timestamp)
+    resampler = SystematicResampler()
+    regulariser = MCMCRegulariser()
+
+    updater = BernoulliParticleUpdater(measurement_model=None,
+                                       resampler=resampler,
+                                       regulariser=regulariser,
+                                       birth_probability=birth_prob,
+                                       survival_probability=survival_prob,
+                                       clutter_rate=2,
+                                       clutter_distribution=1/10,
+                                       nsurv_particles=9,
+                                       detection_probability=detection_probability)
+
+    hypotheses = MultipleHypothesis(
+        [SingleHypothesis(prediction, detection) for detection in detections])
+
+    update = updater.update(hypotheses)
+
+    # Can't check the exact particles due to regularisation and resampling but can check the
+    # updater is returning the correct information.
+
+    # Check that the correct number of particles are returned.
+    assert len(update) == 9
+    # Check the timestamp.
+    assert update.timestamp == new_timestamp
+    # Check the weights
+    assert np.around(float(np.sum(update.weight)), decimals=1) == 1.0
+    # Check that the detections are output in the update state
+    assert update.hypothesis is not None
+    assert update.hypothesis == hypotheses
+    # Check that the existence probability is returned
+    assert update.existence_probability is not None

--- a/stonesoup/updater/tests/test_particle.py
+++ b/stonesoup/updater/tests/test_particle.py
@@ -21,8 +21,8 @@ from ...predictor.particle import BernoulliParticlePredictor
 from ...models.transition.linear import ConstantVelocity
 from ...types.update import BernoulliParticleStateUpdate
 from ...regulariser.particle import MCMCRegulariser
-from ...sampler.particle import ParticleSampler, GaussianDetectionParticleSampler
-from ...sampler.detection import DetectionSampler
+from ...sampler.particle import ParticleSampler
+from ...sampler.detection import SwitchingDetectionSampler, GaussianDetectionParticleSampler
 
 
 @pytest.fixture(params=(
@@ -129,7 +129,8 @@ def test_bernoulli_particle():
                                              'high': np.array([30, 30]),
                                              'size': (nbirth_parts, 2)},
                                      ndim_state=2)
-    sampler = DetectionSampler(detection_sampler=detection_sampler, backup_sampler=backup_sampler)
+    sampler = SwitchingDetectionSampler(detection_sampler=detection_sampler,
+                                        backup_sampler=backup_sampler)
 
     predictor = BernoulliParticlePredictor(transition_model=cv,
                                            birth_sampler=sampler,


### PR DESCRIPTION
Introduced the `BernoulliParticlePredictor` and `BernoulliParticleUpdater` as a new joint detection and tracking single target tracker. The `BernoulliParticleState` has been introduced, as well as the prediction and update variants. 

The `Regulariser` has been added as an optional property to the `ParticleUpdater` class but is only implemented in the `BernoulliParticleUpdater` currently. 

A try and except statement has been added to the `_update_metadata_from_state` method in the Track class to skip the incorporation of metadata from detections into the track object when `MultipleHypothesis` is populated with unordered `SingleHypothesis`.

Here is a gist to demonstrate the use of the tracker: https://gist.github.com/timothy-glover/ae9d5a748604d6bbc12391ff03357af7.