### PR TITLE
Fix non linear constant turn transition model

### DIFF
--- a/docs/tutorials/01_KalmanFilterTutorial.py
+++ b/docs/tutorials/01_KalmanFilterTutorial.py
@@ -273,8 +273,8 @@ plotter.fig
 # ^^^^^^^^^^^^^^^^^^^^^^^^^
 #
 # We're now ready to build a tracker. We'll use a Kalman filter as it's conceptually the simplest
-# to start with. The Kalman filter is described extensively elsewhere [#]_$^,$ [#]_, so for the
-# moment we just assert that the prediction step proceeds as:
+# to start with. The Kalman filter is described extensively elsewhere [#]_ math:`^,` [#]_,
+# so for the moment we just assert that the prediction step proceeds as:
 #
 # .. math::
 #           \mathbf{x}_{k|k-1} &= F_{k}\mathbf{x}_{k-1} + B_{k}\mathbf{u}_{k}\\

--- a/docs/tutorials/01_KalmanFilterTutorial.py
+++ b/docs/tutorials/01_KalmanFilterTutorial.py
@@ -273,7 +273,7 @@ plotter.fig
 # ^^^^^^^^^^^^^^^^^^^^^^^^^
 #
 # We're now ready to build a tracker. We'll use a Kalman filter as it's conceptually the simplest
-# to start with. The Kalman filter is described extensively elsewhere [#]_^, [#]_, so for the
+# to start with. The Kalman filter is described extensively elsewhere [#]_$^,$ [#]_, so for the
 # moment we just assert that the prediction step proceeds as:
 #
 # .. math::

--- a/docs/tutorials/01_KalmanFilterTutorial.py
+++ b/docs/tutorials/01_KalmanFilterTutorial.py
@@ -273,7 +273,7 @@ plotter.fig
 # ^^^^^^^^^^^^^^^^^^^^^^^^^
 #
 # We're now ready to build a tracker. We'll use a Kalman filter as it's conceptually the simplest
-# to start with. The Kalman filter is described extensively elsewhere [#]_ :math:`^,` [#]_,
+# to start with. The Kalman filter is described extensively elsewhere [#]_:math:`^,` [#]_,
 # so for the moment we just assert that the prediction step proceeds as:
 #
 # .. math::

--- a/docs/tutorials/01_KalmanFilterTutorial.py
+++ b/docs/tutorials/01_KalmanFilterTutorial.py
@@ -273,7 +273,7 @@ plotter.fig
 # ^^^^^^^^^^^^^^^^^^^^^^^^^
 #
 # We're now ready to build a tracker. We'll use a Kalman filter as it's conceptually the simplest
-# to start with. The Kalman filter is described extensively elsewhere [#]_, [#]_, so for the
+# to start with. The Kalman filter is described extensively elsewhere [#]_^, [#]_, so for the
 # moment we just assert that the prediction step proceeds as:
 #
 # .. math::

--- a/docs/tutorials/01_KalmanFilterTutorial.py
+++ b/docs/tutorials/01_KalmanFilterTutorial.py
@@ -303,7 +303,7 @@ plotter.fig
 # responsibility, a :class:`~.Predictor` takes a :class:`~.TransitionModel` as input and
 # an :class:`~.Updater` takes a :class:`~.MeasurementModel` as input. Note that for now we're using
 # the same models used to generate the ground truth and the simulated measurements. This won't
-# usually be possible and it's an interesting exercise to explore what happens when these
+# usually be possible, and it's an interesting exercise to explore what happens when these
 # parameters are mismatched.
 from stonesoup.predictor.kalman import KalmanPredictor
 predictor = KalmanPredictor(transition_model)

--- a/docs/tutorials/01_KalmanFilterTutorial.py
+++ b/docs/tutorials/01_KalmanFilterTutorial.py
@@ -273,7 +273,7 @@ plotter.fig
 # ^^^^^^^^^^^^^^^^^^^^^^^^^
 #
 # We're now ready to build a tracker. We'll use a Kalman filter as it's conceptually the simplest
-# to start with. The Kalman filter is described extensively elsewhere [#]_ math:`^,` [#]_,
+# to start with. The Kalman filter is described extensively elsewhere [#]_ :math:`^,` [#]_,
 # so for the moment we just assert that the prediction step proceeds as:
 #
 # .. math::

--- a/stonesoup/models/transition/nonlinear.py
+++ b/stonesoup/models/transition/nonlinear.py
@@ -67,16 +67,11 @@ class ConstantTurn(GaussianTransitionModel, TimeVariantModel):
 
         .. math::
              Q_t & = & \begin{bmatrix}
-                          \frac{dt^4q_x^2}{4} & \frac{dt^3q_x^2}{2} & \frac{dt^4q_xq_y}{4} &
-                              \frac{dt^3q_xq_y}{2} & \frac{dt^2q_xq_\omega}{2} \\
-                          \frac{dt^3q_x^2}{2} & dt^2q_x^2 & \frac{dt^3q_xq_y}{2} & dt^2q_xq_y &
-                              dt q_x q_\omega \\
-                          \frac{dt^4q_xq_y}{4} & \frac{dt^3q_xq_y}{2} & \frac{dt^4q_y^2}{4} &
-                              \frac{dt^3q_y^2}{2} & \frac{dt^2q_y q_\omega}{2} \\
-                          \frac{dt^3q_x q_y}{2} & dt^2q_xq_y & \frac{dt^3q_y^2}{2} &
-                              dt^2q_y^2 & dt q_y q_\omega \\
-                          \frac{dt^2q_xq_\omega}{2} & dtq_xq_\omega & \frac{dt^2q_yq_\omega}{2} &
-                              dt q_y q_\omega & q_\omega^2
+                          \frac{dt^3q_x^2}{3} & \frac{dt^2q_x^2}{2} & 0 & 0 & 0 \\
+                          \frac{dt^2q_x^2}{2} & dtq_x^2 & 0 & 0 & 0 \\
+                          0 & 0 & \frac{dt^3q_y^2}{3} & \frac{dt^2q_y^2}{2} & 0 \\
+                          0 & 0 & \frac{dt^2q_y^2}{2} & dtq_y^2 & 0 \\
+                          0 & 0 & 0 & 0 & q_\omega^2
                      \end{bmatrix}
     """
     linear_noise_coeffs: np.ndarray = Property(
@@ -134,7 +129,7 @@ class ConstantTurn(GaussianTransitionModel, TimeVariantModel):
 
         Q = np.array([[dt**3 / 3., dt**2 / 2.],
                       [dt**2 / 2., dt]])
-        C = block_diag(Q*q_x**2, Q*q_y**2, q**2/dt)
+        C = block_diag(Q*q_x**2, Q*q_y**2, q**2)
 
         return CovarianceMatrix(C)
 

--- a/stonesoup/models/transition/nonlinear.py
+++ b/stonesoup/models/transition/nonlinear.py
@@ -3,7 +3,7 @@ from typing import Sequence
 import numpy as np
 from scipy.linalg import block_diag
 
-from ...types.array import StateVector, StateVector
+from ...types.array import StateVector, StateVectors
 from .base import TransitionModel
 from ..base import GaussianModel, TimeVariantModel
 from ...base import Property

--- a/stonesoup/models/transition/nonlinear.py
+++ b/stonesoup/models/transition/nonlinear.py
@@ -3,7 +3,7 @@ from typing import Sequence
 import numpy as np
 from scipy.linalg import block_diag
 
-from ...types.array import StateVector, StateVectors
+from ...types.array import StateVector, StateVectors, Matrix
 from .base import TransitionModel
 from ..base import GaussianModel, TimeVariantModel
 from ...base import Property
@@ -95,7 +95,8 @@ class ConstantTurn(GaussianTransitionModel, TimeVariantModel):
         sv1 = state.state_vector
         turn_rate = sv1[4, :]
         # Avoid divide by zero in the function evaluation
-        turn_rate[turn_rate == 0.] = np.finfo(float).eps
+        if turn_rate[0] == 0:
+            turn_rate = Matrix([np.finfo(float).eps])
         dAngle = turn_rate * time_interval_sec
         cos_dAngle = np.cos(dAngle)
         sin_dAngle = np.sin(dAngle)

--- a/stonesoup/models/transition/nonlinear.py
+++ b/stonesoup/models/transition/nonlinear.py
@@ -3,7 +3,7 @@ from typing import Sequence
 import numpy as np
 from scipy.linalg import block_diag
 
-from ...types.array import StateVector, StateVectors, Matrix
+from ...types.array import StateVector, StateVector
 from .base import TransitionModel
 from ..base import GaussianModel, TimeVariantModel
 from ...base import Property
@@ -95,8 +95,9 @@ class ConstantTurn(GaussianTransitionModel, TimeVariantModel):
         sv1 = state.state_vector
         turn_rate = sv1[4, :]
         # Avoid divide by zero in the function evaluation
-        if turn_rate[0] == 0:
-            turn_rate = Matrix([np.finfo(float).eps])
+        if turn_rate.dtype != float:
+            turn_rate = turn_rate.astype(float)
+        turn_rate[turn_rate == 0.] = np.finfo(float).eps
         dAngle = turn_rate * time_interval_sec
         cos_dAngle = np.cos(dAngle)
         sin_dAngle = np.sin(dAngle)


### PR DESCRIPTION
I found a few bugs in the `ConstantTurn` transition model, which this PR aims to fix. 

1.  As detailed in #841, the documentation for `Q_t` did not match the implementation. 
2.  The bottom right term in the `Q_t` array was erroneously divided by the change in time, which would result in the noise of the turn rate being smaller for a larger change in time. I'm not really sure personally why this value is not instead **multiplied** by _dt_, but this seems to be a misunderstanding on my part and not a mistake. 
3. There was an issue where if you put in an integer turn rate of zero, you would get an error for division by zero. This is a little bit academic as it's not really the intended use for this transition model, but I thought it was worth fixing for consistency. 

I have also raised up a misbehaving comma in the first tutorial as it looked slightly messy. 