### PR TITLE
Inertia navigation and landmarks tracking

### DIFF
--- a/docs/examples/example_navigation.py
+++ b/docs/examples/example_navigation.py
@@ -1,0 +1,411 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+"""
+==========================================
+Example using navigation measurement model
+==========================================
+"""
+
+# %%
+# In this example, we present how to perform the
+# tracking task using an inertia
+# navigation measurement model making use of
+# instruments mounted on the sensor.
+# This example is relevant for tracking
+# sensors in environments where GPS tracking is not
+# available and we integrate the information
+# obtained from instruments on board, as the
+# accelerometer and gyroscope, with fixed target locations,
+# also refereed as landmarks. In this example, we simulate a
+# three dimensional sensor, moving in 3D cartesian space,
+# we have the measurements from on-board instruments
+# that evaluates the Euler angles, whose describe the
+# sensor rotations and orientation during the flight, as
+# well as the the 3D forces acting on the sensor.
+# This example aims to provide an idea of how to use the
+# combination of the measurement models
+# :class:`~.AccelerometerMeasurementModel` and
+# :class:`~.GyroscopeMeasurementModel` to model
+# the inertia navigation measurements.
+# In this example we ignore GPS measurements, therefore
+# we employ the knowledge of fixed targets
+# to adjust the navigation tracking from drifting, a common
+# problem in navigation scenario.
+# The statespace we are considering is a 15 dimensions object, which
+# combines 3D nearly-constant Acceleration model and the 3D Euler angles,
+# whose are the heading (:math:`\psi`), the pitch (:math:`\theta`)
+# and the roll (:math:`\phi`) and their time derivative.
+#
+# This example follows this points:
+# 1) Describe the transition model;
+# 2) Obtain the ground truth and measurements;
+# 3) Instantiate the tracker components;
+# 4) Run the tracker and obtain the final track.
+#
+
+# %%
+# 1) Describe the transition model
+# --------------------------------
+# As we have previously said, we want a 15 dimensions
+# transition model for the sensor, in the simplest form we can combine
+# :class:`~.ConstantAcceleration` and :class:`~.ConstantVelocity`
+# transition model. Since the sensor is moving onto
+# a fixed plane placed 1km above ground, we employ an
+# exponential declining acceleration model, using :class:`~.Singer` model,
+# to adress the z- movements. A more complex, and realistic, approache
+# would involve Van-Loan models for the transition.
+#
+
+# %%
+# General imports
+# ^^^^^^^^^^^^^^^
+import numpy as np
+from datetime import datetime, timedelta
+
+# %%
+# Stone Soup and transition models
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+from stonesoup.types.groundtruth import GroundTruthState, GroundTruthPath
+from stonesoup.types.detection import Detection
+from stonesoup.types.state import State, StateVector, StateVectors, GaussianState
+from stonesoup.models.transition.linear import CombinedGaussianTransitionModel, \
+    ConstantVelocity, ConstantAcceleration, Singer
+from stonesoup.functions.navigation import getEulersAngles
+
+# %%
+# Simulation parameters setup
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+# Lets assume a target sensor with these specifics
+radius = 5000   # meters
+speed = 200     # meters
+center = np.array([0, 0, 1000])  # 3D center placed at 1km in height
+n_timesteps = 100
+
+timesteps = np.linspace(0, n_timesteps+1, n_timesteps+1)
+simulation_start = datetime.now().replace(microsecond=0)
+np.random.seed(2000) # fix a random seed for reproducibility
+
+# %%
+# Describe the ground truth
+# ^^^^^^^^^^^^^^^^^^^^^^^^^
+# In a different manner from other examples,
+# we create the groundtruth of the sensor without considering
+# the process noise, and at the same time, we calculate the
+# sensor Euler angles. It is possible to still use the
+# existing transition models and extend the state vectors
+# to include such angles.
+#
+
+# Create a function to create the groundtruth paths
+def describe_sensor_motion(target_speed: float,
+                           target_radius: float,
+                           starting_position: np.array,
+                           start_time: datetime,
+                           number_of_timesteps: np.array
+                           ) -> (list, set):
+
+    """
+        Auxuliary function to create the sensor-target dynamics in the
+        specific case of circular motion.
+
+    Parameters:
+    -----------
+    target_speed: float
+        Speed of the sensor;
+    target_tadius: float
+        radius of the circular trajectory;
+    starting_position: np.array
+        starting point of the trajectory, latitude, longitude
+        and altitude;
+    start_time: datetime,
+        start of the simulation;
+    number_of_timesteps: np.array
+        simulation lenght
+
+    Return:
+    -------
+    (list, set):
+        list of timestamps of the simulation and
+        groundtruths path.
+    """
+
+    # Instantiate the 15 dimension object describing
+    # the positions, dynamics and angles of the target
+    sensor_dynamics = np.zeros((15))
+
+    # Generate the groundTruthpath
+    truths = GroundTruthPath([])
+
+    # instantiate a list for the timestamps
+    timestamps = []
+
+    # indexes of the array
+    position_indexes = [0, 3, 6]
+    velocity_indexes = [1, 4, 7]
+    acceleration_indexes = [2, 5, 8]
+    angles_indexes = [9, 11, 13]
+    vangles_indexes = [10, 12, 14]
+
+    # loop over the timestep
+    for i in number_of_timesteps:
+        theta = target_speed * i / target_radius + 0
+
+        # positions
+        sensor_dynamics[position_indexes] += target_radius * \
+                                      np.array([np.cos(theta), np.sin(theta),
+                                                0.001*np.random.choice(np.arange(-5, 5), 1)[0]]) + \
+                                      starting_position
+
+        # velocities
+        sensor_dynamics[velocity_indexes] += target_speed * \
+                                      np.array([-np.sin(theta), np.cos(theta), 0])
+
+        # acceleration
+        sensor_dynamics[acceleration_indexes] += ((-target_speed * target_speed) / target_radius) * \
+                           np.array([np.cos(theta), np.sin(theta), 0])
+
+        # Now using the velocity and accelerations terms we get the Euler angles
+        angles, dangles = getEulersAngles(sensor_dynamics[velocity_indexes],
+                                          sensor_dynamics[acceleration_indexes])
+
+        # add the Euler angles and their time derivative
+        # please check that are all angles
+        sensor_dynamics[angles_indexes] += angles
+        sensor_dynamics[vangles_indexes] += dangles
+
+        # append all those as ground state
+        truths.append(GroundTruthState(state_vector=sensor_dynamics,
+                                       timestamp=start_time +
+                                                 timedelta(seconds=int(i))))
+        # restart the array
+        sensor_dynamics = np.zeros((15))
+        timestamps.append(start_time + timedelta(seconds=int(i)))
+
+    return (timestamps, truths)
+
+
+# Instantiate the transition model, We consider the Singer model for
+# an exponential declining acceleration in the z- coordinate.
+transition_model = CombinedGaussianTransitionModel([ConstantAcceleration(1.5),
+                                     ConstantAcceleration(1.5),
+                                     Singer(0.1, 10),
+                                     ConstantVelocity(0.5),
+                                     ConstantVelocity(0.5),
+                                     ConstantVelocity(0.5)
+                                     ])
+
+
+# %%
+# 2) Obtain the ground truth and gather the measurements;
+# -------------------------------------------------------
+# We have instantiated a function to describe the
+# target-sensor dynamics, obtaining the Euler angles
+# from the vessel acceleration and velocity
+# adopting the ad-hoc function :class:`~.getEulerAngles`.
+# Likewise, we have instantiated the 15 dimension transition
+# model using a constant acceleration model for the 3D dynamics and a
+# constant velocity for modelling the Euler angles
+# dynamics. We consider as well the :class:`~.Singer` model
+# for an exponential declining acceleration model for the
+# z coordinate, since the sensor is moving on a fixed plane at
+# 1 km above the surface.
+# At this stage we can start collecting both the grountruths and
+# the measurement using a composite measurement model merging the
+# measurements from the :class:`~.AccelerometerMeasurementModel`,
+# the :class:`~.GyroscopeMeasurementModel` and
+# the landmarks, using an :class:`~.CartesianAzimuthElevationMeasurementModel`.
+# This measurement model combines the specific forces
+# measured by the accelerometer instrument and the angular rotation
+# from the inertia movements of the target. The landmarks helps reducing the
+# navigation drift.
+#
+
+# %%
+# Get the groungtruth paths
+# ^^^^^^^^^^^^^^^^^^^^^^^^^
+#
+timestamps, truths = describe_sensor_motion(speed,
+                                            radius,
+                                            center,
+                                            simulation_start,
+                                            timesteps)
+
+# %%
+# Load and instantiate the measurement model
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+# We consider a case with the three fixed targets,
+# landmarks, and we use the on-board
+# measurements. To merge all these measurements
+# we employ a :class:`~.CombinedReversibleGaussianMeasurementModel`
+# to concatenate all the different measurement models.
+# We specify a reference frame to evaluate the gravity
+# forces applied onto the sensor, and it is needed for the
+# accelerometer and gyroscope measurements. The landmarks are
+# placed on the ground (z~0). Overall the measurement model will
+# have 14 dimensions space.
+#
+
+from stonesoup.models.measurement.nonlinear import AccelerometerMeasurementModel, GyroscopeMeasurementModel, \
+    CartesianAzimuthElevationMeasurementModel, CombinedReversibleGaussianMeasurementModel
+
+# Instantiate the measurement model
+measurement_model_list = []
+
+# Instantiate the landmarks - the z-coordinate is randomly drawn
+target1 = np.array([3000, 3000, 0.0096])
+target2 = np.array([-3000, 3000, 1.6034])
+target3 = np.array([0, -3000, 0.93])
+target4 = np.array([0, 0, 1.5])
+
+targets = [target1, target2, target3, target4]
+
+# Specify the reference frame for the Accelerometer
+# and Gyroscope measurements.
+reference_frame = StateVector([55, 0, 0])  # Latitude, longitude, Altitude
+
+accelerometer = AccelerometerMeasurementModel(
+    ndim_state=15,
+    mapping=(0, 3, 6),
+    noise_covar=np.diag([1, 1, 5]),  # Acceleration
+    reference_frame=reference_frame
+)
+
+gyroscope = GyroscopeMeasurementModel(
+    ndim_state=15,
+    mapping=(0, 3, 6),
+    noise_covar=np.diag([1, 1, 1]),  # Gyroscope
+    reference_frame=reference_frame
+)
+
+# add the measurements models
+measurement_model_list.append(accelerometer)
+measurement_model_list.append(gyroscope)
+
+# loop over the various targets to initilise the
+# azimuth-elevation models.
+for target in targets:
+    measurement_model_list.append(
+        CartesianAzimuthElevationMeasurementModel(
+            ndim_state=15,
+            mapping=(0, 3, 6),
+            noise_covar=np.diag([1, 1]),
+            target_location=StateVector(target),
+            translation_offset=None)
+    )
+
+# Combine all the measurement model into a unique
+# model
+measurement_model = CombinedReversibleGaussianMeasurementModel(measurement_model_list)
+
+# Now create the measurements
+measurement_set = []
+
+for truth in truths:
+    measurement = measurement_model.function(truth, noise=True)
+    measurement_set.append(Detection(state_vector=measurement,
+                                      timestamp=truth.timestamp,
+                                      measurement_model=measurement_model))
+
+# %%
+# 3) instantiate the tracker components;
+# --------------------------------------
+# We have the truths and the detections,
+# in this simple example we do not include measurement clutter.
+# Now we can set up the tracker components.
+# In this example we consider an UnscentedKalmanFilter given
+# the non-linearity of the problem.
+
+
+# %%
+# Load the filter components
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^
+from stonesoup.predictor.kalman import UnscentedKalmanPredictor
+from stonesoup.updater.kalman import UnscentedKalmanUpdater
+
+predictor = UnscentedKalmanPredictor(transition_model)
+updater = UnscentedKalmanUpdater(None)
+
+# Covariance of the starting location
+covar_starting_position = np.repeat(10, 15)
+
+# Instantiate the prior, with a known location of
+# the sensor
+prior = GaussianState(
+    state_vector=truths[0].state_vector,
+    covar=np.diag(covar_starting_position),
+    timestamp=timestamps[0]
+)
+
+# %%
+# 4) Run the tracker and obtain the final track.
+# ----------------------------------------------
+# We have the tracker components and the starting
+# (prior) knowledge, now we can loop over the
+# various measurements and using a
+# :class:`~.SingleHypothesis` we can perform the
+# tracking.
+#
+
+# Load these components to do the tracking
+from stonesoup.types.track import Track
+from stonesoup.types.hypothesis import SingleHypothesis
+
+track = Track()
+
+# Loop over the measurement
+for k, measurement in enumerate(measurement_set):
+    predictions = predictor.predict(prior, timestamp=measurement.timestamp)
+    hyps = SingleHypothesis(predictions, measurement)
+    post = updater.update(hyps)
+    track.append(post)
+    prior = track[-1]
+
+# %%
+# Load the plotter
+# ^^^^^^^^^^^^^^^^
+# To plot the various landmarks we
+# make use of the fixed platform object.
+
+from stonesoup.platform.base import FixedPlatform
+
+platforms = []
+for target in targets:
+    state = np.array([target[0], 0,
+                      target[1], 0,
+                      target[2], 0])
+    platforms.append(
+        FixedPlatform(
+        states=GaussianState(state,
+                             np.diag([1,1,1,1,1,1])
+                             ),
+        position_mapping=(0, 2, 4)
+        ))
+
+from stonesoup.plotter import Plotter, Dimension
+
+plotter = Plotter(dimension=Dimension.THREE)
+
+plotter.plot_ground_truths(truths, mapping=[0, 3, 6])
+plotter.plot_sensors({*platforms}, mapping=[0, 1, 2],
+                     sensor_label='Landmarks')
+plotter.plot_tracks(track, mapping=[0, 3, 6], uncertainty=False, track_label='Track')
+
+plotter.fig
+
+# %%
+# Conclusion
+# ----------
+# In this example we have shown how to use the inertia
+# navigation and how to integrate the tracking using
+# fixed landmarks. As it is evident from the tracking result
+# this scenario is particularly complex and it is not possible
+# to run a perfect track with the limited information available.
+# Using different measurements for the landmarks, e.g. including the
+# range between the target and sensor
+# (i.e., see :class:`~.CartesianAzimuthElevationRangeMeasurementModel`),
+# would improve the tracking. However this example aims to
+# give an opportunity to show how to perform tracking
+# in the inertia navigation context.
+#

--- a/stonesoup/functions/navigation.py
+++ b/stonesoup/functions/navigation.py
@@ -1,0 +1,469 @@
+"""
+Navigation functions
+--------------------
+"""
+
+import numpy as np
+from math import pi
+from . import localSphere2GCS
+
+def angle_wrap(angle):
+    """ Fix the angle if it gets over the threshold"""
+
+    return np.remainder(angle+pi, 2.*pi) - pi
+
+
+def earthSpeedFlatSq(dx, dy):
+    r"""Calculate the Earth speed flat vector respect to the reference
+    frame, from 2D Cartesian coordinates.
+
+    Parameters
+    ----------
+    dx : float, array like
+        :math:`dx` Earth velocity component
+
+    dy : float, array like
+        :math:`dy` Earth velocity component
+
+    Returns
+    -------
+    np.array: sum of the powers of dx and dy
+    """
+
+    return np.power(dx, 2) + np.power(dy, 2)
+
+
+def earthSpeedSq(dx, dy, dz):
+    r"""Calculate the Earth speed respect to the reference frame
+    from 3D Cartesian coordinates.
+
+    Parameters
+    ----------
+    dx : float, array like
+        :math:`dx` Earth velocity component
+
+    dy : float, array like
+        :math:`dy` Earth velocity component
+
+    dz : float, array like
+        :math:`dz` Earth velocity component
+
+    Returns
+    -------
+    np.array: sum of the powers of dx, dy and dz
+    """
+    return np.power(dx, 2) + np.power(dy, 2) + np.power(dz, 2)
+
+
+def earthSpeedFlat(dx, dy):
+    r"""Same as :class:`~.EarthSpeedFlatSq` but squared.
+
+    Parameters
+    ----------
+    dx : float, array like
+        :math:`dx` Earth velocity component
+
+    dy : float, array like
+        :math:`dy` Earth velocity component
+
+    Returns
+    -------
+    np.array: square root of the sum of the powers of dx and dy
+    """
+    return np.sqrt(np.power(dx, 2) + np.power(dy, 2))
+
+
+def getEulersAngles(earthSpeed, earthAcceleration):
+    r"""Function to obtain the Euler angles from the
+        speed of the aeroplane. The Euler angles are:
+
+        - :math:`\psi` : heading
+        - :math:`\theta` : pitch
+        - :math:`\phi` : roll
+
+    Parameters
+    ----------
+    earthSpeed : np.array, float
+                Earth velocity components (dx, dy, dz)
+                in local Earth coordinates (m/s)
+
+    earthAcceleration : np.array, float
+                  Earth acceleration components (ddx, ddy, ddz)
+                  in local Earth coordinates (m/s^2)
+
+    Returns
+    -------
+    np.array, float
+            a 3xN matrix of Euler angles (heading, pitch, roll) (in degrees)
+
+    np.array, float
+            a 3xN matrix of time derivatives of Euler angles (heading, pitch, roll) (deg/s)
+
+    """
+
+    dx, dy, dz = earthSpeed
+    ddx, ddy, ddz = earthAcceleration
+
+    # Calculate the earth speed
+    Esfq = earthSpeedFlatSq(dx, dy)
+    Esf = earthSpeedFlat(dx, dy)
+    Ess = earthSpeedSq(dx, dy, dz)
+
+    psi = np.degrees(np.arctan2(dy, dx))
+    Theta = np.degrees(np.arctan2(-dz,Esf))
+    Phi = np.degrees(0.)
+
+    composite_euler_angles = np.array([psi, Theta, Phi])
+
+    composite_euler_acc_angles = np.array([0, 0, 0])
+
+    # in case of acceleration different from 0
+    if earthAcceleration.any() > 0:
+
+        num_dpsi = np.multiply(dx, ddy) - np.multiply(dy, ddx)
+        dPsi = np.degrees(np.divide(num_dpsi, Esfq))
+
+        num_dtheta = np.divide(np.multiply(dz,
+                                           (np.multiply(dx, ddz) +
+                                            np.multiply(dy, ddy))
+                                           ), Esf) -\
+                     np.multiply(ddz, Esf)
+
+        dTheta = np.degrees(np.divide(num_dtheta, Ess))
+        dPhi = np.degrees(0)
+        composite_euler_acc_angles = np.array([dPsi, dTheta, dPhi])
+
+    return (composite_euler_angles, composite_euler_acc_angles)
+
+
+def euler2rotationVector(psiThetaPhi_deg, dpsiThetaPhi_deg):
+    r""" Function to obtain the rotation vector for given Euler angles
+        and their time derivative. The Euler angles are
+        the heading of the plane, the pitch and roll.
+        This function is taken from [#]_
+
+    Parameters
+    ----------
+    psiThetaPhi_deg: np.array, float
+                    array containing the three Euler angles (deg)
+
+    dpsiThetaPhi_deg: np.array, float
+                    array containing the time derivative of the
+                    three Euler angles (deg/s)
+
+    Returns
+    -------
+    np.array, float
+            :math:`\omega_{deg}', array of the rotation vectors
+
+    Reference
+    ---------
+    [#]_ :  P. Groves, Principles of GNSS, Inertial,
+            and Multisensor Integrated
+            Navigation Systems (Second Edition),
+            Artech House, 2013.
+    """
+
+    # Number of points
+    npts = psiThetaPhi_deg.shape[1]
+
+    # Create an array of 3x Number of points
+    omega_deg = np.zeros((3, npts))
+
+    # loop on the various points
+    for ipoint in range(npts):
+        # convert the angles into radians for maths calculations
+        theta_rad = np.radians(psiThetaPhi_deg[1, ipoint])
+        phi_rad = np.radians(psiThetaPhi_deg[2, ipoint])
+
+        R = np.array([[1, 0, -np.sin(theta_rad)],
+                      [0, np.cos(phi_rad), np.sin(phi_rad) * np.cos(theta_rad)],
+                      [0, -np.sin(phi_rad), np.cos(phi_rad) * np.cos(theta_rad)]
+                      ])
+
+        omega_deg[:, ipoint] = np.matmul(R, dpsiThetaPhi_deg[:, ipoint].reshape(-1, 1))[:, 0]
+    return omega_deg
+
+
+def getAngularRotationVector(states, latLonAlt0):
+    r"""Function to obtain the rotation vector measured by
+        the gyroscope instrument.
+
+    Parameters
+    ----------
+    states: :class:`~.State`
+        target state containing the positions, velocities,
+        acceleration and the Euler angles
+    latLonAlt0: np.array
+        reference frame in latitude, longitude and altitude
+
+    Returns
+    -------
+    np.array, float
+                :math:`\omega_{deg}' array of the rotation vectors
+    """
+
+    # specify the mapping - may fail if we are not doing things in 3D
+    position_mapping = (0, 3, 6)
+    velocity_mapping = (1, 4, 7)
+    acceleration_mapping = (2, 5, 8)
+    angles_mapping = (9, 11, 13)
+    dangles_mapping = (10, 12, 14)
+
+    # create a series of points
+    npts = states.shape[1]
+
+    # Coordinates in navigation reference frame
+    localpos = states[position_mapping, :]  # use the indices of the position
+    psiThetaPhi_deg = states[angles_mapping, :]  # use the indices of the Euler angles
+    dpsiThetaPhi_deg = states[dangles_mapping, :]  # use the indices of the dEuler
+
+    # Convert the local reference point to latitude and longitude
+    lat_deg, _, _ = localSphere2GCS(localpos[0, :],
+                                    localpos[1, :],
+                                    localpos[2, :],
+                                    latLonAlt0)
+
+    omega_ib_b = np.zeros((3, npts))
+
+    # loop over the datapoints
+    for i in range(npts):
+
+        omega_nb_b = euler2rotationVector(psiThetaPhi_deg[:, i].reshape(-1, 1),
+                                          dpsiThetaPhi_deg[:, i].reshape(-1, 1))
+
+        # evaluate the rotation of the earth in the specific point
+        omega_ie_n = earthTurnRateVector(lat_deg[i])
+
+        Rbn = rotate3Ddeg(psiThetaPhi_deg[0, i],
+                          psiThetaPhi_deg[1, i],
+                          psiThetaPhi_deg[2, i])
+
+        # assume zero transport rate
+        omega_ib_b[:, i] = (np.matmul(Rbn, omega_ie_n.reshape(-1, 1)) + omega_nb_b)[:, 0]
+
+    return omega_ib_b
+
+
+def rotate3Ddeg(psi, theta, phi):
+    """Get a 3D rotation matrix corresponding
+        to the Euler angles (in degrees). The
+        3D rotation matrix (ground to airframe).
+
+    Parameters
+    ----------
+    psi : degrees
+        Heading angle in degrees
+    theta : degrees
+        pitch angle in degrees
+    phi : degrees
+        roll angle in degrees
+
+    Returns
+    -------
+    np.array
+        3D rotation matrix
+
+    """
+
+    # convert the angles in radians
+    psi_rad = np.radians(psi)
+    theta_rad = np.radians(theta)
+    phi_rad = np.radians(phi)
+
+    # create matrix components
+    rot_0 = np.array([(np.cos(psi_rad), np.sin(psi_rad), 0),
+                      (-np.sin(psi_rad), np.cos(psi_rad), 0),
+                      (0, 0, 1)])
+
+    rot_1 = np.array([(np.cos(theta_rad), 0, -np.sin(theta_rad)),
+                      (0, 1, 0),
+                      (np.sin(theta_rad), 0, np.cos(theta_rad))
+                      ])
+
+    R1 = rot_1 @ rot_0
+
+    rot_2 = np.array([(1, 0, 0),
+                      (0, np.cos(phi_rad), np.sin(phi_rad)),
+                      (0, -np.sin(phi_rad), np.cos(phi_rad))
+                      ])
+
+    return rot_2 @ R1
+
+
+def earthTurnRateVector(Lat_degs):
+    r"""Function to obtain the Earth turn rate vector
+        given the latitude in degrees. The Earth turn rate
+        is equal to :math:`7.29\times10^5` radians per seconds.
+        The equations are from [#]_.
+
+    Parameters
+    ----------
+    Lat_degs : float
+               latitude in degrees
+
+    Returns
+    -------
+    np.array
+        :math:`~\omega_{ie,i}`
+
+    Reference
+    ---------
+    [#] : M. Kok, J. Hol and T. Sch\"{o}n,
+          “Using Inertial Sensors for Position and Orientation Estimation”,
+          Foundations 456 and Trends in Signal Processing, Vol. 11, No. 1–2, pp 1–153, 2017.
+    """
+
+    # Earth turn rate (rads/s)
+    turn_rate = 7.292115e-5
+
+    # convert the latitude in radians for math operations
+    Lat_rads = np.radians(Lat_degs)
+
+    # Turn Rate of the Earth (omega_ie_n)
+    omega_ie_n = turn_rate * np.array([np.cos(Lat_rads),
+                                       0,
+                                       -np.sin(Lat_rads)]).reshape(1, -1)
+
+    return omega_ie_n
+
+
+def getForceVector(state, latLonAlt0):
+    """Measure the force measured by the accelerometer.
+        The final product is a matrix that measure
+        the forces as explained in [#]_.
+
+    Parameters
+    ----------
+    state : :class:`~.State`
+        Target states in 15-dimension space
+
+    latLonAlt0: np.array
+        reference frame array in latitude,
+        longitude and altitude
+
+    Returns
+    -------
+    np.array
+        3D array containing the velocity components
+        of the Euler angles.
+
+    Reference
+    ---------
+    [#] = M. Kok, J. Hol and T. Sch\"{o}n,
+          “Using Inertial Sensors for Position and Orientation Estimation”,
+          Foundations 456 and Trends in Signal Processing, Vol. 11, No. 1–2, pp 1–153, 2017.
+    """
+
+    # mapping
+    position_mapping = (0, 3, 6)
+    velocity_mapping = (1, 4, 7)
+    acceleration_mapping = (2, 5, 8)
+    angles_mapping = (9, 11, 13)
+    dangles_mapping = (10, 12, 14)
+
+
+    # get the points
+    npts = state.shape[1]
+
+    # coordinates in local navigation frame
+    localpos = state[position_mapping, :]
+    localvel = state[velocity_mapping, :]
+    localacc = state[acceleration_mapping, :]
+    psiThetaPhi_deg = state[dangles_mapping, :]
+
+
+    lat_deg, _, alt = localSphere2GCS(localpos[0, :],
+                                      localpos[1, :],
+                                      localpos[2, :],
+                                    latLonAlt0)
+
+    # create a force matrix
+    fb = np.zeros((3, npts))
+
+    # loop over the points
+    for ipoint in range(npts):
+        # get the 3D local position, acceleration velocity
+        p_n = localpos[:, ipoint]
+        a_nn_n = localacc[:, ipoint]
+        v_n_n = localvel[:, ipoint]
+
+        # omega rotation
+        omega_ie_n = earthTurnRateVector(lat_deg[ipoint])
+
+        a_ii_n = a_nn_n + 2 * np.cross(omega_ie_n, v_n_n) + \
+                 np.cross(omega_ie_n, np.cross(omega_ie_n, p_n))
+
+        grav_n = getGravityVector(lat_deg[ipoint], alt[ipoint])
+
+        Rbn = rotate3Ddeg(psiThetaPhi_deg[0, ipoint],
+                          psiThetaPhi_deg[1, ipoint],
+                          psiThetaPhi_deg[2, ipoint])
+
+        fb[:, ipoint] = np.matmul(Rbn, (a_ii_n - grav_n).reshape(-1,1))[:, 0]
+
+    return fb
+
+
+def getGravityVector(lat_degs, alt):
+    """Obtain the gravity vector for a particular
+        latitude and altitude.
+        This code is adapted from [#]_.
+
+    Parameters
+    ----------
+    lat_degs : degrees
+                latitude in degrees
+    alt : float
+          altitude in meters
+
+    Returns
+    -------
+    g_vector : np.array, float
+                array containing the gravity
+                components on the specific latitude, altitude
+                location.
+
+    Reference:
+    ----------
+    [#] : P. Groves, Principles of GNSS, Inertial,
+          and Multisensor Integrated Navigation Systems (Second Edition),
+          Artech House, 2013.
+    """
+
+    # Define some WGS 84 ellispod
+    earth_major_axis = 6378137.0  # meters
+    earth_minor_axis = 6356752.314245  # meters
+
+    # compute the Earth flattening and eccentricy
+    flattening = (earth_major_axis - earth_minor_axis) / earth_major_axis
+    eccentricity = np.sqrt(flattening * (2 - flattening))
+
+    # Define the equatorial radius (adapted from Groves)
+    earth_radius = 6378137.0  # meters
+    # Define the angular rate (omega_ie, WGS_84)
+    omega_i_e = 7.292115e-5
+    # Define the gravitational constant
+    mu = 3.9860044e14
+
+    # Convert the latitude in radians from degrees
+    lat_rads = np.radians(lat_degs)
+
+    # gravity model
+    g0_L = 9.7803253359 * ((1. + 0.001931853 *
+                            (np.sin(lat_rads)) ** 2) /
+                           np.sqrt(1 - eccentricity ** 2 *
+                                   (np.sin(lat_rads)) ** 2))
+
+    # gravity component north
+    g_north = -8.08e-9 * alt * np.sin(2 * lat_rads)
+    # gravity component low
+    g_down = g0_L * (1. - (2. / earth_radius) *
+                     (1. + flattening * (1. - 2. *
+                                         ((np.sin(lat_rads)) ** 2))
+                      + ((omega_i_e ** 2 * earth_radius ** 2 * earth_minor_axis) / mu))
+                     * alt + (3 / (earth_radius ** 2)) * alt ** 2)
+
+    g_vector = np.array([g_north, 0, g_down])
+
+    return g_vector

--- a/stonesoup/functions/tests/test_navigation.py
+++ b/stonesoup/functions/tests/test_navigation.py
@@ -1,0 +1,144 @@
+import pytest
+import numpy as np
+from copy import deepcopy
+from stonesoup.types.state import StateVector
+from stonesoup.functions.navigation import earthSpeedFlatSq, earthSpeedSq, earthTurnRateVector, \
+    getGravityVector, rotate3Ddeg, getEulersAngles, getForceVector, getAngularRotationVector, \
+    euler2rotationVector
+
+
+@pytest.mark.parametrize(
+    "x, y, z",
+    [  # Cartesian values
+        (1., 0., 0.),
+        (0., 1., 0.),
+        (0., 0., 1.)
+    ]
+)
+def test_EarthSpeed(x, y, z):
+    """Speed respect the Earth tests"""
+    speed3D = np.power(x, 2) + np.power(y, 2) + np.power(z, 2)
+    speed2D = np.power(x, 2) + np.power(y, 2)
+
+    # check that the 2D speed is the same as calculated with EarthSpeedSq
+    assert np.allclose(speed3D, earthSpeedSq(x, y, z))
+
+    # check that the 3D speed is the same as calculated with EarthSpeed
+    assert np.allclose(speed2D, earthSpeedFlatSq(x, y))
+
+@pytest.mark.parametrize(
+    "latitude",
+    [
+        (40),
+        (55),
+        (60),
+        (10),
+        (35)
+    ]
+)
+def test_earthTurnRateVector(latitude):
+    """earthTurnRateVector test"""
+
+    turn_rate = 7.292115e-5
+
+    assert np.allclose(earthTurnRateVector(latitude),
+                       turn_rate*np.array([
+                           np.cos(np.radians(latitude)),
+                           0,
+                           -np.sin(np.radians(latitude))]
+                       ).reshape(1, -1))
+
+
+@pytest.mark.parametrize(
+    "latitude, altitude, gv",
+    [
+        (55.0018, 1000, np.array([-7.59254272e-06, 0.00000000e+00, 9.81199039e+00])),
+    ]
+)
+def test_getGravityVector(latitude, altitude, gv):
+    """getGravityVector test"""
+
+    assert np.allclose(getGravityVector(latitude, altitude), gv, rtol=1e-4)
+
+
+
+@pytest.mark.parametrize(
+    "psi, theta, phi",
+    [
+        (90, 0, 0),
+        (0, 90, 0),
+        (0, 0, 90),
+        (30, 60, 0),
+        (0, 30, 60),
+        (60, 0, 30),
+        (45, 0, 0),
+        (0, 45, 0),
+        (0, 0, 45)
+    ]
+)
+def test_rotate3Ddeg(psi, theta, phi):
+    """rotate3Ddeg test"""
+
+    arr0 = np.array([
+        (np.cos(np.radians(psi)), np.sin(np.radians(psi)), 0),
+        (-np.sin(np.radians(psi)), np.cos(np.radians(psi)), 0),
+        (0, 0, 1)
+    ])
+
+    arr1 = np.array([
+        (np.cos(np.radians(theta)), 0, -np.sin(np.radians(theta))),
+        (0, 1, 0),
+        (np.sin(np.radians(theta)), 0, np.cos(np.radians(theta)))
+    ])
+
+    arr2= np.array([
+        (1, 0, 0),
+        (0, np.cos(np.radians(phi)), np.sin(np.radians(phi))),
+        (0, -np.sin(np.radians(phi)), np.cos(np.radians(phi)))
+    ])
+
+    assert np.array_equal(rotate3Ddeg(psi, theta, phi), arr2@arr1@arr0)
+
+
+def test_functions_using_states():
+    """A unique routine to test various
+        functions using a unique 15 dimension state
+        and check the results
+    """
+
+    state_test = StateVector(
+        [10, 20, 1,  # xyz
+          5, -5, 1,   # v, xyz
+          1, 1, 1,    # a, xyz
+          100, 2,     # psi dpsi
+          50, 5,      # theta, dtheta
+          0, 1])      # phi, dpi
+
+    # index state positions
+    pos_idx = [0, 3, 6]
+    speed_idx = [1, 4, 7]
+    acc_idx = [2, 5, 8]
+    ang_idx = [9, 11, 13]
+    vang_idx = [10, 12, 14]
+
+    # latitude, longitude, altitude
+    reference = np.array([55, 0, 0])
+
+    # set of results
+    angular_rotation = np.array([1.23399665, 4.99995881, 0.64274365]).reshape(-1, 1)
+
+    force_vector = np.array([ 7.27296026, -1.1574382, -5.04688849]).reshape(-1, 1)
+
+    euler_rotation = np.array([1.23395556, 5., 0.64278761]).reshape(-1, 1)
+
+    euler_angles = (np.array([-14.03624347,  -2.7770768, 0.]),
+                    np.array([3.37033997, -2.67486843, 0.]))
+
+    assert np.allclose(getAngularRotationVector(state_test, reference),
+                       angular_rotation)
+    assert np.allclose(getForceVector(state_test, reference),
+                  force_vector)
+    assert np.allclose(euler2rotationVector(state_test[ang_idx], state_test[vang_idx]),
+                       euler_rotation)
+    assert np.allclose(getEulersAngles(state_test[speed_idx], state_test[acc_idx]),
+                       euler_angles)


### PR DESCRIPTION
In this PR we present a set of measurement models regarding inertia navigation, in particular the measurement models from accelerometer and gyroscope on board of sensors. To use these measurement models a set of navigation functions have been added (including tests).
Summarising this PR consists in:

1.  Navigation functions and Euler angles calculations;
2.  Accelerometer measurement model
3.  Gyroscope Measurement model
4.  Azimuth-Elevation and Azimuth-Elevation-Range measurement model with fixed targets (for navigation calibration)
5.  an example of tracking using these measurement models.
6.  set of tests for the functions and measurement models.