### PR TITLE
Fix edge case with mod elevation for 2π

### DIFF
--- a/stonesoup/functions/__init__.py
+++ b/stonesoup/functions/__init__.py
@@ -627,9 +627,10 @@ def mod_elevation(x):
         x = np.pi - x
     elif N == 3:
         x = x - 2.0 * np.pi
-    elif N == 4:  # will only occur on occasions when first operation 
-                  # ('x = ..') returns 2pi to floating point limit. 
-        x = 0.0 
+    elif N == 4:
+        # will only occur on occasions when first operation ('x = ..') returns 2pi to floating
+        # point limit.
+        x = 0.0
     return x
 
 

--- a/stonesoup/functions/__init__.py
+++ b/stonesoup/functions/__init__.py
@@ -627,6 +627,9 @@ def mod_elevation(x):
         x = np.pi - x
     elif N == 3:
         x = x - 2.0 * np.pi
+    elif N == 4:  # will only occur on occasions when first operation 
+                  # ('x = ..') returns 2pi to floating point limit. 
+        x = 0.0 
     return x
 
 


### PR DESCRIPTION
Added option to mod_elevation to counter edge case where elevation returns == 2*pi, rather than 0.