### PR TITLE
Introduce ability to constrain particle states in ParticleUpdater and MCMCRegulariser

### DIFF
--- a/stonesoup/regulariser/particle.py
+++ b/stonesoup/regulariser/particle.py
@@ -35,10 +35,12 @@ class MCMCRegulariser(Regulariser):
     constraint_func: Callable = Property(
         default=None,
         doc="Callable, user defined function for applying "
-            "constraints to particle states. This is done by reverting "
+            "constraints to particle states. This is done by reverting particles "
             "that are moved to a state outside of the defined constraints "
             "back to the state prior to the move step. Particle states that are "
-            "input are assumed to be constrained."
+            "input are assumed to be constrained. This function provides indices "
+            "of the unconstrained particles and should accept a :class:`~.ParticleState` "
+            "object and return an array-like object of logical indices. "
     )
 
     def regularise(self, prior, posterior):

--- a/stonesoup/regulariser/tests/test_particle.py
+++ b/stonesoup/regulariser/tests/test_particle.py
@@ -13,25 +13,39 @@ from ...types.update import Update, ParticleStateUpdate
 from ..particle import MCMCRegulariser
 
 
+def dummy_constraint_function(particles):
+    part_indx = particles.state_vector[1, :] > 20
+    return part_indx
+
+
 @pytest.mark.parametrize(
-    "transition_model, model_flag",
+    "transition_model, model_flag, constraint_func",
     [
         (
             CombinedLinearGaussianTransitionModel([ConstantVelocity([0.05])]),  # transition_model
             False,  # model_flag
+            None  # constraint_function
         ),
         (
             CombinedLinearGaussianTransitionModel([ConstantVelocity([0.05])]),  # transition_model
             True,  # model_flag
+            None  # constraint_function
         ),
         (
             None,  # transition_model
             False,  # model_flag
+            None  # constraint_function
+        ),
+        (
+            CombinedLinearGaussianTransitionModel([ConstantVelocity([0.05])]),  # transition_model
+            False,  # model_flag
+            dummy_constraint_function # constraint_function
         )
     ],
-    ids=["with_transition_model_init", "without_transition_model_init", "no_transition_model"]
+    ids=["with_transition_model_init", "without_transition_model_init", "no_transition_model",
+         "with_constraint_function"]
 )
-def test_regulariser(transition_model, model_flag):
+def test_regulariser(transition_model, model_flag, constraint_func):
     particles = ParticleState(state_vector=None, particle_list=[Particle(np.array([[10], [10]]),
                                                                          1 / 9),
                                                                 Particle(np.array([[10], [20]]),
@@ -78,9 +92,10 @@ def test_regulariser(transition_model, model_flag):
     state_update.weight = np.array([1/6, 5/48, 5/48, 5/48, 5/48, 5/48, 5/48, 5/48, 5/48])
 
     if model_flag:
-        regulariser = MCMCRegulariser()
+        regulariser = MCMCRegulariser(constraint_func=constraint_func)
     else:
-        regulariser = MCMCRegulariser(transition_model=transition_model)
+        regulariser = MCMCRegulariser(transition_model=transition_model,
+                                      constraint_func=constraint_func)
 
     # state check
     new_particles = regulariser.regularise(prediction, state_update)
@@ -90,6 +105,10 @@ def test_regulariser(transition_model, model_flag):
     assert any(new_particles.weight == state_update.weight)
     # Check that the timestamp is the same
     assert new_particles.timestamp == state_update.timestamp
+    # Check that moved particles have been reverted back to original states if constrained
+    if constraint_func is not None:
+        indx = constraint_func(prediction)  # likely unconstrained particles
+        assert np.all(new_particles.state_vector[:, indx] == prediction.state_vector[:, indx])
 
     # list check3
     with pytest.raises(TypeError) as e:

--- a/stonesoup/regulariser/tests/test_particle.py
+++ b/stonesoup/regulariser/tests/test_particle.py
@@ -39,7 +39,7 @@ def dummy_constraint_function(particles):
         (
             CombinedLinearGaussianTransitionModel([ConstantVelocity([0.05])]),  # transition_model
             False,  # model_flag
-            dummy_constraint_function # constraint_function
+            dummy_constraint_function  # constraint_function
         )
     ],
     ids=["with_transition_model_init", "without_transition_model_init", "no_transition_model",

--- a/stonesoup/updater/particle.py
+++ b/stonesoup/updater/particle.py
@@ -1,5 +1,6 @@
 import copy
 from functools import lru_cache
+from typing import Callable
 
 import numpy as np
 from scipy.linalg import inv
@@ -32,6 +33,15 @@ class ParticleUpdater(Updater):
     regulariser: Regulariser = Property(default=None, doc="Regulariser to prevent particle "
                                                           "impoverishment")
 
+    constraint_func: Callable = Property(
+        default=None,
+        doc="Callable, user defined function for applying "
+            "constraints to the states. This is done by setting the weights "
+            "of particles to 0 for particles that are not correctly constrained. "
+            "The function should accept a :class:`~.ParticleState` object and "
+            "return a np.ndarray of logical indices. "
+    )
+
     def update(self, hypothesis, **kwargs):
         """Particle Filter update step
 
@@ -60,6 +70,11 @@ class ParticleUpdater(Updater):
 
         new_weight = predicted_state.log_weight + measurement_model.logpdf(
             hypothesis.measurement, predicted_state, **kwargs)
+
+        # Apply constraints if defined
+        if self.constraint_func is not None:
+            part_indx = self.constraint_func(predicted_state)
+            new_weight[part_indx] = -1*np.inf
 
         # Normalise the weights
         new_weight -= logsumexp(new_weight)

--- a/stonesoup/updater/particle.py
+++ b/stonesoup/updater/particle.py
@@ -38,8 +38,9 @@ class ParticleUpdater(Updater):
         doc="Callable, user defined function for applying "
             "constraints to the states. This is done by setting the weights "
             "of particles to 0 for particles that are not correctly constrained. "
-            "The function should accept a :class:`~.ParticleState` object and "
-            "return a np.ndarray of logical indices. "
+            "This function provides indices of the unconstrained particles and "
+            "should accept a :class:`~.ParticleState` object and return an array-like "
+            "object of logical indices. "
     )
 
     def update(self, hypothesis, **kwargs):


### PR DESCRIPTION
This PR has introduced the optional property `constraint_func` to `ParticleUpdater` and `MCMCRegulariser`. If defined, this is intended to enforce that particle states should not exceed certain values by modifying the associated weights, increasing the likelihood of resampling. Here the constraint function should accept a `ParticleState` type and return a logical index of particles that exceed the defined constraints. An example of this can be seen here:
https://github.com/timothy-glover/Stone-Soup/blob/7ae343e147176107a35fafa81c00c2a7d879561e/stonesoup/regulariser/tests/test_particle.py#L16-L18

A bug was also spotted in the test for the `ParticleUpdater`. The original line, seen below, was passing regardless of what the weights are. This has been replaced with a check to ensure the sum of the weights is correct. 
https://github.com/dstl/Stone-Soup/blob/f24090cc919b3b590b84f965a3884ed1293d181d/stonesoup/updater/tests/test_particle.py#L74