### PR TITLE
Change how sensor parameters are passed to action generators

### DIFF
--- a/docs/tutorials/sensormanagement/02_MultiSensorManagement.py
+++ b/docs/tutorials/sensormanagement/02_MultiSensorManagement.py
@@ -146,7 +146,7 @@ for n in range(0, total_no_sensors):
         fov_angle=np.radians(30),
         dwell_centre=StateVector([0.0]),
         max_range=np.inf,
-        resolutions={'dwell_centre': Angle(np.radians(30))}
+        resolution=Angle(np.radians(30))
     )
     sensor_setA.add(sensor)
 for sensor in sensor_setA:
@@ -164,7 +164,7 @@ for n in range(0, total_no_sensors):
         fov_angle=np.radians(30),
         dwell_centre=StateVector([0.0]),
         max_range=np.inf,
-        resolutions={'dwell_centre': Angle(np.radians(30))}
+        resolution=Angle(np.radians(30))
     )
     sensor_setB.add(sensor)
 

--- a/docs/tutorials/sensormanagement/03_OptimisedSensorManagement.py
+++ b/docs/tutorials/sensormanagement/03_OptimisedSensorManagement.py
@@ -133,7 +133,7 @@ for n in range(0, total_no_sensors):
         fov_angle=np.radians(30),
         dwell_centre=StateVector([0.0]),
         max_range=np.inf,
-        resolutions={'dwell_centre': Angle(np.radians(30))}
+        resolution=Angle(np.radians(30))
     )
     sensor_setA.add(sensor)
 for sensor in sensor_setA:
@@ -151,7 +151,7 @@ for n in range(0, total_no_sensors):
         fov_angle=np.radians(30),
         dwell_centre=StateVector([0.0]),
         max_range=np.inf,
-        resolutions={'dwell_centre': Angle(np.radians(30))}
+        resolution=Angle(np.radians(30))
     )
     sensor_setB.add(sensor)
 
@@ -170,7 +170,7 @@ for n in range(0, total_no_sensors):
         fov_angle=np.radians(30),
         dwell_centre=StateVector([0.0]),
         max_range=np.inf,
-        resolutions={'dwell_centre': Angle(np.radians(30))}
+        resolution=Angle(np.radians(30))
     )
     sensor_setC.add(sensor)
 

--- a/stonesoup/sensor/action/dwell_action.py
+++ b/stonesoup/sensor/action/dwell_action.py
@@ -67,8 +67,11 @@ class DwellActionsGenerator(RealNumberActionGenerator):
     time period."""
 
     owner: object = Property(doc="Object with `timestamp`, `rpm` (revolutions per minute) and "
-                                 "dwell-centre attributes")
-    resolution: Angle = Property(default=np.radians(1), doc="Resolution of action space")
+                                 "`resolution`.")
+    resolution: Angle = Property(default=np.radians(1),
+                                 doc="Resolution of the action space.")
+    rpm: float = Property(default=60,
+                          doc="The number of rotations per minute (RPM).")
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -106,7 +109,7 @@ class DwellActionsGenerator(RealNumberActionGenerator):
 
     @property
     def rps(self):
-        return self.owner.rpm / 60
+        return self.rpm / 60
 
     @property
     def angle_delta(self):

--- a/stonesoup/sensor/action/tests/test_dwell_action.py
+++ b/stonesoup/sensor/action/tests/test_dwell_action.py
@@ -11,8 +11,10 @@ from ....types.array import StateVector
 
 
 class DummyActionable(Actionable):
-    dwell_centre: StateVector = ActionableProperty(doc="Actionable dwell centre.",
-                                                   generator_cls=DwellActionsGenerator)
+    dwell_centre: StateVector = ActionableProperty(
+        doc="Actionable dwell centre.",
+        generator_cls=DwellActionsGenerator,
+        generator_kwargs_mapping={'rpm': 'rpm'})
     timestamp: datetime = Property(doc="Current time that actionable exists at.")
     rpm: float = Property(doc="Dwell centre revolutions per minute")
 
@@ -36,9 +38,10 @@ def test_dwell_action(initial_bearing):
                                  1)  # 1 revolution per minute
 
     generator = DwellActionsGenerator(actionable,
-                                      "dwell_centre",
-                                      start,
-                                      end)  # 15s maximum action duration
+                                      attribute="dwell_centre",
+                                      start_time=start,
+                                      end_time=end,
+                                      rpm=actionable.rpm)  # 15s maximum action duration
 
     # Test call and resolution
     generator()

--- a/stonesoup/sensor/radar/radar.py
+++ b/stonesoup/sensor/radar/radar.py
@@ -18,6 +18,7 @@ from ...sensor.action.dwell_action import DwellActionsGenerator
 from ...sensor.actionable import ActionableProperty
 from ...sensor.sensor import Sensor, SimpleSensor
 from ...types.array import CovarianceMatrix
+from ...types.angle import Angle
 from ...types.detection import TrueDetection, Detection
 from ...types.groundtruth import GroundTruthState
 from ...types.numeric import Probability
@@ -135,9 +136,14 @@ class RadarRotatingBearingRange(RadarBearingRange):
             "sensor frame/orientation. The angle is positive if the rotation is in the "
             "counter-clockwise direction when viewed by an observer looking down the z-axis of "
             "the sensor frame, towards the origin. Angle units are in radians",
-        generator_cls=DwellActionsGenerator)
+        generator_cls=DwellActionsGenerator,
+        generator_kwargs_mapping={'rpm': 'rpm', 'resolution': 'resolution'})
     rpm: float = Property(
         doc="The number of antenna rotations per minute (RPM)")
+    resolution: Angle = Property(
+        default=Angle(np.radians(1)),
+        doc="Resolution of the dwell_centre. Used by the :class:`~.DwellActionsGenerator` "
+            "during sensor management.")
     max_range: float = Property(
         default=np.inf,
         doc="The maximum detection range of the radar (in meters)")
@@ -215,9 +221,14 @@ class RadarRotatingBearing(RadarBearing):
             "sensor frame/orientation. The angle is positive if the rotation is in the "
             "counter-clockwise direction when viewed by an observer looking down the z-axis of "
             "the sensor frame, towards the origin. Angle units are in radians",
-        generator_cls=DwellActionsGenerator)
+        generator_cls=DwellActionsGenerator,
+        generator_kwargs_mapping={'rpm': 'rpm', 'resolution': 'resolution'})
     rpm: float = Property(
         doc="The number of antenna rotations per minute (RPM)")
+    resolution: Angle = Property(
+        default=Angle(np.radians(1)),
+        doc="Resolution of the dwell_centre. Used by the :class:`~.DwellActionsGenerator` "
+            "during sensor management.")
     max_range: float = Property(
         default=np.inf,
         doc="The maximum detection range of the radar (in meters)")

--- a/stonesoup/sensor/tests/test_actionable.py
+++ b/stonesoup/sensor/tests/test_actionable.py
@@ -11,8 +11,10 @@ from ...types.array import StateVector
 
 
 class DummyActionable(Actionable):
-    dwell_centre: StateVector = ActionableProperty(doc="Actionable dwell centre.",
-                                                   generator_cls=DwellActionsGenerator)
+    dwell_centre: StateVector = ActionableProperty(
+        doc="Actionable dwell centre.",
+        generator_cls=DwellActionsGenerator,
+        generator_kwargs_mapping={'rpm': 'rpm'})
     timestamp: datetime = Property(doc="Current time that actionable exists at.")
     rpm: float = Property(doc="Dwell centre revolutions per minute")
 

--- a/stonesoup/sensormanager/tests/conftest.py
+++ b/stonesoup/sensormanager/tests/conftest.py
@@ -58,7 +58,7 @@ def params():
         fov_angle=np.radians(90),
         dwell_centre=StateVector([np.radians(315)]),
         max_range=np.inf,
-        resolutions={'dwell_centre': Angle(np.radians(90))}
+        resolution=Angle(np.radians(90))
     )
     sensor.timestamp = start_time
     sensor_set.add(sensor)


### PR DESCRIPTION
ActionableProperties have "generator_kwargs" dictionary which maps properties of the ActionGenerator, to properties of the Sensor. This removes the "resolutions" property from all Actionables and allows properties of the ActionGenerator to be set via the Sensor.