### PR TITLE
Variable-step Bayesian Recursive Updater

### DIFF
--- a/stonesoup/updater/kalman.py
+++ b/stonesoup/updater/kalman.py
@@ -115,7 +115,7 @@ class KalmanUpdater(Updater):
         """
         return predicted_state.covar @ measurement_matrix.T
 
-    def _innovation_covariance(self, m_cross_cov, meas_mat, meas_mod):
+    def _innovation_covariance(self, m_cross_cov, meas_mat, meas_mod, **kwargs):
         """Compute the innovation covariance
 
         Parameters
@@ -222,7 +222,7 @@ class KalmanUpdater(Updater):
 
         # The measurement cross covariance and innovation covariance
         meas_cross_cov = self._measurement_cross_covariance(predicted_state, hh)
-        innov_cov = self._innovation_covariance(meas_cross_cov, hh, measurement_model)
+        innov_cov = self._innovation_covariance(meas_cross_cov, hh, measurement_model, **kwargs)
 
         return MeasurementPrediction.from_state(
             predicted_state, pred_meas, innov_cov, cross_covar=meas_cross_cov)

--- a/stonesoup/updater/tests/test_recursive.py
+++ b/stonesoup/updater/tests/test_recursive.py
@@ -137,7 +137,7 @@ def test_bruf_multi_step(measurement_model, prediction, measurement, timestamp):
         measurement_model.matrix() @ prediction.mean,
         measurement_model.matrix() @ prediction.covar
         @ measurement_model.matrix().T
-        + n_steps * measurement_model.covar(),
+        + measurement_model.covar(),
         cross_covar=prediction.covar @ measurement_model.matrix().T)
 
     # Get and assert measurement prediction
@@ -380,7 +380,7 @@ def test_jcru_multi_step(measurement_model, prediction, measurement, timestamp):
         measurement_model.matrix() @ prediction.mean,
         measurement_model.matrix() @ prediction.covar
         @ measurement_model.matrix().T
-        + n_steps * measurement_model.covar(),
+        + measurement_model.covar(),
         cross_covar=prediction.covar @ measurement_model.matrix().T)
 
     # Get and assert measurement prediction


### PR DESCRIPTION
New Updater class VariableStepBayesianRecursiveUpdater.

Extension of the BayesianRecursiveUpdater. Unlike how the BayesianRecursiveUpdater uses equal measurement noise for each recursive step, the VariableStepBayesianUpdater over-inflates measurement noise in the earlier steps, requiring the use of a smaller number of steps.