### PR TITLE
Fixing bug which causes multiplication by Probability to return a Probability

### DIFF
--- a/stonesoup/hypothesiser/probability.py
+++ b/stonesoup/hypothesiser/probability.py
@@ -147,10 +147,10 @@ class PDAHypothesiser(Hypothesiser):
                 prediction, detection.measurement_model, **kwargs)
             # Calculate difference before to handle custom types (mean defaults to zero)
             # This is required as log pdf coverts arrays to floats
-            log_pdf = multivariate_normal.logpdf(
+            log_prob = multivariate_normal.logpdf(
                 (detection.state_vector - measurement_prediction.state_vector).ravel(),
                 cov=measurement_prediction.covar)
-            pdf = Probability(log_pdf, log_value=True)
+            probability = Probability(log_prob, log_value=True)
 
             if measure(measurement_prediction, detection) \
                     <= self._gate_threshold(self.prob_gate, measurement_prediction.ndim):
@@ -161,7 +161,7 @@ class PDAHypothesiser(Hypothesiser):
                 valid_measurement = False
 
             if self.include_all or valid_measurement:
-                probability = pdf * self.prob_detect
+                probability *= self.prob_detect
                 if self.clutter_spatial_density is not None:
                     probability /= self.clutter_spatial_density
 

--- a/stonesoup/types/numeric.py
+++ b/stonesoup/types/numeric.py
@@ -141,8 +141,11 @@ class Probability(Real):
 
     def __mul__(self, other):
         try:
-            return Probability(self.log_value + self._log(other),
-                               log_value=True)
+            if isinstance(other, Probability):
+                return Probability(self.log_value + self._log(other),
+                                   log_value=True)
+            else:
+                return exp(self.log_value + self._log(other))
         except ValueError:
             return float(self) * other
 

--- a/stonesoup/types/numeric.py
+++ b/stonesoup/types/numeric.py
@@ -139,6 +139,13 @@ class Probability(Real):
         return Probability(log_l + log1p(-exp_diff),
                            log_value=True)
 
+    def __imul__(self, other):
+        try:
+            return Probability(self.log_value + self._log(other),
+                               log_value=True)
+        except ValueError:
+            return float(self) * other
+
     def __mul__(self, other):
         try:
             if isinstance(other, Probability):

--- a/stonesoup/types/tests/test_numeric.py
+++ b/stonesoup/types/tests/test_numeric.py
@@ -116,6 +116,9 @@ def test_probability_multiply():
     assert isinstance(probability1*value1, float)
     assert approx(45.0) == probability2*value1
 
+    probability1 *= 0.5
+    assert isinstance(probability1, Probability)
+
 
 def test_probability_divide():
     probability1 = Probability(0.2)

--- a/stonesoup/types/tests/test_numeric.py
+++ b/stonesoup/types/tests/test_numeric.py
@@ -102,6 +102,7 @@ def test_probability_subtraction():
 def test_probability_multiply():
     probability1 = Probability(0.2)
     probability2 = Probability(0.3)
+    value1 = 150.0
 
     assert approx(0.06) == probability1 * probability2
     assert (probability1 * probability2).log_value == log(0.2) + log(0.3)
@@ -111,6 +112,9 @@ def test_probability_multiply():
 
     assert approx(-0.4) == probability1 * -2
     assert approx(-0.6) == -2 * probability2
+
+    assert isinstance(probability1*value1, float)
+    assert approx(45.0) == probability2*value1
 
 
 def test_probability_divide():


### PR DESCRIPTION
In general when you multiply a value by a probability you shouldn't get a probability. This is what the overwritten `__mult__()` method is doing. Hence if `a = Probability(0.3)*5.0`, `a = Probability(1.5)` which doesn't make sense. This fixes that to return a float unless the input is `Probability` in which case return `Probability`.

There may also be a discussion to be had about preserving the class of the value by which the probability is multiplied, using `value.__class__(prob*value)` or something, but that runs a little against allowing Python to do its thing. And it creates problems with integers. But it might fix a problem by which StateVectors of size (1,1) are reduced to floats.

