### PR TITLE
Correct UKF kappa default to match documentation

### DIFF
--- a/stonesoup/predictor/kalman.py
+++ b/stonesoup/predictor/kalman.py
@@ -299,7 +299,7 @@ class UnscentedKalmanPredictor(KalmanPredictor):
             "true distribution is Gaussian, the value of 2 is optimal. "
             "Default is 2")
     kappa: float = Property(
-        default=0,
+        default=None,
         doc="Secondary spread scaling parameter. Default is calculated as "
             "3-Ns")
 

--- a/stonesoup/updater/kalman.py
+++ b/stonesoup/updater/kalman.py
@@ -358,7 +358,7 @@ class UnscentedKalmanUpdater(KalmanUpdater):
             "true distribution is Gaussian, the value of 2 is optimal. "
             "Default is 2")
     kappa: float = Property(
-        default=0,
+        default=None,
         doc="Secondary spread scaling parameter. Default is calculated as "
             "3-Ns")
 


### PR DESCRIPTION
Changing default to `None` sets it to `3 - Ns` as described.

Closes #900