### PR TITLE
Introduce Kullback-Leibler Divegence measure and reward function

### DIFF
--- a/stonesoup/measures.py
+++ b/stonesoup/measures.py
@@ -1,4 +1,5 @@
 import copy
+import math
 from abc import abstractmethod
 from functools import lru_cache
 
@@ -6,7 +7,7 @@ import numpy as np
 from scipy.spatial import distance
 
 from .base import Base, Property
-from .types.state import State
+from .types.state import State, ParticleState, GaussianState
 
 
 class Measure(Base):
@@ -401,3 +402,33 @@ class ObservationAccuracy(Measure):
         mins = [min(s1, s2) for s1, s2 in zip(s1, s2)]
         maxs = [max(s1, s2) for s1, s2 in zip(s1, s2)]
         return np.sum(mins)/np.sum(maxs)
+
+class KLDivergence(Measure):
+    """  """
+
+    def __call__(self, state1, state2):
+        r"""
+        Computes the Kullback–Leibler divergence from :class:`~.State` object1 to :class: '~.State object2
+
+        Parameters
+        ----------
+        state1 : :class:`~.State`
+        state2 : :class:`~.State`
+
+        Returns
+        -------
+        float
+            Kullback–Leibler divergence from :class:`~.State` object1 to :class: '~.State object2
+
+        """
+        if isinstance(state1, ParticleState) and isinstance(state2, ParticleState):
+            if len(state1.particles) == len(state2.particles):
+                kld = 0
+                for ii in range(0, len(state1.particles)):
+                    kld += math.exp(state1.log_weight[ii])*(state1.log_weight[ii] - state2.log_weight[ii])
+            else:
+                raise ValueError('The input objects different number of particles.')
+        else:
+            raise TypeError('The inputs are possible states')
+
+        return kld

--- a/stonesoup/sensormanager/reward.py
+++ b/stonesoup/sensormanager/reward.py
@@ -10,14 +10,18 @@ from ..platform import Platform
 from ..sensor.actionable import Actionable
 from ..types.detection import TrueDetection
 from ..base import Base, Property
+from ..predictor.particle import ParticlePredictor
 from ..predictor.kalman import KalmanPredictor
 from ..updater.kalman import ExtendedKalmanUpdater
 from ..types.track import Track
 from ..types.hypothesis import SingleHypothesis
 from ..sensor.sensor import Sensor
 from ..sensor.action import Action
+from ..types.prediction import Prediction
 from ..updater.particle import ParticleUpdater
+from ..resampler.particle import SystematicResampler
 from ..types.state import State
+
 
 class RewardFunction(Base, ABC):
     """
@@ -138,43 +142,181 @@ class UncertaintyRewardFunction(RewardFunction):
         # Return value of configuration metric
         return config_metric
 
-class ExpectedKLDivergenceSTE(RewardFunction):
+
+class ExpectedKLDivergence(RewardFunction):
+    """A reward function that implements the Kullback-Leibler divergence
+    for quantifying relative information gain between actions taken by
+    a sensor or group of sensors.
+
+    From a configuration of sensors and actions, an expected measurement is
+    generated based on the predicted distribution and an action being taken.
+    An update is generated based on this measurement. The Kullback-Leibler
+    divergence is then calculated between the predicted and updated target
+    distribution that resulted from the measurement. A larger divergence
+    between these distributions equates to more information gained from
+    the action and resulting measurement from that action.
     """
 
-    """
-    updater: ParticleUpdater = Property()
+    predictor: ParticlePredictor = Property(default=None,
+                                            doc="Predictor used to predict the track to a "
+                                                "new state. This reward function is only "
+                                                "compatible with :class:`~.ParticlePredictor` "
+                                                "types.")
+    updater: ParticleUpdater = Property(default=None,
+                                        doc="Updater used to update the track to the new state. "
+                                            "This reward function is only compatible with "
+                                            ":class:`~.ParticleUpdater` types.")
+    method_sum: bool = Property(default=True, doc="Determines method of calculating reward."
+                                                  "Default calculates sum across all targets."
+                                                  "Otherwise calculates mean of all targets.")
 
-    def __init__(self,*args,**kwargs):
-        super().__init__(*args,**kwargs)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         self.KLD = KLDivergence()
+        if self.predictor is not None and not isinstance(self.predictor, ParticlePredictor):
+            raise TypeError('Only ParticlePredictor types can be used with this reward function')
+        if self.updater is not None and not isinstance(self.updater, ParticleUpdater):
+            raise TypeError('Only ParticleUpdater types can be used with this reward function')
 
-    def __call__(self, config: Mapping[Actionable, Sequence[Action]], tracks: Set[Track],
+    def __call__(self, config: Mapping[Sensor, Sequence[Action]], tracks: Set[Track],
                  metric_time: datetime.datetime, *args, **kwargs):
-        predicted_actionable = list()
+        """
+        For a given configuration of sensors and actions this reward function
+        calculates the expected Kullback-Leibler divergence of each track. It is
+        calculated between the prediction and the posterior assuming an expected update
+        based on a predicted measurement.
+
+        This requires a mapping of sensors to action(s) to be evaluated by the
+        reward function, a set of tracks at given time and the time at which
+        the actions would be carried out until.
+
+        The metric returned is the total expected Kullback-Leibler
+        divergence across all tracks.
+
+        Returns
+        -------
+        : float
+            Kullback-Leibler divergence for given configuration
+
+        """
+
+        # Reward value
+        kld = 0.
+
         memo = {}
-        # For each sensor in the configuration
+        predicted_actionables = []
+        # For each actionable in the configuration
         for actionable, actions in config.items():
-            if isinstance(actionable, Platform):
-                # print(actionable.sensors)
+            # Don't currently have an Actionable base for platforms hence either Platform or Sensor
+            if isinstance(actionable, Platform) or isinstance(actionable, Actionable):
                 predicted_actionable = copy.deepcopy(actionable, memo)
                 predicted_actionable.add_actions(actions)
                 predicted_actionable.act(metric_time)
-            # if isinstance(actionable, Actionable):
-            #     predicted_actionable.append(predicted_actionable)  # checks if its a sensor
-        sensors = predicted_actionable.sensors
-        kld = 0
-        for sensor in sensors:
-            for track in tracks:
-                prior = track[-1]
-                post = prior
-                predicted_measurement = sensor.measure({State(prior.mean)}, noise=False)
-                for measurement in predicted_measurement:
-                    if isinstance(measurement,TrueDetection):
-                        hypothesis = SingleHypothesis(prior, measurement)
-                        post = self.updater.update(hypothesis)
-                        prior = post
+                predicted_actionables.append(predicted_actionable)
 
-            kld += self.KLD(track[-1], post)
-        # print(kld)
+        # Create dictionary of predictions for the tracks in the configuration
+        predicted_tracks = set()
+        for track in tracks:
+            predicted_track = Track()
+            if self.predictor:
+                predicted_track = copy.copy(track)
+                predicted_track.append(self.predictor.predict(track[-1],
+                                                              timestamp=metric_time))
+            else:
+                predicted_track.append(Prediction.from_state(track[-1],
+                                                             timestamp=metric_time))
 
+            predicted_tracks.add(predicted_track)
+
+        for predicted_actionable_ in predicted_actionables:
+            if isinstance(predicted_actionable_, Sensor):
+                sensors = [predicted_actionable_]
+            elif isinstance(predicted_actionable_, Platform):
+                sensors = predicted_actionable_.sensors
+            # sensors = predicted_actionable_.sensors
+            for sensor in sensors:
+                # Assumes one detection per track
+
+                detections = self._generate_detections(predicted_tracks, sensor)
+
+                for predicted_track, detection_set in detections.items():
+
+                    for n, detection in enumerate(detection_set):
+
+                        # if detection:
+                        # Generate hypothesis based on prediction/previous update and detection
+                        hypothesis = SingleHypothesis(predicted_track, detection)
+
+                        # Do the update based on this hypothesis and store covariance matrix
+                        update = self.updater.update(hypothesis)
+
+                        # else:
+                        #     update = copy.copy(predicted_track[-1])
+
+                        kld += self.KLD(predicted_track[-1], update)
+
+                if self.method_sum is False and len(detections) != 0:
+
+                    kld /= len(detections)
+
+        # Return value of configuration metric
         return kld
+
+    def _generate_detections(self, predicted_tracks, sensor):
+
+        detections = {}
+        for predicted_track in predicted_tracks:
+            track_detections = set()
+            track_detections.update(sensor.measure({State(predicted_track.mean)}, noise=True))
+
+            detections.update({predicted_track: track_detections})
+
+        return detections
+
+
+class MultiUpdateExpectedKLDivergence(ExpectedKLDivergence):
+    """A reward function that implements the Kullback-Leibler divergence
+    for quantifying relative information gain between actions taken by
+    a sensor or group of sensors.
+
+    From a configuration of sensors and actions, multiple expected measurements per
+    track are generated based on the predicted distribution and an action being taken.
+    The measurements are generated by resampling the particle state down to a
+    subsample with length specified by the user. Updates are generated for each of
+    these measurements and the Kullback-Leibler divergence calculated for each
+    of them.
+    """
+
+    updates_per_track: int = Property(default=2,
+                                      doc="Number of measurements to generate from each "
+                                          "track prediction. This should be > 1.")
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.KLD = KLDivergence()
+        if self.predictor is not None and not isinstance(self.predictor, ParticlePredictor):
+            raise TypeError('Only ParticlePredictor types can be used with this reward function')
+        if self.updater is not None and not isinstance(self.updater, ParticleUpdater):
+            raise TypeError('Only ParticleUpdater types can be used with this reward function')
+        if self.updates_per_track < 2:
+            raise ValueError(f'updates_per_track = {self.updates_per_track}. This reward '
+                             f'function only accepts >= 2')
+
+    def _generate_detections(self, predicted_tracks, sensor):
+
+        detections = {}
+
+        resampler = SystematicResampler()
+
+        for predicted_track in predicted_tracks:
+
+            measurement_sources = resampler.resample(predicted_track[-1],
+                                                     nparts=self.updates_per_track)
+
+            track_detections = set()
+            for state in measurement_sources.state_vector:
+                track_detections.update(sensor.measure({State(state)}, noise=True))
+
+            detections.update({predicted_track: track_detections})
+
+        return detections

--- a/stonesoup/sensormanager/tests/test_sensormanager.py
+++ b/stonesoup/sensormanager/tests/test_sensormanager.py
@@ -155,8 +155,8 @@ def test_random_choose_actions():
     ids=['UncertaintySMTest', 'KLDivergenceSMTest', 'MultiUpdateKLDivergenceSMTest',
          'KLDivergenceRaisesTest', 'MultiUpdateKLDivergenceRaisesTest']
 )
-def test_uncertainty_based_managers(predictor_obj, updater_obj, reward_function_obj, track1_state1,
-                                    track1_state2, track2_state1, track2_state2, error_flag):
+def test_sensor_managers(predictor_obj, updater_obj, reward_function_obj, track1_state1,
+                         track1_state2, track2_state1, track2_state2, error_flag):
     time_start = datetime.now()
 
     track1_state1.timestamp = time_start

--- a/stonesoup/sensormanager/tests/test_sensormanager.py
+++ b/stonesoup/sensormanager/tests/test_sensormanager.py
@@ -1,17 +1,22 @@
 import numpy as np
 from datetime import datetime, timedelta
 
-from ...types.array import StateVector
-from ...types.state import GaussianState
+import pytest
+
+from ...types.array import StateVector, StateVectors
+from ...types.state import GaussianState, ParticleState
 from ...types.track import Track
 from ...sensor.radar import RadarRotatingBearingRange
 from ...sensor.action.dwell_action import ChangeDwellAction
 from ...sensormanager import RandomSensorManager, BruteForceSensorManager
-from ...sensormanager.reward import UncertaintyRewardFunction
+from ...sensormanager.reward import UncertaintyRewardFunction, ExpectedKLDivergence, \
+    MultiUpdateExpectedKLDivergence
 from ...sensormanager.optimise import OptimizeBruteSensorManager, \
     OptimizeBasinHoppingSensorManager
 from ...predictor.kalman import KalmanPredictor
+from ...predictor.particle import ParticlePredictor
 from ...updater.kalman import ExtendedKalmanUpdater
+from ...updater.particle import ParticleUpdater
 from ...models.transition.linear import CombinedLinearGaussianTransitionModel, \
                                     ConstantVelocity
 
@@ -51,129 +56,246 @@ def test_random_choose_actions():
                 assert isinstance(actions[0], ChangeDwellAction)
 
 
-def test_uncertainty_based_managers():
+@pytest.mark.parametrize(
+    "predictor_obj, updater_obj, reward_function_obj, track1_state1, track1_state2, "
+    "track2_state1, track2_state2, error_flag",
+    [
+        (
+            KalmanPredictor,  # predictor_obj
+            ExtendedKalmanUpdater,  # updater_obj
+            UncertaintyRewardFunction,  # reward_function_obj
+            GaussianState([[1], [1], [1], [1]],
+                          np.diag([1.5, 0.25, 1.5, 0.25] + np.random.normal(0, 5e-4, 4))),
+            GaussianState([[2], [1.5], [2], [1.5]],
+                          np.diag([3, 0.5, 3, 0.5] + np.random.normal(0, 5e-4, 4))),
+            GaussianState([[-1], [1], [-1], [1]],
+                          np.diag([3, 0.5, 3, 0.5] + np.random.normal(0, 5e-4, 4))),
+            GaussianState([[2], [1.5], [2], [1.5]],
+                          np.diag([1.5, 0.25, 1.5, 0.25] + np.random.normal(0, 5e-4, 4)),
+                          ),
+            False  # error_flag
+        ), (
+            ParticlePredictor,  # predictor_obj
+            ParticleUpdater,  # updater_obj
+            ExpectedKLDivergence,  # reward_function_obj
+            ParticleState(state_vector=StateVectors(np.random.multivariate_normal(
+                mean=np.array([1, 1, 1, 1]),
+                cov=np.diag([1.5, 0.25, 1.5, 0.25]),
+                size=100).T),
+                          weight=np.array([1/100]*100)),
+            ParticleState(state_vector=StateVectors(np.random.multivariate_normal(
+                mean=np.array([2, 1.5, 2, 1.5]),
+                cov=np.diag([3, 0.5, 3, 0.5]),
+                size=100).T),
+                          weight=np.array([1/100]*100)),
+            ParticleState(state_vector=StateVectors(np.random.multivariate_normal(
+                mean=np.array([-1, 1, -1, 1]),
+                cov=np.diag([3, 0.5, 3, 0.5]),
+                size=100).T),
+                          weight=np.array([1/100]*100)),
+            ParticleState(state_vector=StateVectors(np.random.multivariate_normal(
+                mean=np.array([2, 1.5, 2, 1.5]),
+                cov=np.diag([1.5, 0.25, 1.5, 0.25]),
+                size=100).T),
+                          weight=np.array([1/100]*100)),
+            False  # error_flag
+        ), (
+            ParticlePredictor,  # predictor_obj
+            ParticleUpdater,  # updater_obj
+            MultiUpdateExpectedKLDivergence,  # reward_function_obj
+            ParticleState(state_vector=StateVectors(np.random.multivariate_normal(
+                mean=np.array([1, 1, 1, 1]),
+                cov=np.diag([1.5, 0.25, 1.5, 0.25]),
+                size=100).T),
+                          weight=np.array([1/100]*100)),
+            ParticleState(state_vector=StateVectors(np.random.multivariate_normal(
+                mean=np.array([2, 1.5, 2, 1.5]),
+                cov=np.diag([3, 0.5, 3, 0.5]),
+                size=100).T),
+                          weight=np.array([1/100]*100)),
+            ParticleState(state_vector=StateVectors(np.random.multivariate_normal(
+                mean=np.array([-1, 1, -1, 1]),
+                cov=np.diag([3, 0.5, 3, 0.5]),
+                size=100).T),
+                          weight=np.array([1/100]*100)),
+            ParticleState(state_vector=StateVectors(np.random.multivariate_normal(
+                mean=np.array([2, 1.5, 2, 1.5]),
+                cov=np.diag([1.5, 0.25, 1.5, 0.25]),
+                size=100).T),
+                          weight=np.array([1/100]*100)),
+            False
+        ), (
+            KalmanPredictor,  # predictor_obj
+            ExtendedKalmanUpdater,  # updater_obj
+            ExpectedKLDivergence,  # reward_function_obj
+            GaussianState([[1], [1], [1], [1]],
+                          np.diag([1.5, 0.25, 1.5, 0.25] + np.random.normal(0, 5e-4, 4))),
+            GaussianState([[2], [1.5], [2], [1.5]],
+                          np.diag([3, 0.5, 3, 0.5] + np.random.normal(0, 5e-4, 4))),
+            GaussianState([[-1], [1], [-1], [1]],
+                          np.diag([3, 0.5, 3, 0.5] + np.random.normal(0, 5e-4, 4))),
+            GaussianState([[2], [1.5], [2], [1.5]],
+                          np.diag([1.5, 0.25, 1.5, 0.25] + np.random.normal(0, 5e-4, 4))),
+            True
+        ), (
+            KalmanPredictor,  # predictor_obj
+            ExtendedKalmanUpdater,  # updater_obj
+            MultiUpdateExpectedKLDivergence,  # reward_function_obj
+            GaussianState([[1], [1], [1], [1]],
+                          np.diag([1.5, 0.25, 1.5, 0.25] + np.random.normal(0, 5e-4, 4))),
+            GaussianState([[2], [1.5], [2], [1.5]],
+                          np.diag([3, 0.5, 3, 0.5] + np.random.normal(0, 5e-4, 4))),
+            GaussianState([[-1], [1], [-1], [1]],
+                          np.diag([3, 0.5, 3, 0.5] + np.random.normal(0, 5e-4, 4))),
+            GaussianState([[2], [1.5], [2], [1.5]],
+                          np.diag([1.5, 0.25, 1.5, 0.25] + np.random.normal(0, 5e-4, 4))),
+            True
+        )
+    ],
+    ids=['UncertaintySMTest', 'KLDivergenceSMTest', 'MultiUpdateKLDivergenceSMTest',
+         'KLDivergenceRaisesTest', 'MultiUpdateKLDivergenceRaisesTest']
+)
+def test_uncertainty_based_managers(predictor_obj, updater_obj, reward_function_obj, track1_state1,
+                                    track1_state2, track2_state1, track2_state2, error_flag):
     time_start = datetime.now()
 
+    track1_state1.timestamp = time_start
+    track2_state1.timestamp = time_start
+    track1_state2.timestamp = time_start + timedelta(seconds=1)
+    track2_state2.timestamp = time_start + timedelta(seconds=1)
+
     tracks = [Track(states=[
-        GaussianState([[1], [1], [1], [1]],
-                      np.diag([1.5, 0.25, 1.5, 0.25] + np.random.normal(0, 5e-4, 4)),
-                      timestamp=time_start),
-        GaussianState([[2], [1.5], [2], [1.5]],
-                      np.diag([3, 0.5, 3, 0.5] + np.random.normal(0, 5e-4, 4)),
-                      timestamp=time_start + timedelta(seconds=1))]),
-              Track(states=[
-                  GaussianState([[-1], [1], [-1], [1]],
-                                np.diag([3, 0.5, 3, 0.5] + np.random.normal(0, 5e-4, 4)),
-                                timestamp=time_start),
-                  GaussianState([[2], [1.5], [2], [1.5]],
-                                np.diag([1.5, 0.25, 1.5, 0.25] + np.random.normal(0, 5e-4, 4)),
-                                timestamp=time_start + timedelta(seconds=1))])]
+        track1_state1,
+        track1_state2]),
+        Track(states=[
+            track2_state1,
+            track2_state2
+        ])]
 
     transition_model = CombinedLinearGaussianTransitionModel([ConstantVelocity(0.005),
                                                               ConstantVelocity(0.005)])
-    predictor = KalmanPredictor(transition_model)
-    updater = ExtendedKalmanUpdater(measurement_model=None)
-    reward_function = UncertaintyRewardFunction(predictor, updater, method_sum=False)
+    predictor = predictor_obj(transition_model)
+    updater = updater_obj(measurement_model=None)
+
+    if error_flag:
+        # Check that raises function as expected
+        with pytest.raises(TypeError) as e:
+            reward_function = reward_function_obj(predictor, updater, method_sum=False)
+        assert 'Only ParticlePredictor types can be used with this reward function' in str(e.value)
+        with pytest.raises(TypeError) as e:
+            reward_function = reward_function_obj(None, updater, method_sum=False)
+        assert 'Only ParticleUpdater types can be used with this reward function' in str(e.value)
+        if reward_function_obj == MultiUpdateExpectedKLDivergence:
+            with pytest.raises(ValueError) as e:
+                reward_function = reward_function_obj(method_sum=False, updates_per_track=1)
+            assert f'updates_per_track = {1}. This reward function only accepts >= 2' in \
+                   str(e.value)
+        return
+
+    reward_function = reward_function_obj(predictor, updater, method_sum=False)
+    if isinstance(reward_function, MultiUpdateExpectedKLDivergence):
+        reward_function = reward_function_obj(predictor, updater, method_sum=False,
+                                              updates_per_track=3)
+
+    timesteps = []
+    for t in range(3):
+        timesteps.append(time_start + timedelta(seconds=t + 2))
+
+    sensor_rpm = 5
+
+    sensorsA = {RadarRotatingBearingRange(
+        position_mapping=(0, 2),
+        noise_covar=np.array([[np.radians(0.5) ** 2, 0],
+                              [0, 0.75 ** 2]]),
+        position=np.array([[0], [0]]),
+        ndim_state=4,
+        rpm=sensor_rpm,
+        fov_angle=np.radians(30),
+        dwell_centre=StateVector([0.0]),
+        max_range=np.inf,
+    )}
+
+    sensorsB = {RadarRotatingBearingRange(
+        position_mapping=(0, 2),
+        noise_covar=np.array([[np.radians(0.5) ** 2, 0],
+                              [0, 0.75 ** 2]]),
+        position=np.array([[0], [0]]),
+        ndim_state=4,
+        rpm=sensor_rpm,
+        fov_angle=np.radians(30),
+        dwell_centre=StateVector([0.0]),
+        max_range=np.inf,
+    )}
+
+    sensorsC = {RadarRotatingBearingRange(
+        position_mapping=(0, 2),
+        noise_covar=np.array([[np.radians(0.5) ** 2, 0],
+                              [0, 0.75 ** 2]]),
+        position=np.array([[0], [0]]),
+        ndim_state=4,
+        rpm=sensor_rpm,
+        fov_angle=np.radians(30),
+        dwell_centre=StateVector([0.0]),
+        max_range=np.inf,
+    )}
+
+    sensorsD = {RadarRotatingBearingRange(
+        position_mapping=(0, 2),
+        noise_covar=np.array([[np.radians(0.5) ** 2, 0],
+                              [0, 0.75 ** 2]]),
+        position=np.array([[0], [0]]),
+        ndim_state=4,
+        rpm=sensor_rpm,
+        fov_angle=np.radians(30),
+        dwell_centre=StateVector([0.0]),
+        max_range=np.inf,
+    )}
+
+    for sensor_set in [sensorsA, sensorsB, sensorsC, sensorsD]:
+        for sensor in sensor_set:
+            sensor.timestamp = time_start
+
+    sensor_managerA = BruteForceSensorManager(sensorsA, reward_function)
+    sensor_managerB = OptimizeBruteSensorManager(sensorsB, reward_function)
+    sensor_managerC = OptimizeBasinHoppingSensorManager(sensorsC,
+                                                        reward_function)
+    sensor_managerD = OptimizeBruteSensorManager(sensorsD, reward_function,
+                                                 generate_full_output=True,
+                                                 finish=True)
+
+    sensor_managers = [sensor_managerA,
+                       sensor_managerB,
+                       sensor_managerC,
+                       sensor_managerD]
 
     all_dwell_centres = []
+    for sensor_manager in sensor_managers:
+        dwell_centres_over_time = []
+        for time in timesteps:
+            chosen_action_configs = sensor_manager.choose_actions(tracks, time)
 
-    for i in range(3):
-        sensorsA = {RadarRotatingBearingRange(
-            position_mapping=(0, 2),
-            noise_covar=np.array([[np.radians(0.5) ** 2, 0],
-                                  [0, 0.75 ** 2]]),
-            position=np.array([[0], [0]]),
-            ndim_state=4,
-            rpm=60,
-            fov_angle=np.radians(30),
-            dwell_centre=StateVector([0.0]),
-            max_range=np.inf,
-        )}
+            for chosen_config in chosen_action_configs:
+                for sensor, actions in chosen_config.items():
+                    sensor.add_actions(actions)
+                    sensor.act(time)
+                    dwell_centres_over_time.append(sensor.dwell_centre)
 
-        sensorsB = {RadarRotatingBearingRange(
-            position_mapping=(0, 2),
-            noise_covar=np.array([[np.radians(0.5) ** 2, 0],
-                                  [0, 0.75 ** 2]]),
-            position=np.array([[0], [0]]),
-            ndim_state=4,
-            rpm=60,
-            fov_angle=np.radians(30),
-            dwell_centre=StateVector([0.0]),
-            max_range=np.inf,
-        )}
+                    assert isinstance(sensor, RadarRotatingBearingRange)
+                    assert isinstance(actions[0], ChangeDwellAction)
 
-        sensorsC = {RadarRotatingBearingRange(
-            position_mapping=(0, 2),
-            noise_covar=np.array([[np.radians(0.5) ** 2, 0],
-                                  [0, 0.75 ** 2]]),
-            position=np.array([[0], [0]]),
-            ndim_state=4,
-            rpm=60,
-            fov_angle=np.radians(30),
-            dwell_centre=StateVector([0.0]),
-            max_range=np.inf,
-        )}
+        all_dwell_centres.append(dwell_centres_over_time)
 
-        sensorsD = {RadarRotatingBearingRange(
-            position_mapping=(0, 2),
-            noise_covar=np.array([[np.radians(0.5) ** 2, 0],
-                                  [0, 0.75 ** 2]]),
-            position=np.array([[0], [0]]),
-            ndim_state=4,
-            rpm=60,
-            fov_angle=np.radians(30),
-            dwell_centre=StateVector([0.0]),
-            max_range=np.inf,
-        )}
-
-        for sensor_set in [sensorsA, sensorsB, sensorsC, sensorsD]:
-            for sensor in sensor_set:
-                sensor.timestamp = time_start
-
-        sensor_managerA = BruteForceSensorManager(sensorsA, reward_function)
-        sensor_managerB = OptimizeBruteSensorManager(sensorsB, reward_function)
-        sensor_managerC = OptimizeBasinHoppingSensorManager(sensorsC,
-                                                            reward_function)
-        sensor_managerD = OptimizeBruteSensorManager(sensorsD, reward_function,
-                                                     generate_full_output=True,
-                                                     finish=True)
-
-        sensor_managers = [sensor_managerA,
-                           sensor_managerB,
-                           sensor_managerC,
-                           sensor_managerD]
-
-        timesteps = []
-        for t in range(3):
-            timesteps.append(time_start + timedelta(seconds=t))
-
-        dwell_centres_for_i = []
-        for sensor_manager in sensor_managers:
-            dwell_centres_over_time = []
-            for time in timesteps:
-                chosen_action_configs = sensor_manager.choose_actions(tracks, time)
-
-                for chosen_config in chosen_action_configs:
-                    for sensor, actions in chosen_config.items():
-                        sensor.add_actions(actions)
-                        sensor.act(time)
-                        dwell_centres_over_time.append(sensor.dwell_centre)
-
-                        assert isinstance(sensor, RadarRotatingBearingRange)
-                        assert isinstance(actions[0], ChangeDwellAction)
-
-            dwell_centres_for_i.append(dwell_centres_over_time)
-
-        all_dwell_centres.append(dwell_centres_for_i)
-        for t in range(3):
-            difference_between_managersAB = dwell_centres_for_i[0][t] - dwell_centres_for_i[1][t]
-            difference_between_managersAC = dwell_centres_for_i[0][t] - dwell_centres_for_i[2][t]
-            difference_between_managersBC = dwell_centres_for_i[1][t] - dwell_centres_for_i[2][t]
-            assert difference_between_managersAB <= np.radians(60)
-            assert difference_between_managersAC <= np.radians(60)
-            assert difference_between_managersBC <= np.radians(60)
-
-    assert all_dwell_centres[0][0] == all_dwell_centres[1][0] == all_dwell_centres[2][0]
-    assert all_dwell_centres[0][1] == all_dwell_centres[1][1] == all_dwell_centres[2][1]
+    for sm in range(3):
+        # check that the sensors are not exceeding the maximum speed
+        difference_between_t1t2 = \
+            np.abs(np.min([all_dwell_centres[sm][0] - all_dwell_centres[sm][1],
+                           all_dwell_centres[sm][1] - all_dwell_centres[sm][0]]))
+        difference_between_t2t3 = \
+            np.abs(np.min([all_dwell_centres[sm][1] - all_dwell_centres[sm][2],
+                           all_dwell_centres[sm][2] - all_dwell_centres[sm][1]]))
+        assert np.round(difference_between_t1t2, decimals=4) <= \
+               np.round(np.radians(sensor_rpm*36/6), decimals=4)
+        assert np.round(difference_between_t2t3, decimals=4) <= \
+               np.round(np.radians(sensor_rpm*36/6), decimals=4)
 
     assert isinstance(sensor_managerD.get_full_output(), tuple)

--- a/stonesoup/tests/test_measures.py
+++ b/stonesoup/tests/test_measures.py
@@ -4,11 +4,12 @@ import pickle
 import numpy as np
 import pytest
 from scipy.spatial import distance
+from scipy.stats import multivariate_normal
 
 from .. import measures
 from ..measures import ObservationAccuracy
-from ..types.array import StateVector, CovarianceMatrix
-from ..types.state import GaussianState, State
+from ..types.array import StateVector, CovarianceMatrix, StateVectors
+from ..types.state import GaussianState, State, ParticleState
 
 # Create a time stamp to use for both states
 t = datetime.datetime.now()
@@ -274,3 +275,48 @@ def test_mahalanobis_pickle(measure, result):
     if measure.state_covar_inv_cache_size > 0:
         assert measure._inv_cov.cache_info().hits == 0  # Cache not pickled currently
         assert measure._inv_cov.cache_info().currsize == 1
+
+
+def test_kld():
+
+    measure = measures.KLDivergence()
+
+    part_state_a = ParticleState(
+        state_vector=StateVectors(np.random.uniform(np.array([[0], [0], [0], [0]]),
+                                                    np.array([[20], [2], [20], [2]]),
+                                                    size=(4, 100))))
+    part_state_b = ParticleState(
+        state_vector=StateVectors(np.random.multivariate_normal(np.ravel(u),
+                                                                ui,
+                                                                100).T))
+
+    part_state_a.log_weight = multivariate_normal.logpdf((part_state_a.state_vector - u).T, cov=ui)
+    part_state_b.log_weight = multivariate_normal.logpdf((part_state_b.state_vector - u).T, cov=ui)
+
+    kld = measure(part_state_a, part_state_b)
+
+    # Verify that KLD is not reversible
+    assert kld != measure(part_state_b, part_state_a)
+
+    eval_kld = np.sum(np.exp(part_state_a.log_weight)
+                      * (part_state_a.log_weight - part_state_b.log_weight))
+
+    assert np.isclose(kld, eval_kld)
+
+    # Verify that if both distributions are the same then KLD is 0
+    assert measure(part_state_a, part_state_a) == 0.
+    assert measure(part_state_b, part_state_b) == 0.
+
+    # Check errors
+    part_state_c = ParticleState(
+        state_vector=StateVectors(np.random.uniform(np.array([[0], [0], [0], [0]]),
+                                                    np.array([[20], [2], [20], [2]]),
+                                                    size=(4, 101))))
+    with pytest.raises(ValueError) as e:
+        measure(part_state_a, part_state_c)
+    assert f'The input sizes are not compatible ' \
+           f'({len(part_state_a)} != {len(part_state_c)})' in str(e.value)
+
+    with pytest.raises(TypeError) as e:
+        measure(state_u, state_v)
+    assert 'state1 or state2 is not a ParticleState' in str(e.value)


### PR DESCRIPTION
This PR is to introduce the Kullback-Leibler Divergence (KLD) measure and reward function for calculating the relative entropy between two distributions. This implementation uses the discrete formulation for KLD and is currently only compatible with particle state types. The mathematical form of the equation is provided in the measure, `KLDivergence`. The reward function, `ExpectedKLDivergence`, implements the KLD measure in order to decide which candidate sensing (or movement) action leads to the most informative measurement based on the provided predictor and updater. A second KLD based reward function, `MultiUpdateExpectedKLDivergence`, which generates expected detections by resampling from the predicted particle state to create a subsample of possible measurements based on the target distribution. The KLD is then calculated based on each of the measurements. This comes at a computational burden. I am open to name suggestions if the general consensus on these class names is that these are confusing.

Tests for each new class have been introduced or incorporated into existing test frameworks. The `MultiUpdateExpectedKLDivergence` results in a significant increate in test time for the sensor management module. The sensor management test takes around 8 minutes 30 seconds on my fairly standard PC and takes total testing time to 9 minutes 24 seconds.