### PR TITLE
Fix ellipse plot

### DIFF
--- a/stonesoup/plotter.py
+++ b/stonesoup/plotter.py
@@ -988,6 +988,7 @@ class Plotterly(_Plotter):
         rotational_matrix = np.array(((c, -s), (s, c)))
 
         points = np.array([[a * np.sin(i), b * np.cos(i)] for i in points])
+        points.append(points[0])
         points = rotational_matrix @ points.T
         return points + state.mean[mapping[:2], :]
 

--- a/stonesoup/plotter.py
+++ b/stonesoup/plotter.py
@@ -986,9 +986,8 @@ class Plotterly(_Plotter):
 
         c, s = np.cos(orient), np.sin(orient)
         rotational_matrix = np.array(((c, -s), (s, c)))
-
-        points = np.array([[a * np.sin(i), b * np.cos(i)] for i in points])
         points.append(points[0])
+        points = np.array([[a * np.sin(i), b * np.cos(i)] for i in points])
         points = rotational_matrix @ points.T
         return points + state.mean[mapping[:2], :]
 


### PR DESCRIPTION
A quick PR. Changes ellipse plotting so that the first point is appended to the end of the list of ellipse points so that, if the outline of an ellipse is plotted, the outline draws the proper shape.

Before:
<img width="494" alt="broken" src="https://github.com/dstl/Stone-Soup/assets/117291860/08ed2079-e5b3-4081-bd62-fcca3cc953c0">

After:
<img width="520" alt="fix" src="https://github.com/dstl/Stone-Soup/assets/117291860/b7397b06-400b-4559-a535-78b6a158827e">
