### PR TITLE
Add LRU cache to Updater predict measurement methods

### DIFF
--- a/stonesoup/updater/alphabeta.py
+++ b/stonesoup/updater/alphabeta.py
@@ -1,3 +1,5 @@
+from functools import lru_cache
+
 import numpy as np
 
 from ..base import Property
@@ -63,6 +65,7 @@ class AlphaBetaUpdater(Updater):
                                                   "assume that the velocity elements interleave "
                                                   "the position elements in the state vector.")
 
+    @lru_cache()
     def predict_measurement(self, prediction, measurement_model=None, **kwargs):
         """Return the predicted measurement
 

--- a/stonesoup/updater/chernoff.py
+++ b/stonesoup/updater/chernoff.py
@@ -1,3 +1,5 @@
+from functools import lru_cache
+
 import numpy as np
 
 from ..base import Property
@@ -78,6 +80,7 @@ class ChernoffUpdater(Updater):
         default=0.5,
         doc="A weighting parameter in the range :math:`(0,1]`")
 
+    @lru_cache()
     def predict_measurement(self, predicted_state, measurement_model=None,  **kwargs):
         r"""
         This function predicts the measurement of a state in situations where measurements consist

--- a/stonesoup/updater/ensemble.py
+++ b/stonesoup/updater/ensemble.py
@@ -1,3 +1,5 @@
+from functools import lru_cache
+
 import numpy as np
 import scipy
 
@@ -104,6 +106,7 @@ class EnsembleUpdater(KalmanUpdater):
                 predicted_state, measurement_model=measurement_model, **kwargs)
         return hypothesis
 
+    @lru_cache()
     def predict_measurement(self, predicted_state, measurement_model=None,
                             **kwargs):
         r"""Predict the measurement implied by the predicted state mean

--- a/stonesoup/updater/kalman.py
+++ b/stonesoup/updater/kalman.py
@@ -188,6 +188,7 @@ class KalmanUpdater(Updater):
 
         return post_cov.view(CovarianceMatrix), kalman_gain
 
+    @lru_cache()
     def predict_measurement(self, predicted_state, measurement_model=None,
                             **kwargs):
         r"""Predict the measurement implied by the predicted state mean


### PR DESCRIPTION
The cache for predict measurement was remove mistakenly in #794 and also missing on other methods. This offers notable performance improvement.