### PR TITLE
Modify Ensemble state generation and initiator test thresholds

### DIFF
--- a/docs/examples/EnsembleFilterExample.py
+++ b/docs/examples/EnsembleFilterExample.py
@@ -153,7 +153,7 @@ from stonesoup.types.state import EnsembleState
 
 ensemble = EnsembleState.generate_ensemble(
     mean=np.array([[0], [1], [0], [1]]),
-    covar=np.diag([[1.5, 0.5, 1.5, 0.5]]), num_vectors=100)
+    covar=np.diag([1.5, 0.5, 1.5, 0.5]), num_vectors=100)
 prior = EnsembleState(state_vector=ensemble, timestamp=start_time)
 
 # %%

--- a/stonesoup/initiator/simple.py
+++ b/stonesoup/initiator/simple.py
@@ -494,11 +494,9 @@ class EnsembleInitiator(GaussianInitiator):
                                            track.covar,
                                            track.timestamp)
 
-            ensemble = EnsembleState.from_gaussian_state(gaussian_state, self.ensemble_size)
-
-            track[-1] = EnsembleStateUpdate(
-                state_vector=ensemble.state_vector,
-                hypothesis=track.hypothesis,
-                timestamp=ensemble.timestamp)
+            track[-1] = EnsembleStateUpdate.from_gaussian_state(
+                gaussian_state,
+                self.ensemble_size,
+                hypothesis=track.hypothesis)
 
         return tracks

--- a/stonesoup/initiator/tests/test_simple.py
+++ b/stonesoup/initiator/tests/test_simple.py
@@ -528,13 +528,13 @@ def test_ensemble_1d(gaussian_initiator):
         assert isinstance(track.state, EnsembleStateUpdate)
 
         if track.state.mean > 0:
-            assert np.allclose(np.mean(track.state.mean), np.array([[5]]), atol=0.4)
+            assert np.allclose(np.mean(track.state.mean), np.array([[5]]), atol=0.5)
             assert track.state.hypothesis.measurement is detections[0]
         else:
-            assert np.allclose(np.mean(track.state.mean), np.array([[-5]]), atol=0.4)
+            assert np.allclose(np.mean(track.state.mean), np.array([[-5]]), atol=0.5)
             assert track.state.hypothesis.measurement is detections[1]
         assert track.timestamp == timestamp
-        assert np.allclose(track.covar, np.array([[1]]), atol=0.4)
+        assert np.allclose(track.covar, np.array([[1]]), atol=0.6)
 
 
 @pytest.mark.parametrize("gaussian_initiator", [
@@ -559,10 +559,10 @@ def test_ensemble_2d(gaussian_initiator):
     for track in tracks:
         assert isinstance(track.state, EnsembleStateUpdate)
         if track.state.mean[0] > 0:
-            assert np.allclose(track.state.mean, np.array([[5], [0]]), atol=0.4)
+            assert np.allclose(track.state.mean, np.array([[5], [0]]), atol=0.5)
             assert track.state.hypothesis.measurement is detections[0]
         else:
-            assert np.allclose(track.state.mean, np.array([[-5], [0]]), atol=0.4)
+            assert np.allclose(track.state.mean, np.array([[-5], [0]]), atol=0.5)
             assert track.state.hypothesis.measurement is detections[1]
         assert track.timestamp == timestamp
-        assert np.allclose(track.covar, np.diag([1, 0]), atol=0.4)
+        assert np.allclose(track.covar, np.diag([1, 0]), atol=0.6)

--- a/stonesoup/types/state.py
+++ b/stonesoup/types/state.py
@@ -939,7 +939,7 @@ class EnsembleState(State):
         default=None, doc="Timestamp of the state. Default None.")
 
     @classmethod
-    def from_gaussian_state(cls, gaussian_state, num_vectors):
+    def from_gaussian_state(cls, gaussian_state, num_vectors, **kwargs):
         """
         Returns an EnsembleState instance, from a given
         GaussianState object.
@@ -960,7 +960,8 @@ class EnsembleState(State):
         timestamp = gaussian_state.timestamp
 
         return cls(state_vector=cls.generate_ensemble(mean, covar, num_vectors),
-                   timestamp=timestamp)
+                   timestamp=timestamp,
+                   **kwargs)
 
     @staticmethod
     def generate_ensemble(mean, covar, num_vectors):


### PR DESCRIPTION
Increase tolerance on initiator test for ensemble filter, as these were failing fairly frequently due to random sampling.

Modification for sampling on Ensemble state makes it similar to other sampling done in models, as well as supporting custom data types (e.g. Bearing) properly.