### PR TITLE
Progress Trackers Manually: Option C

### DIFF
--- a/docs/examples/Track2Track_Fusion_Example.py
+++ b/docs/examples/Track2Track_Fusion_Example.py
@@ -571,7 +571,7 @@ class DummyDetector(DetectionReader):
 
 # %%
 
-sensor1_detections, sensor2_detections = [], []
+sensor1_all_detections, sensor2_all_detections = [], []
 jpda_tracks, gmlcc_tracks = set(), set()
 meas_fusion_tracks, track_fusion_tracks = set(), set()
 
@@ -582,47 +582,38 @@ sim_generator = radar_simulator.detections_gen()
 for t in range(num_steps):
 
     # Run JPDA tracker from sensor 1
-    s1d = next(sim_generator)
-    sensor1_detections.extend(s1d[1])  # hold in list for plotting
-    # Pass the detections into a DummyDetector and set it up as an iterable
-    jpda_tracker.detector = DummyDetector(current=s1d)
-    jpda_tracker.__iter__()
-    # Run the tracker and store the resulting tracks
-    _, sensor1_tracks = next(jpda_tracker)
+    time, sensor1_detections = next(sim_generator)
+    sensor1_all_detections.extend(sensor1_detections)  # hold in list for plotting
+    # Pass the detections into the tracker and store the resulting tracks
+    time, sensor1_tracks = jpda_tracker.update_tracker(time, sensor1_detections)
     jpda_tracks.update(sensor1_tracks)
 
     # Run GM-LCC tracker from sensor 2
-    s2d = next(sim_generator)
-    sensor2_detections.extend(s2d[1])  # hold in list for plotting
-    # Pass the detections into a DummyDetector and set it up as an iterable
-    gmlcc_tracker.detector = DummyDetector(current=s2d)
-    gmlcc_tracker.__iter__()
-    # Run the tracker and store results
-    time, sensor2_tracks = next(gmlcc_tracker)
+    time, sensor2_detections = next(sim_generator)
+    sensor2_all_detections.extend(sensor2_detections)  # hold in list for plotting
+    # Pass the detections into the tracker and store the resulting tracks
+    time, sensor2_tracks = gmlcc_tracker.update_tracker(time, sensor2_detections)
     gmlcc_tracks.update(sensor2_tracks)
 
     # Run the GM-PHD for measurement fusion. This one gets called twice, once for each set of
     # detections. This ensures there is only one detection per target.
-    for detections in [s1d, s2d]:
-        meas_fusion_tracker.detector = DummyDetector(current=detections)
-        meas_fusion_tracker.__iter__()
-        _, tracks = next(meas_fusion_tracker)
+    for detections in [sensor1_detections, sensor2_detections]:
+        time, tracks = meas_fusion_tracker.update_tracker(time, detections)
         meas_fusion_tracks.update(tracks)
 
     # Run the GM-PHD for track fusion. Similar to the measurement fusion, this tracker gets run
     # twice, once for each set of tracks.
-    for tracks_as_meas in [sensor1_tracks, sensor2_tracks]:
-        dummy_detector = DummyDetector(current=[time, tracks_as_meas])
-        track_fusion_tracker.detector = Tracks2GaussianDetectionFeeder(dummy_detector)
-        track_fusion_tracker.__iter__()
-        _, tracks = next(track_fusion_tracker)
+    for sensor_tracks in [sensor1_tracks, sensor2_tracks]:
+        time, tracks_as_detections = next(iter(
+            Tracks2GaussianDetectionFeeder([(time, sensor_tracks)])))
+        time, tracks = track_fusion_tracker.update_tracker(time, tracks_as_detections)
         track_fusion_tracks.update(tracks)
 
     # ----------------------------------------------------------------------
 
     # Add ground truth data and measurements to metric manager
     truths = radar_simulator.groundtruth.current
-    detections = s1d[1] | s2d[1]
+    detections = sensor1_detections | sensor2_detections
     metric_manager.add_data({'truths': truths[1], 'detections': detections}, overwrite=False)
 
 # Ensure that all tracks have been extracted from the trackers
@@ -661,9 +652,9 @@ plotter1, plotter2 = Plotter(), Plotter()
 for plotter in [plotter1, plotter2]:
     plotter.plot_ground_truths(set(radar_simulator.groundtruth.groundtruth_paths), [0, 2],
                                color='black')
-    plotter.plot_measurements(sensor1_detections, [0, 2], color='orange', marker='*',
+    plotter.plot_measurements(sensor1_all_detections, [0, 2], color='orange', marker='*',
                               measurements_label='Measurements - Airborne Radar')
-    plotter.plot_measurements(sensor2_detections, [0, 2], color='blue', marker='*',
+    plotter.plot_measurements(sensor2_all_detections, [0, 2], color='blue', marker='*',
                               measurements_label='Measurements - Ground Radar')
     plotter.plot_tracks(jpda_tracks, [0, 2], color='red',
                         track_label='Tracks - Airborne Radar (JPDAF)')

--- a/docs/examples/Track2Track_Fusion_Example.py
+++ b/docs/examples/Track2Track_Fusion_Example.py
@@ -88,9 +88,8 @@ Multi-Sensor Fusion: Covariance Intersection Using Tracks as Measurements
 #   * Create a GM-PHD tracker that will perform track fusion via covariance intersection using
 #     the :class:`ChernoffUpdater` class.
 #   * Create a metric manager to generate metrics for each of the four trackers
-#   * Set up the detection feeders. Each tracker will receive measurements using a custom
-#     :class:`DummyDetector` class. The track fusion tracker will also use the
-#     :class:`Tracks2GaussianDetectionFeeder` class.
+#   * The track fusion tracker will use the :class:`Tracks2GaussianDetectionFeeder` class to
+#     receive tracks as detections.
 #   * Run the simulation
 #   * Plot the resulting tracks and the metrics over time
 
@@ -545,25 +544,13 @@ metric_manager = MultiManager(metric_generators, associator=associator)
 #
 # The track fusion tracker will also use the :class:`~.Tracks2GaussianDetectionFeeder` class to
 # feed the tracks as measurements. At each time step, the resultant live tracks from the JPDA and
-# GM-LCC trackers will be put into a :class:`~.Tracks2GaussianDetectionFeeder` (using the
-# :class:`~.DummyDetector` we write below). The feeder will take the most recent state from each
+# GM-LCC trackers will be put into a :class:`~.Tracks2GaussianDetectionFeeder`.
+# The feeder will take the most recent state from each
 # track and turn it into a :class:`~.GaussianDetection` object. The set of detection objects will
 # be returned and passed into the tracker.
 
 # %%
 from stonesoup.feeder.track import Tracks2GaussianDetectionFeeder
-from stonesoup.buffered_generator import BufferedGenerator
-from stonesoup.reader.base import DetectionReader
-
-
-class DummyDetector(DetectionReader):
-    def __init__(self, *args, **kwargs):
-        self.current = kwargs['current']
-
-    @BufferedGenerator.generator_method
-    def detections_gen(self):
-        yield self.current
-
 
 # %%
 # 8: Run Simulation

--- a/stonesoup/reader/yaml.py
+++ b/stonesoup/reader/yaml.py
@@ -70,11 +70,11 @@ class YAMLSensorDataReader(YAMLReader, SensorDataReader):
 class YAMLTrackReader(YAMLReader, Tracker):
     """YAML Track Reader"""
 
-    def data_gen(self):
+    @ property
+    def detector(self):
         yield from super().data_gen()
 
     def __iter__(self):
-        self.data_iter = iter(self.data_gen())
         self._tracks = dict()
         return super().__iter__()
 
@@ -82,8 +82,7 @@ class YAMLTrackReader(YAMLReader, Tracker):
     def tracks(self):
         return self._tracks
 
-    def __next__(self):
-        time, document = next(self.data_iter)
+    def update_tracker(self, time, document):
         updated_tracks = set()
         for track in document.get('tracks', set()):
             if track.id in self.tracks:

--- a/stonesoup/tracker/base.py
+++ b/stonesoup/tracker/base.py
@@ -1,22 +1,43 @@
+import datetime
 from abc import abstractmethod
+from typing import Tuple, Set, Iterator, Iterable
 
 from ..base import Base
+from ..types.detection import Detection
+from ..types.track import Track
 
 
 class Tracker(Base):
     """Tracker base class"""
 
-    @property
-    @abstractmethod
-    def tracks(self):
-        raise NotImplementedError
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.detector_iter = None
 
-    def __iter__(self):
+    @property
+    def detector(self) -> Iterable[Tuple[datetime.datetime, Set[Detection]]]:
+        """ Input into the tracker"""
+        raise TypeError("Detector is not present in this tracker")
+
+    def __iter__(self) -> Iterator[Tuple[datetime.datetime, Set[Track]]]:
+        if self.detector is None:
+            raise ValueError("Detector has not been set")
+
+        if self.detector_iter is None:
+            self.detector_iter = iter(self.detector)
+
         return self
 
+    def __next__(self) -> Tuple[datetime.datetime, Set[Track]]:
+        time, detections = next(self.detector_iter)
+        return self.update_tracker(time, detections)
+
     @abstractmethod
-    def __next__(self):
+    def update_tracker(self, time: datetime.datetime, detections: Set[Detection]) \
+            -> Tuple[datetime.datetime, Set[Track]]:
         """
+        This function updates the tracker with detections and outputs the time and tracks
+
         Returns
         -------
         : :class:`datetime.datetime`
@@ -24,4 +45,9 @@ class Tracker(Base):
         : set of :class:`~.Track`
             Tracks existing in the time step
         """
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def tracks(self) -> Set[Track]:
         raise NotImplementedError

--- a/stonesoup/tracker/base.py
+++ b/stonesoup/tracker/base.py
@@ -1,6 +1,6 @@
 import datetime
 from abc import abstractmethod
-from typing import Tuple, Set, Iterator, Iterable
+from typing import Tuple, Set, Iterator
 
 from ..base import Base
 from ..types.detection import Detection
@@ -8,20 +8,28 @@ from ..types.track import Track
 
 
 class Tracker(Base):
-    """Tracker base class"""
+    """
+    Tracker base class
+
+    Note
+    ======
+    Sub-classes of :class:`~.Tracker` require a ``detector`` property to be iterators. A subclass
+    can be created without it, however it won't be an iterator. Its functionality will be
+    restricted to only using the :meth:`~.Tracker.update_tracker` method.
+    """
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        try:
+            _ = self.detector
+        except AttributeError:
+            self.detector = None
         self.detector_iter = None
-
-    @property
-    def detector(self) -> Iterable[Tuple[datetime.datetime, Set[Detection]]]:
-        """ Input into the tracker"""
-        raise TypeError("Detector is not present in this tracker")
 
     def __iter__(self) -> Iterator[Tuple[datetime.datetime, Set[Track]]]:
         if self.detector is None:
-            raise ValueError("Detector has not been set")
+            raise AttributeError("Detector has not been set. A detector attribute is required to"
+                                 "iterate over a tracker.")
 
         if self.detector_iter is None:
             self.detector_iter = iter(self.detector)

--- a/stonesoup/tracker/pointprocess.py
+++ b/stonesoup/tracker/pointprocess.py
@@ -1,13 +1,17 @@
+import datetime
+from typing import Tuple, Set
+
 from .base import Tracker
 from ..base import Property
-from ..reader import DetectionReader
-from ..types.state import TaggedWeightedGaussianState
-from ..types.mixture import GaussianMixture
-from ..types.numeric import Probability
-from ..types.track import Track
-from ..updater import Updater
 from ..hypothesiser.gaussianmixture import GaussianMixtureHypothesiser
 from ..mixturereducer.gaussianmixture import GaussianMixtureReducer
+from ..reader import DetectionReader
+from ..types.detection import Detection
+from ..types.mixture import GaussianMixture
+from ..types.numeric import Probability
+from ..types.state import TaggedWeightedGaussianState
+from ..types.track import Track
+from ..updater import Updater
 
 
 class PointProcessMultiTargetTracker(Tracker):
@@ -40,15 +44,11 @@ class PointProcessMultiTargetTracker(Tracker):
         self.gaussian_mixture = GaussianMixture()
 
     @property
-    def tracks(self):
+    def tracks(self) -> Set[Track]:
         tracks = set()
         for track in self.target_tracks.values():
             tracks.add(track)
         return tracks
-
-    def __iter__(self):
-        self.detector_iter = iter(self.detector)
-        return super().__iter__()
 
     def update_tracks(self):
         """
@@ -77,8 +77,8 @@ class PointProcessMultiTargetTracker(Tracker):
                             self.extraction_threshold:
                         self.target_tracks[tag] = Track([component], id=tag)
 
-    def __next__(self):
-        time, detections = next(self.detector_iter)
+    def update_tracker(self, time: datetime.datetime, detections: Set[Detection]) \
+            -> Tuple[datetime.datetime, Set[Track]]:
         # Add birth component
         self.birth_component.timestamp = time
         self.gaussian_mixture.append(self.birth_component)

--- a/stonesoup/tracker/simple.py
+++ b/stonesoup/tracker/simple.py
@@ -1,16 +1,21 @@
+import datetime
+from typing import Set, Tuple
+
 import numpy as np
 
 from .base import Tracker
 from ..base import Property
 from ..dataassociator import DataAssociator
 from ..deleter import Deleter
-from ..reader import DetectionReader
-from ..initiator import Initiator
-from ..updater import Updater
-from ..types.array import StateVectors
-from ..types.prediction import GaussianStatePrediction
-from ..types.update import GaussianStateUpdate
 from ..functions import gm_reduce_single
+from ..initiator import Initiator
+from ..reader import DetectionReader
+from ..types.array import StateVectors
+from ..types.detection import Detection
+from ..types.prediction import GaussianStatePrediction
+from ..types.track import Track
+from ..types.update import GaussianStateUpdate
+from ..updater import Updater
 
 
 class SingleTargetTracker(Tracker):
@@ -46,15 +51,12 @@ class SingleTargetTracker(Tracker):
         self._track = None
 
     @property
-    def tracks(self):
+    def tracks(self) -> Set[Track]:
         return {self._track} if self._track else set()
 
-    def __iter__(self):
-        self.detector_iter = iter(self.detector)
-        return super().__iter__()
+    def update_tracker(self, time: datetime.datetime, detections: Set[Detection]) \
+            -> Tuple[datetime.datetime, Set[Track]]:
 
-    def __next__(self):
-        time, detections = next(self.detector_iter)
         if self._track is not None:
             associations = self.data_associator.associate(
                 self.tracks, detections, time)
@@ -107,12 +109,8 @@ class SingleTargetMixtureTracker(Tracker):
     def tracks(self):
         return {self._track} if self._track else set()
 
-    def __iter__(self):
-        self.detector_iter = iter(self.detector)
-        return super().__iter__()
-
-    def __next__(self):
-        time, detections = next(self.detector_iter)
+    def update_tracker(self, time: datetime.datetime, detections: Set[Detection]) \
+            -> Tuple[datetime.datetime, Set[Track]]:
 
         if self._track is not None:
             associations = self.data_associator.associate(
@@ -203,15 +201,11 @@ class MultiTargetTracker(Tracker):
         self._tracks = set()
 
     @property
-    def tracks(self):
+    def tracks(self) -> Set[Track]:
         return self._tracks
 
-    def __iter__(self):
-        self.detector_iter = iter(self.detector)
-        return super().__iter__()
-
-    def __next__(self):
-        time, detections = next(self.detector_iter)
+    def update_tracker(self, time: datetime.datetime, detections: Set[Detection]) \
+            -> Tuple[datetime.datetime, Set[Track]]:
 
         associations = self.data_associator.associate(
             self.tracks, detections, time)
@@ -259,15 +253,11 @@ class MultiTargetMixtureTracker(Tracker):
         self._tracks = set()
 
     @property
-    def tracks(self):
+    def tracks(self) -> Set[Track]:
         return self._tracks
 
-    def __iter__(self):
-        self.detector_iter = iter(self.detector)
-        return super().__iter__()
-
-    def __next__(self):
-        time, detections = next(self.detector_iter)
+    def update_tracker(self, time: datetime.datetime, detections: Set[Detection]) \
+            -> Tuple[datetime.datetime, Set[Track]]:
 
         associations = self.data_associator.associate(
             self.tracks, detections, time)

--- a/stonesoup/tracker/tests/test_base.py
+++ b/stonesoup/tracker/tests/test_base.py
@@ -1,0 +1,137 @@
+import datetime
+import heapq
+from typing import Tuple, Set, List
+
+import pytest
+
+from ..base import Tracker
+from ...base import Property
+from ...types.detection import Detection
+from ...types.track import Track
+
+
+class TrackerWithoutDetector(Tracker):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._tracks = set()
+
+    def update_tracker(self, time: datetime.datetime, detections: Set[Detection]) \
+            -> Tuple[datetime.datetime, Set[Track]]:
+
+        self._tracks = {Track(detection) for detection in detections}
+        return time, self.tracks
+
+    @property
+    def tracks(self):
+        return self._tracks
+
+
+class TrackerWithDetector(TrackerWithoutDetector):
+    detector: list = Property(default=[])
+
+
+@pytest.fixture
+def detector() -> List[Tuple[datetime.datetime, Set[Detection]]]:
+    detections = [Detection(timestamp=datetime.datetime(2023, 11, i),
+                            state_vector=[i])
+                  for i in range(1, 10)
+                  ]
+
+    detector = [(det.timestamp, {det}) for det in detections]
+
+    return detector
+
+
+@pytest.mark.parametrize("tracker_class", [TrackerWithoutDetector, TrackerWithDetector])
+def test_tracker_update_tracker(tracker_class, detector):
+    tracker_without_detector = tracker_class()
+    for input_time, detections in detector:
+        time, tracks = tracker_without_detector.update_tracker(input_time, detections)
+
+        assert time == input_time
+        assert tracks == tracker_without_detector.tracks
+        tracks_state = {track.state for track in tracks}
+        assert tracks_state == detections
+
+
+def test_tracker_without_detector_iter_error():
+    tracker_without_detector = TrackerWithoutDetector()
+    with pytest.raises(AttributeError):
+        iter(tracker_without_detector)
+
+    with pytest.raises(TypeError):
+        next(tracker_without_detector)
+
+
+def test_tracker_with_detector_iter():
+    tracker = TrackerWithDetector()
+    assert iter(tracker) is tracker
+    assert tracker.detector_iter is not None
+
+    with pytest.raises(StopIteration):
+        next(tracker)
+
+
+def test_tracker_with_detector_for_loop(detector):
+    tracker = TrackerWithDetector(detector=detector)
+
+    for (tracker_time, tracks), (detect_time, detections) in zip(tracker, detector):
+        assert tracker_time == detect_time
+        assert tracks == tracker.tracks
+        tracks_state = {track.state for track in tracks}
+        assert tracks_state == detections
+
+
+def test_tracker_with_detector_next(detector):
+    tracker = TrackerWithDetector(detector=detector)
+    assert iter(tracker) is tracker
+
+    for detect_time, detections in detector:
+        tracker_time, tracks = next(tracker)
+        assert tracker_time == detect_time
+        assert tracks == tracker.tracks
+        tracks_state = {track.state for track in tracks}
+        assert tracks_state == detections
+
+    with pytest.raises(StopIteration):
+        _ = next(tracker)
+
+
+def test_tracker_wont_restart(detector):
+    tracker = TrackerWithDetector(detector=detector)
+    for _ in tracker:
+        pass
+
+    iter(tracker)
+    with pytest.raises(StopIteration):
+        next(tracker)
+
+
+def test_heapq_merge_with_tracker(detector):
+    merge_output = list(heapq.merge(TrackerWithDetector(detector=detector),
+                                    TrackerWithDetector(detector=detector)))
+
+    assert len(merge_output) == len(detector)*2
+
+    for idx, (tracker_time, tracks) in enumerate(merge_output):
+        detect_time, detections = detector[int(idx/2)]
+        assert tracker_time == detect_time
+        tracks_state = {track.state for track in tracks}
+        assert tracks_state == detections
+
+
+# The next two tests are 'Tracker' implementation specific.
+@pytest.mark.parametrize("tracker_class, expected",
+                         [(TrackerWithoutDetector, None),
+                          (TrackerWithDetector, [])
+                          ])
+def test_tracker_detector_creation(tracker_class, expected):
+    tracker_without_detector = tracker_class()
+    assert tracker_without_detector.detector == expected
+
+
+@pytest.mark.parametrize("tracker_class", [TrackerWithoutDetector, TrackerWithDetector])
+def test_tracker_detector_iter_creation(tracker_class):
+    tracker_without_detector = tracker_class()
+    assert tracker_without_detector.detector_iter is None

--- a/stonesoup/writer/tests/conftest.py
+++ b/stonesoup/writer/tests/conftest.py
@@ -51,17 +51,22 @@ def groundtruth_reader():
 @pytest.fixture()
 def tracker():
     class TestTracker(Tracker):
+
+        detector = zip([None]*2, range(2))
+
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            self._tracks = set()
+
         @property
         def tracks(self):
             return self._tracks
 
         def __iter__(self):
-            self.iter = iter(range(2))
             self.time = datetime.datetime(2018, 1, 1, 13, 59)
             return super().__iter__()
 
-        def __next__(self):
-            i = next(self.iter)
+        def update_tracker(self, _, i):
             state_vector = StateVector([[0]])
             self.time += datetime.timedelta(minutes=1)
             self._tracks = {


### PR DESCRIPTION
All current trackers require a detection feeder. It can be useful to progress a tracker manually without a detection feeder (see Multi-Sensor Fusion: Covariance Intersection Using Tracks as Measurements example). 

All current trackers and start their `__next__` function with:
```
time, detections = next(self.detector_iter)
# Some tracking logic
```

I've moved this line to the new `Tracker`  baseclass and added an `update_tracker` function which takes the time and detections from the detection feeder as an input. With this being a separate function, you can access it directly and bypass the detection feeder which may be easier in instances.

This also fixes issue #883 

This is my third iteration of trying to get this right. See #742 and #779 for previous implementations.