### PR TITLE
Change plot in Resampler Tutorial to display correct CDF

### DIFF
--- a/docs/tutorials/sampling/ResamplingTutorial.py
+++ b/docs/tutorials/sampling/ResamplingTutorial.py
@@ -298,7 +298,7 @@ plot(normalised_residual_weights)
 
 u_j = np.random.rand(2)
 
-plot(normalised_weights, u_j)
+plot(normalised_residual_weights, u_j)
 
 # %%
 #


### PR DESCRIPTION
Final plot in Resampler tutorial was displaying the CDF of full particle weights. This change makes it display the CDF of the residual weights.