### PR TITLE
Modify track fusion example to use tee and plot longest track

### DIFF
--- a/docs/examples/Track2Track_Fusion_Example.py
+++ b/docs/examples/Track2Track_Fusion_Example.py
@@ -653,7 +653,7 @@ for plotter in [plotter1, plotter2]:
 
 plotter1.fig.show()
 
-track = track_fusion_tracks.pop()
+track = sorted(track_fusion_tracks, key=len)[-1]  # Longest track
 x_min = min([state.state_vector[0] for state in track])
 x_max = max([state.state_vector[0] for state in track])
 y_min = min([state.state_vector[2] for state in track])


### PR DESCRIPTION
This utilises `itertools.tee()` in order to replicate the iterators from components like simulators, trackers and detectors, for use later on. This avoids need for `DummyDetector` and calls to `iter`.

Also use longest track in track2track fusion example plot, as sometimes randomly chosen example is very short.