### PR TITLE
Change return type and add track ID metadata to Track2GaussianDetectionFeeder

### DIFF
--- a/stonesoup/feeder/tests/test_track.py
+++ b/stonesoup/feeder/tests/test_track.py
@@ -34,16 +34,22 @@ def test_Track2GaussianDetectionFeeder(tracks):
     assert len(detections) == len(tracks)
 
     # Check that the correct state was taken from each track
-    assert np.all([detections[i].timestamp == tracks[i][-1].timestamp for i in range(len(tracks))])
-    assert np.all([detections[i].timestamp == time for i in range(len(tracks))])
+    assert np.all([detection.timestamp == track.timestamp
+                   for track in tracks
+                   for detection in detections if detection.metadata['track_id'] == track.id])
+    assert np.all([detection.timestamp == time for detection in detections])
 
     # Check that the dimension of each detection is correct
-    assert np.all([len(detections[i].state_vector) == len(tracks[i][-1].state_vector)
-                   for i in range(len(tracks))])
+    assert np.all([len(detection.state_vector) == len(track.state_vector)
+                   for track in tracks
+                   for detection in detections if detection.metadata['track_id'] == track.id])
     assert np.all([len(detection.state_vector) == detection.measurement_model.ndim
                    for detection in detections])
 
     # Check that the detection has the correct mean and covariance
-    for i in range(len(tracks)):
-        assert np.all(detections[i].state_vector == tracks[i][-1].state_vector)
-        assert np.all(detections[i].covar == tracks[i][-1].covar)
+    for track in tracks:
+        detection = next(iter(detection
+                              for detection in detections
+                              if detection.metadata['track_id'] == track.id))
+        assert np.all(detection.state_vector == track.state_vector)
+        assert np.all(detection.covar == track.covar)

--- a/stonesoup/feeder/track.py
+++ b/stonesoup/feeder/track.py
@@ -19,10 +19,11 @@ class Tracks2GaussianDetectionFeeder(DetectionFeeder):
     @BufferedGenerator.generator_method
     def data_gen(self):
         for time, tracks in self.reader:
-            detections = []
+            detections = set()
             for track in tracks:
                 dim = len(track.state.state_vector)
                 detections.append(
+                detections.add(
                     GaussianDetection.from_state(
                         track.state,
                         measurement_model=LinearGaussian(

--- a/stonesoup/feeder/track.py
+++ b/stonesoup/feeder/track.py
@@ -22,12 +22,14 @@ class Tracks2GaussianDetectionFeeder(DetectionFeeder):
             detections = set()
             for track in tracks:
                 dim = len(track.state.state_vector)
-                detections.append(
+                metadata = track.metadata.copy()
+                metadata['track_id'] = track.id
                 detections.add(
                     GaussianDetection.from_state(
                         track.state,
                         measurement_model=LinearGaussian(
                             dim, list(range(dim)), np.asarray(track.covar)),
+                        metadata=metadata,
                         target_type=GaussianDetection)
                 )
 


### PR DESCRIPTION
Change Tracks2GaussianDetectionFeeder return type to a set.
 Previously this was a list which isn't the correct type for detection
 feeders.

Also added `track.id` to metadata on detection as this can be useful to trace source of detection.