### PR TITLE
Regulariser amendment and implementation in ParticleUpdater

### DIFF
--- a/stonesoup/predictor/particle.py
+++ b/stonesoup/predictor/particle.py
@@ -341,6 +341,7 @@ class BernoulliParticlePredictor(ParticlePredictor):
             existence_probability=predicted_existence,
             parent=untransitioned_state,
             timestamp=timestamp,
+            transition_model=self.transition_model
         )
         return new_particle_state
 

--- a/stonesoup/predictor/particle.py
+++ b/stonesoup/predictor/particle.py
@@ -54,6 +54,7 @@ class ParticlePredictor(Predictor):
             **kwargs)
 
         return Prediction.from_state(prior,
+                                     parent=prior,
                                      state_vector=new_state_vector,
                                      timestamp=timestamp,
                                      transition_model=self.transition_model)

--- a/stonesoup/regulariser/tests/test_particle.py
+++ b/stonesoup/regulariser/tests/test_particle.py
@@ -9,13 +9,29 @@ from ...types.prediction import ParticleStatePrediction, ParticleMeasurementPred
 from ...models.measurement.linear import LinearGaussian
 from ...models.transition.linear import CombinedLinearGaussianTransitionModel, ConstantVelocity
 from ...types.detection import Detection
-from ...types.update import ParticleStateUpdate
+from ...types.update import Update, ParticleStateUpdate
 from ..particle import MCMCRegulariser
 
 
-def test_regulariser():
-    transition_model = CombinedLinearGaussianTransitionModel([ConstantVelocity([0.05])])
-
+@pytest.mark.parametrize(
+    "transition_model, model_flag",
+    [
+        (
+            CombinedLinearGaussianTransitionModel([ConstantVelocity([0.05])]),  # transition_model
+            False,  # model_flag
+        ),
+        (
+            CombinedLinearGaussianTransitionModel([ConstantVelocity([0.05])]),  # transition_model
+            True,  # model_flag
+        ),
+        (
+            None,  # transition_model
+            False,  # model_flag
+        )
+    ],
+    ids=["with_transition_model_init", "without_transition_model_init", "no_transition_model"]
+)
+def test_regulariser(transition_model, model_flag):
     particles = ParticleState(state_vector=None, particle_list=[Particle(np.array([[10], [10]]),
                                                                          1 / 9),
                                                                 Particle(np.array([[10], [20]]),
@@ -36,25 +52,38 @@ def test_regulariser():
                                                                          1 / 9),
                                                                 ])
     timestamp = datetime.datetime.now()
-    new_state_vector = transition_model.function(particles,
-                                                 noise=True,
-                                                 time_interval=datetime.timedelta(seconds=1))
+    if transition_model is not None:
+        new_state_vector = transition_model.function(particles,
+                                                     noise=True,
+                                                     time_interval=datetime.timedelta(seconds=1))
+    else:
+        new_state_vector = particles.state_vector
+
     prediction = ParticleStatePrediction(new_state_vector,
                                          timestamp=timestamp,
                                          transition_model=transition_model)
-    meas_pred = ParticleMeasurementPrediction(prediction, timestamp=timestamp)
+
     measurement_model = LinearGaussian(ndim_state=2, mapping=(0, 1), noise_covar=np.eye(2))
-    measurement = [Detection(state_vector=np.array([[5], [7]]),
-                             timestamp=timestamp, measurement_model=measurement_model)]
-    state_update = ParticleStateUpdate(None, SingleHypothesis(prediction=prediction,
-                                                              measurement=measurement,
-                                                              measurement_prediction=meas_pred),
-                                       particle_list=particles.particle_list,
-                                       timestamp=timestamp+datetime.timedelta(seconds=1))
-    regulariser = MCMCRegulariser(transition_model=transition_model)
+    measurement = Detection(state_vector=np.array([[5], [7]]),
+                            timestamp=timestamp, measurement_model=measurement_model)
+    hypothesis = SingleHypothesis(prediction=prediction,
+                                  measurement=measurement,
+                                  measurement_prediction=None)
+
+    state_update = Update.from_state(state=prediction,
+                                     hypothesis=hypothesis,
+                                     timestamp=timestamp+datetime.timedelta(seconds=1))
+    # A PredictedParticleState is used here as the point at which the regulariser is implemented
+    # in the updater is before the updated state has taken the updated state type.
+    state_update.weight = np.array([1/6, 5/48, 5/48, 5/48, 5/48, 5/48, 5/48, 5/48, 5/48])
+
+    if model_flag:
+        regulariser = MCMCRegulariser()
+    else:
+        regulariser = MCMCRegulariser(transition_model=transition_model)
 
     # state check
-    new_particles = regulariser.regularise(prediction, state_update, measurement)
+    new_particles = regulariser.regularise(prediction, state_update)
     # Check the shape of the new state vector
     assert new_particles.state_vector.shape == state_update.state_vector.shape
     # Check weights are unchanged
@@ -65,13 +94,11 @@ def test_regulariser():
     # list check3
     with pytest.raises(TypeError) as e:
         new_particles = regulariser.regularise(particles.particle_list,
-                                               state_update,
-                                               measurement)
+                                               state_update)
     assert "Only ParticleState type is supported!" in str(e.value)
     with pytest.raises(Exception) as e:
         new_particles = regulariser.regularise(particles,
-                                               state_update.particle_list,
-                                               measurement)
+                                               state_update.particle_list)
     assert "Only ParticleState type is supported!" in str(e.value)
 
 
@@ -103,9 +130,9 @@ def test_no_measurement():
                                                               measurement=None,
                                                               measurement_prediction=meas_pred),
                                        particle_list=particles.particle_list, timestamp=timestamp)
-    regulariser = MCMCRegulariser(transition_model=None)
+    regulariser = MCMCRegulariser()
 
-    new_particles = regulariser.regularise(particles, state_update, detections=None)
+    new_particles = regulariser.regularise(particles, state_update)
 
     # Check the shape of the new state vector
     assert new_particles.state_vector.shape == state_update.state_vector.shape

--- a/stonesoup/types/multihypothesis.py
+++ b/stonesoup/types/multihypothesis.py
@@ -1,5 +1,5 @@
-from collections.abc import Sized, Iterable, Container
-from typing import Sequence
+from collections.abc import Sequence
+import typing
 
 from .detection import MissedDetection
 from .numeric import Probability
@@ -10,13 +10,13 @@ from ..types.hypothesis import SingleHypothesis, CompositeHypothesis
 from ..types.prediction import Prediction
 
 
-class MultipleHypothesis(Type, Sized, Iterable, Container):
+class MultipleHypothesis(Type, Sequence):
     """Multiple Hypothesis base type
 
     A Multiple Hypothesis is a container to store a collection of hypotheses.
     """
 
-    single_hypotheses: Sequence[SingleHypothesis] = Property(
+    single_hypotheses: typing.Sequence[SingleHypothesis] = Property(
         default=None,
         doc="The initial list of :class:`~.SingleHypothesis`. Default `None` "
             "which initialises with empty list.")
@@ -119,7 +119,7 @@ class MultipleHypothesis(Type, Sized, Iterable, Container):
         return None
 
 
-class MultipleCompositeHypothesis(Type, Sized, Iterable, Container):
+class MultipleCompositeHypothesis(Type, Sequence):
     """Multiple composite hypothesis type
 
     A Multiple Composite Hypothesis is a container to store a collection of composite hypotheses.
@@ -128,7 +128,7 @@ class MultipleCompositeHypothesis(Type, Sized, Iterable, Container):
     redefined.
     """
 
-    single_hypotheses: Sequence[CompositeHypothesis] = Property(
+    single_hypotheses: typing.Sequence[CompositeHypothesis] = Property(
         default=None,
         doc="The initial list of :class:`~.CompositeHypothesis`. Default `None` which initialises "
             "with empty list.")

--- a/stonesoup/updater/particle.py
+++ b/stonesoup/updater/particle.py
@@ -65,6 +65,12 @@ class ParticleUpdater(Updater):
         if self.resampler is not None:
             predicted_state = self.resampler.resample(predicted_state)
 
+        if self.regulariser is not None:
+            predicted_state = self.regulariser.regularise(predicted_state.parent,
+                                                          predicted_state,
+                                                          [hypothesis.measurement],
+                                                          hypothesis.prediction.transition_model)
+
         return Update.from_state(
             state=hypothesis.prediction,
             state_vector=predicted_state.state_vector,
@@ -465,7 +471,8 @@ class BernoulliParticleUpdater(ParticleUpdater):
             if self.regulariser is not None:
                 regularised_parts = self.regulariser.regularise(updated_state.parent,
                                                                 updated_state,
-                                                                detections)
+                                                                detections,
+                                                                prediction.transition_model)
                 updated_state.state_vector = regularised_parts.state_vector
 
         return Update.from_state(

--- a/stonesoup/updater/particle.py
+++ b/stonesoup/updater/particle.py
@@ -68,8 +68,7 @@ class ParticleUpdater(Updater):
         if self.regulariser is not None:
             predicted_state = self.regulariser.regularise(predicted_state.parent,
                                                           predicted_state,
-                                                          [hypothesis.measurement],
-                                                          hypothesis.prediction.transition_model)
+                                                          [hypothesis.measurement])
 
         return Update.from_state(
             state=hypothesis.prediction,
@@ -471,8 +470,7 @@ class BernoulliParticleUpdater(ParticleUpdater):
             if self.regulariser is not None:
                 regularised_parts = self.regulariser.regularise(updated_state.parent,
                                                                 updated_state,
-                                                                detections,
-                                                                prediction.transition_model)
+                                                                detections)
                 updated_state.state_vector = regularised_parts.state_vector
 
         return Update.from_state(

--- a/stonesoup/updater/particle.py
+++ b/stonesoup/updater/particle.py
@@ -46,7 +46,12 @@ class ParticleUpdater(Updater):
         : :class:`~.ParticleState`
             The state posterior
         """
-        predicted_state = copy.copy(hypothesis.prediction)
+
+        predicted_state = Update.from_state(
+            state=hypothesis.prediction,
+            hypothesis=hypothesis,
+            timestamp=hypothesis.prediction.timestamp
+        )
 
         if hypothesis.measurement.measurement_model is None:
             measurement_model = self.measurement_model
@@ -66,17 +71,11 @@ class ParticleUpdater(Updater):
             predicted_state = self.resampler.resample(predicted_state)
 
         if self.regulariser is not None:
-            predicted_state = self.regulariser.regularise(predicted_state.parent,
-                                                          predicted_state,
-                                                          [hypothesis.measurement])
+            prior = hypothesis.prediction.parent
+            predicted_state = self.regulariser.regularise(prior,
+                                                          predicted_state)
 
-        return Update.from_state(
-            state=hypothesis.prediction,
-            state_vector=predicted_state.state_vector,
-            log_weight=predicted_state.log_weight,
-            hypothesis=hypothesis,
-            timestamp=hypothesis.measurement.timestamp,
-            )
+        return predicted_state
 
     @lru_cache()
     def predict_measurement(self, state_prediction, measurement_model=None,
@@ -419,8 +418,12 @@ class BernoulliParticleUpdater(ParticleUpdater):
         # copy prediction
         prediction = hypotheses.single_hypotheses[0].prediction
 
-        updated_state = copy.copy(prediction)
-
+        # updated_state = copy.copy(prediction)
+        updated_state = Update.from_state(
+            state=prediction,
+            hypothesis=hypotheses,
+            timestamp=prediction.timestamp
+        )
         if any(hypotheses):
             detections = [single_hypothesis.measurement
                           for single_hypothesis in hypotheses.single_hypotheses]
@@ -468,16 +471,10 @@ class BernoulliParticleUpdater(ParticleUpdater):
         if any(hypotheses):
             # Regularisation
             if self.regulariser is not None:
-                regularised_parts = self.regulariser.regularise(updated_state.parent,
-                                                                updated_state,
-                                                                detections)
-                updated_state.state_vector = regularised_parts.state_vector
+                updated_state = self.regulariser.regularise(updated_state.parent,
+                                                            updated_state)
 
-        return Update.from_state(
-            updated_state,
-            timestamp=updated_state.timestamp,
-            hypothesis=hypotheses,
-        )
+        return updated_state
 
     @staticmethod
     def _log_space_product(A, B):

--- a/stonesoup/updater/tests/test_particle.py
+++ b/stonesoup/updater/tests/test_particle.py
@@ -140,7 +140,7 @@ def test_bernoulli_particle():
 
     prediction = predictor.predict(prior, timestamp=new_timestamp)
     resampler = SystematicResampler()
-    regulariser = MCMCRegulariser()
+    regulariser = MCMCRegulariser(transition_model=cv)
 
     updater = BernoulliParticleUpdater(measurement_model=None,
                                        resampler=resampler,
@@ -179,7 +179,7 @@ def test_regularised_particle():
     measurement_model = LinearGaussian(
         ndim_state=2, mapping=[0], noise_covar=np.array([[10]]))
 
-    updater = ParticleUpdater(regulariser=MCMCRegulariser(),
+    updater = ParticleUpdater(regulariser=MCMCRegulariser(transition_model=transition_model),
                               measurement_model=measurement_model)
     # Measurement model
     timestamp = datetime.datetime.now()

--- a/stonesoup/updater/tests/test_particle.py
+++ b/stonesoup/updater/tests/test_particle.py
@@ -12,13 +12,14 @@ from ...types.detection import Detection
 from ...types.hypothesis import SingleHypothesis
 from ...types.multihypothesis import MultipleHypothesis
 from ...types.particle import Particle
+from ...types.state import ParticleState
 from ...types.prediction import (
     ParticleStatePrediction, ParticleMeasurementPrediction)
 from ...updater.particle import (
     ParticleUpdater, GromovFlowParticleUpdater,
     GromovFlowKalmanParticleUpdater, BernoulliParticleUpdater)
 from ...predictor.particle import BernoulliParticlePredictor
-from ...models.transition.linear import ConstantVelocity
+from ...models.transition.linear import ConstantVelocity, CombinedLinearGaussianTransitionModel
 from ...types.update import BernoulliParticleStateUpdate
 from ...regulariser.particle import MCMCRegulariser
 from ...sampler.particle import ParticleSampler
@@ -170,3 +171,56 @@ def test_bernoulli_particle():
     assert update.hypothesis == hypotheses
     # Check that the existence probability is returned
     assert update.existence_probability is not None
+
+
+def test_regularised_particle():
+
+    transition_model = CombinedLinearGaussianTransitionModel([ConstantVelocity([0.05])])
+    measurement_model = LinearGaussian(
+        ndim_state=2, mapping=[0], noise_covar=np.array([[10]]))
+
+    updater = ParticleUpdater(regulariser=MCMCRegulariser(),
+                              measurement_model=measurement_model)
+    # Measurement model
+    timestamp = datetime.datetime.now()
+    particles = [Particle([[10], [10]], 1 / 9),
+                 Particle([[10], [20]], 1 / 9),
+                 Particle([[10], [30]], 1 / 9),
+                 Particle([[20], [10]], 1 / 9),
+                 Particle([[20], [20]], 1 / 9),
+                 Particle([[20], [30]], 1 / 9),
+                 Particle([[30], [10]], 1 / 9),
+                 Particle([[30], [20]], 1 / 9),
+                 Particle([[30], [30]], 1 / 9),
+                 ]
+
+    particles = ParticleState(None, particle_list=particles, timestamp=timestamp)
+    predicted_state = transition_model.function(particles,
+                                                noise=True,
+                                                time_interval=datetime.timedelta(seconds=1))
+    prediction = ParticleStatePrediction(predicted_state,
+                                         weight=np.array([1/9]*9),
+                                         timestamp=timestamp,
+                                         transition_model=transition_model,
+                                         parent=particles)
+
+    measurement = Detection([[40.0]], timestamp=timestamp, measurement_model=measurement_model)
+    eval_measurement_prediction = ParticleMeasurementPrediction(
+        StateVectors([prediction.state_vector[0, :]]), timestamp=timestamp)
+
+    measurement_prediction = updater.predict_measurement(prediction)
+
+    assert np.all(eval_measurement_prediction.state_vector == measurement_prediction.state_vector)
+    assert measurement_prediction.timestamp == timestamp
+
+    updated_state = updater.update(SingleHypothesis(
+        prediction, measurement, measurement_prediction))
+
+    # Don't know what the particles will exactly be due to randomness so check
+    # some obvious properties
+
+    assert np.all(weight == 1 / 9 for weight in updated_state.weight)
+    assert updated_state.timestamp == timestamp
+    assert updated_state.hypothesis.measurement_prediction == measurement_prediction
+    assert updated_state.hypothesis.prediction == prediction
+    assert updated_state.hypothesis.measurement == measurement


### PR DESCRIPTION
The prior used for the `MCMCRegulariser` should be projected through time without the inclusion of noise. To do this, `transition_model` has been added as a property of the MCMCRegulariser. The transition model is used to propagate the prior particles at the beginning of the `regularise()` method. The support for lists of type `Particle` has also been dropped to allow for the calculation of the time interval in the `regularise()` method.