### PR TITLE
Error-Controller BRUF and Variable-Step BRUF

### DIFF
--- a/stonesoup/updater/kalman.py
+++ b/stonesoup/updater/kalman.py
@@ -115,7 +115,7 @@ class KalmanUpdater(Updater):
         """
         return predicted_state.covar @ measurement_matrix.T
 
-    def _innovation_covariance(self, m_cross_cov, meas_mat, meas_mod):
+    def _innovation_covariance(self, m_cross_cov, meas_mat, meas_mod, **kwargs):
         """Compute the innovation covariance
 
         Parameters
@@ -222,7 +222,7 @@ class KalmanUpdater(Updater):
 
         # The measurement cross covariance and innovation covariance
         meas_cross_cov = self._measurement_cross_covariance(predicted_state, hh)
-        innov_cov = self._innovation_covariance(meas_cross_cov, hh, measurement_model)
+        innov_cov = self._innovation_covariance(meas_cross_cov, hh, measurement_model, **kwargs)
 
         return MeasurementPrediction.from_state(
             predicted_state, pred_meas, innov_cov, cross_covar=meas_cross_cov)

--- a/stonesoup/updater/recursive.py
+++ b/stonesoup/updater/recursive.py
@@ -385,3 +385,77 @@ class VariableStepBayesianRecursiveUpdater(BayesianRecursiveUpdater):
     @classmethod
     def _get_meas_cov_scale_factor(cls, n=1, step_no=None):
         return 1 / (step_no / ((n * (n + 1)) / 2))
+
+
+class ErrorControllerBayesianRecursiveUpdater(BayesianRecursiveUpdater):
+    atol: float = Property(doc="TODO")
+    rtol: float = Property(doc="TODO")
+
+    def update(self, hypothesis, **kwargs):
+
+        # 1) X0 = prior state
+
+        # 2) P0 = prior covariance
+
+        # 3) tc = 0
+
+        # 4) ds = 1/number steps
+
+        # 5) i = 1
+
+        # 7 while loop
+        while tc < 1:
+
+            # 8 *** BEGIN IF STATEMENT ***
+            if tc + ds > 1:
+
+                # 9) ds = 1 - tc
+
+            # 10) *** END OF IF STATEMENT ***
+
+            # 12-14) Jacobian, innov_cov, Kalman gain calculations using prior state. Note different innov cov method
+
+            # 15) deltaX calculation
+
+            # 16) posterior state calculation
+
+            # 17) posterior cov calculaion
+
+            # 19-21) Jacobian, innov_cov, Kalman gain calculations using posterior state. Note different innov cov method
+
+            # 22) deltaX_prime calculation
+
+            # 23) posterior_state_prime calculation
+
+            # 24) sc calculation
+
+            # 25) error calculation
+
+            # 27) if statement
+            if error > 1:
+
+                # 28) update ds
+
+                # 29) reject update and begin next iteration
+
+            # 30) *** END OF IF STATEMENT ***
+
+            # 32) update tc (tc = tc + ds)
+
+            # 33) posterior_state_vector <- posterior_state_vector_tilda
+
+            # 34) posterior_cov <- posterior_cov_tilda
+
+            # 35) update iteration count
+            i += 1
+
+            # 36) update ds
+
+        # 37) *** END OF WHILE LOOP ***
+
+        # 39) final_posterior_state_vector <- posterior_state_vector at i-1
+
+        # 40) final_posterior_cov <- posterior_cov
+
+
+

--- a/stonesoup/updater/tests/test_recursive.py
+++ b/stonesoup/updater/tests/test_recursive.py
@@ -137,7 +137,7 @@ def test_bruf_multi_step(measurement_model, prediction, measurement, timestamp):
         measurement_model.matrix() @ prediction.mean,
         measurement_model.matrix() @ prediction.covar
         @ measurement_model.matrix().T
-        + n_steps * measurement_model.covar(),
+        + measurement_model.covar(),
         cross_covar=prediction.covar @ measurement_model.matrix().T)
 
     # Get and assert measurement prediction
@@ -380,7 +380,7 @@ def test_jcru_multi_step(measurement_model, prediction, measurement, timestamp):
         measurement_model.matrix() @ prediction.mean,
         measurement_model.matrix() @ prediction.covar
         @ measurement_model.matrix().T
-        + n_steps * measurement_model.covar(),
+        + measurement_model.covar(),
         cross_covar=prediction.covar @ measurement_model.matrix().T)
 
     # Get and assert measurement prediction

--- a/stonesoup/updater/tests/test_recursive.py
+++ b/stonesoup/updater/tests/test_recursive.py
@@ -710,7 +710,7 @@ def test_vsbruf_single_step(n_steps, force_sym_cov, use_joseph_cov, measurement_
 
     updater = VariableStepBayesianRecursiveUpdater(measurement_model=measurement_model,
                                                    number_steps=n_steps,
-                                                   use_joseph_cov=False,
+                                                   use_joseph_cov=use_joseph_cov,
                                                    force_symmetric_covariance=force_sym_cov)
 
     hypothesis = SingleHypothesis(prediction=prediction,

--- a/stonesoup/updater/tests/test_recursive.py
+++ b/stonesoup/updater/tests/test_recursive.py
@@ -1,5 +1,6 @@
 """Test for updater.recursive module"""
 import datetime
+import math
 
 import numpy as np
 import pytest
@@ -10,7 +11,8 @@ from stonesoup.types.hypothesis import SingleHypothesis
 from stonesoup.types.prediction import GaussianMeasurementPrediction, EnsembleStatePrediction
 from stonesoup.types.state import GaussianState, EnsembleState
 from stonesoup.updater.recursive import BayesianRecursiveUpdater, RecursiveEnsembleUpdater, \
-    RecursiveLinearisedEnsembleUpdater, VariableStepBayesianRecursiveUpdater
+    RecursiveLinearisedEnsembleUpdater, VariableStepBayesianRecursiveUpdater, \
+    ErrorControllerBayesianRecursiveUpdater
 
 
 def test_bruf_single_step(measurement_model, prediction, measurement, timestamp):
@@ -1043,6 +1045,421 @@ def test_joseph_cov_vsbruf_multi_step(measurement_model, prediction, measurement
     updater = VariableStepBayesianRecursiveUpdater(measurement_model=measurement_model,
                                                    number_steps=n_steps,
                                                    use_joseph_cov=True)
+
+    hypothesis = SingleHypothesis(prediction=prediction,
+                                  measurement=measurement)
+
+    # Run updater
+
+    updated_state = updater.update(hypothesis)
+
+    assert updated_state.timestamp == timestamp
+    assert updated_state.hypothesis.prediction == prediction
+    assert updated_state.hypothesis.measurement == measurement
+    assert updated_state.ndim == updated_state.hypothesis.prediction.ndim
+    # Test updater runs with measurement prediction already in hypothesis.
+    test_measurement_prediction = updater.predict_measurement(prediction)
+    hypothesis = SingleHypothesis(prediction=prediction,
+                                  measurement=measurement,
+                                  measurement_prediction=test_measurement_prediction)
+    updated_state = updater.update(hypothesis)
+
+    assert updated_state.timestamp == timestamp
+    assert updated_state.hypothesis.prediction == prediction
+    assert updated_state.hypothesis.measurement == measurement
+    assert updated_state.ndim == updated_state.hypothesis.prediction.ndim
+
+    eval_measurement_prediction = GaussianMeasurementPrediction(
+        measurement_model.matrix() @ prediction.mean,
+        measurement_model.matrix() @ prediction.covar
+        @ measurement_model.matrix().T
+        + n_steps * measurement_model.covar(),
+        cross_covar=prediction.covar @ measurement_model.matrix().T)
+
+    # Get and assert measurement prediction
+    measurement_prediction = updater.predict_measurement(prediction)
+    assert (np.allclose(measurement_prediction.mean,
+                        eval_measurement_prediction.mean,
+                        0, atol=1.e-14))
+
+    assert (np.allclose(measurement_prediction.cross_covar,
+                        eval_measurement_prediction.cross_covar,
+                        0, atol=1.e-14))
+
+
+def test_ec_bruf_single_step(measurement_model, prediction, measurement, timestamp):
+
+    n_steps = 1
+
+    updater = ErrorControllerBayesianRecursiveUpdater(measurement_model=measurement_model,
+                                                      number_steps=n_steps,
+                                                      use_joseph_cov=False,
+                                                      atol=10e-3,
+                                                      rtol=10e-3,
+                                                      f=math.sqrt(0.38),
+                                                      fmin=0.2,
+                                                      fmax=6)
+
+    hypothesis = SingleHypothesis(prediction=prediction,
+                                  measurement=measurement)
+
+    # Run updater
+
+    updated_state = updater.update(hypothesis)
+
+    assert updated_state.timestamp == timestamp
+    assert updated_state.hypothesis.prediction == prediction
+    assert updated_state.hypothesis.measurement == measurement
+    assert updated_state.ndim == updated_state.hypothesis.prediction.ndim
+    # Test updater runs with measurement prediction already in hypothesis.
+    test_measurement_prediction = updater.predict_measurement(prediction)
+    hypothesis = SingleHypothesis(prediction=prediction,
+                                  measurement=measurement,
+                                  measurement_prediction=test_measurement_prediction)
+    updated_state = updater.update(hypothesis)
+
+    assert updated_state.timestamp == timestamp
+    assert updated_state.hypothesis.prediction == prediction
+    assert updated_state.hypothesis.measurement == measurement
+    assert updated_state.ndim == updated_state.hypothesis.prediction.ndim
+
+    eval_measurement_prediction = GaussianMeasurementPrediction(
+        measurement_model.matrix() @ prediction.mean,
+        measurement_model.matrix() @ prediction.covar
+        @ measurement_model.matrix().T
+        + n_steps * measurement_model.covar(),
+        cross_covar=prediction.covar @ measurement_model.matrix().T)
+    kalman_gain = eval_measurement_prediction.cross_covar @ np.linalg.inv(
+        eval_measurement_prediction.covar)
+    eval_posterior = GaussianState(
+        prediction.mean
+        + kalman_gain @ (measurement.state_vector
+                         - eval_measurement_prediction.mean),
+        prediction.covar
+        - kalman_gain @ eval_measurement_prediction.covar @ kalman_gain.T)
+
+    # Get and assert measurement prediction
+    measurement_prediction = updater.predict_measurement(prediction)
+    assert (np.allclose(measurement_prediction.mean,
+                        eval_measurement_prediction.mean,
+                        0, atol=1.e-14))
+
+    assert (np.allclose(measurement_prediction.covar,
+                        eval_measurement_prediction.covar,
+                        0, atol=1.e-14))
+    assert (np.allclose(measurement_prediction.cross_covar,
+                        eval_measurement_prediction.cross_covar,
+                        0, atol=1.e-14))
+
+    # Perform and assert state update (without measurement prediction)
+    posterior = updater.update(SingleHypothesis(
+        prediction=prediction,
+        measurement=measurement))
+    assert (np.allclose(posterior.mean, eval_posterior.mean, 0, atol=1.e-14))
+    assert (np.allclose(posterior.covar, eval_posterior.covar, 0, atol=1.e-14))
+    assert (np.array_equal(posterior.hypothesis.prediction, prediction))
+    assert (np.allclose(
+        posterior.hypothesis.measurement_prediction.state_vector,
+        measurement_prediction.state_vector, 0, atol=1.e-14))
+    assert (np.allclose(posterior.hypothesis.measurement_prediction.covar,
+                        measurement_prediction.covar, 0, atol=1.e-14))
+    assert (np.array_equal(posterior.hypothesis.measurement, measurement))
+    assert (posterior.timestamp == prediction.timestamp)
+
+    # Perform and assert state update
+    posterior = updater.update(SingleHypothesis(
+        prediction=prediction,
+        measurement=measurement,
+        measurement_prediction=measurement_prediction))
+    assert (np.allclose(posterior.mean, eval_posterior.mean, 0, atol=1.e-14))
+    assert (np.allclose(posterior.covar, eval_posterior.covar, 0, atol=1.e-14))
+    assert (np.array_equal(posterior.hypothesis.prediction, prediction))
+    assert (np.allclose(
+        posterior.hypothesis.measurement_prediction.state_vector,
+        measurement_prediction.state_vector, 0, atol=1.e-14))
+    assert (np.allclose(posterior.hypothesis.measurement_prediction.covar,
+                        measurement_prediction.covar, 0, atol=1.e-14))
+    assert (np.array_equal(posterior.hypothesis.measurement, measurement))
+    assert (posterior.timestamp == prediction.timestamp)
+
+
+def test_ecbruf_multi_step(measurement_model, prediction, measurement, timestamp):
+
+    n_steps = 10
+
+    updater = ErrorControllerBayesianRecursiveUpdater(measurement_model=measurement_model,
+                                                      number_steps=n_steps,
+                                                      use_joseph_cov=False,
+                                                      atol=10e-3,
+                                                      rtol=10e-3,
+                                                      f=math.sqrt(0.38),
+                                                      fmin=0.2,
+                                                      fmax=6)
+
+    hypothesis = SingleHypothesis(prediction=prediction,
+                                  measurement=measurement)
+
+    # Run updater
+
+    updated_state = updater.update(hypothesis)
+
+    assert updated_state.timestamp == timestamp
+    assert updated_state.hypothesis.prediction == prediction
+    assert updated_state.hypothesis.measurement == measurement
+    assert updated_state.ndim == updated_state.hypothesis.prediction.ndim
+    # Test updater runs with measurement prediction already in hypothesis.
+    test_measurement_prediction = updater.predict_measurement(prediction)
+    hypothesis = SingleHypothesis(prediction=prediction,
+                                  measurement=measurement,
+                                  measurement_prediction=test_measurement_prediction)
+    updated_state = updater.update(hypothesis)
+
+    assert updated_state.timestamp == timestamp
+    assert updated_state.hypothesis.prediction == prediction
+    assert updated_state.hypothesis.measurement == measurement
+    assert updated_state.ndim == updated_state.hypothesis.prediction.ndim
+
+    eval_measurement_prediction = GaussianMeasurementPrediction(
+        measurement_model.matrix() @ prediction.mean,
+        measurement_model.matrix() @ prediction.covar
+        @ measurement_model.matrix().T
+        + n_steps * measurement_model.covar(),
+        cross_covar=prediction.covar @ measurement_model.matrix().T)
+
+    # Get and assert measurement prediction
+    measurement_prediction = updater.predict_measurement(prediction)
+    assert (np.allclose(measurement_prediction.mean,
+                        eval_measurement_prediction.mean,
+                        0, atol=1.e-14))
+
+    assert (np.allclose(measurement_prediction.cross_covar,
+                        eval_measurement_prediction.cross_covar,
+                        0, atol=1.e-14))
+
+
+def test_force_symmetric_ecbruf(measurement_model, prediction, measurement, timestamp):
+
+    n_steps = 1
+
+    updater = ErrorControllerBayesianRecursiveUpdater(measurement_model=measurement_model,
+                                                      number_steps=n_steps,
+                                                      use_joseph_cov=False,
+                                                      force_symmetric_covariance=True,
+                                                      atol=10e-3,
+                                                      rtol=10e-3,
+                                                      f=math.sqrt(0.38),
+                                                      fmin=0.2,
+                                                      fmax=6)
+
+    hypothesis = SingleHypothesis(prediction=prediction,
+                                  measurement=measurement)
+
+    # Run updater
+
+    updated_state = updater.update(hypothesis)
+
+    assert updated_state.timestamp == timestamp
+    assert updated_state.hypothesis.prediction == prediction
+    assert updated_state.hypothesis.measurement == measurement
+    assert updated_state.ndim == updated_state.hypothesis.prediction.ndim
+    # Test updater runs with measurement prediction already in hypothesis.
+    test_measurement_prediction = updater.predict_measurement(prediction)
+    hypothesis = SingleHypothesis(prediction=prediction,
+                                  measurement=measurement,
+                                  measurement_prediction=test_measurement_prediction)
+    updated_state = updater.update(hypothesis)
+
+    assert updated_state.timestamp == timestamp
+    assert updated_state.hypothesis.prediction == prediction
+    assert updated_state.hypothesis.measurement == measurement
+    assert updated_state.ndim == updated_state.hypothesis.prediction.ndim
+
+    eval_measurement_prediction = GaussianMeasurementPrediction(
+        measurement_model.matrix() @ prediction.mean,
+        measurement_model.matrix() @ prediction.covar
+        @ measurement_model.matrix().T
+        + n_steps * measurement_model.covar(),
+        cross_covar=prediction.covar @ measurement_model.matrix().T)
+    kalman_gain = eval_measurement_prediction.cross_covar @ np.linalg.inv(
+        eval_measurement_prediction.covar)
+    eval_posterior = GaussianState(
+        prediction.mean
+        + kalman_gain @ (measurement.state_vector
+                         - eval_measurement_prediction.mean),
+        prediction.covar
+        - kalman_gain @ eval_measurement_prediction.covar @ kalman_gain.T)
+
+    # Get and assert measurement prediction
+    measurement_prediction = updater.predict_measurement(prediction)
+    assert (np.allclose(measurement_prediction.mean,
+                        eval_measurement_prediction.mean,
+                        0, atol=1.e-14))
+
+    assert (np.allclose(measurement_prediction.covar,
+                        eval_measurement_prediction.covar,
+                        0, atol=1.e-14))
+    assert (np.allclose(measurement_prediction.cross_covar,
+                        eval_measurement_prediction.cross_covar,
+                        0, atol=1.e-14))
+
+    # Perform and assert state update (without measurement prediction)
+    posterior = updater.update(SingleHypothesis(
+        prediction=prediction,
+        measurement=measurement))
+    assert (np.allclose(posterior.mean, eval_posterior.mean, 0, atol=1.e-14))
+    assert (np.allclose(posterior.covar, eval_posterior.covar, 0, atol=1.e-14))
+    assert (np.array_equal(posterior.hypothesis.prediction, prediction))
+    assert (np.allclose(
+        posterior.hypothesis.measurement_prediction.state_vector,
+        measurement_prediction.state_vector, 0, atol=1.e-14))
+    assert (np.allclose(posterior.hypothesis.measurement_prediction.covar,
+                        measurement_prediction.covar, 0, atol=1.e-14))
+    assert (np.array_equal(posterior.hypothesis.measurement, measurement))
+    assert (posterior.timestamp == prediction.timestamp)
+
+    # Perform and assert state update
+    posterior = updater.update(SingleHypothesis(
+        prediction=prediction,
+        measurement=measurement,
+        measurement_prediction=measurement_prediction))
+    assert (np.allclose(posterior.mean, eval_posterior.mean, 0, atol=1.e-14))
+    assert (np.allclose(posterior.covar, eval_posterior.covar, 0, atol=1.e-14))
+    assert (np.array_equal(posterior.hypothesis.prediction, prediction))
+    assert (np.allclose(
+        posterior.hypothesis.measurement_prediction.state_vector,
+        measurement_prediction.state_vector, 0, atol=1.e-14))
+    assert (np.allclose(posterior.hypothesis.measurement_prediction.covar,
+                        measurement_prediction.covar, 0, atol=1.e-14))
+    assert (np.array_equal(posterior.hypothesis.measurement, measurement))
+    assert (posterior.timestamp == prediction.timestamp)
+
+
+def test_ecbruf_errors(measurement_model, prediction, measurement):
+
+    # Initialise a kalman updater
+    updater = ErrorControllerBayesianRecursiveUpdater(measurement_model=measurement_model,
+                                                      number_steps=0,
+                                                      use_joseph_cov=False,
+                                                      force_symmetric_covariance=True,
+                                                      atol=10e-3,
+                                                      rtol=10e-3,
+                                                      f=math.sqrt(0.38),
+                                                      fmin=0.2,
+                                                      fmax=6)
+
+    # Run updater
+    with pytest.raises(ValueError):
+        _ = updater.update(SingleHypothesis(prediction=prediction, measurement=measurement))
+
+
+def test_joseph_cov_ecbruf_single_step(measurement_model, prediction, measurement, timestamp):
+
+    n_steps = 1
+
+    updater = ErrorControllerBayesianRecursiveUpdater(measurement_model=measurement_model,
+                                                      number_steps=n_steps,
+                                                      use_joseph_cov=True,
+                                                      atol=10e-3,
+                                                      rtol=10e-3,
+                                                      f=math.sqrt(0.38),
+                                                      fmin=0.2,
+                                                      fmax=6)
+
+    hypothesis = SingleHypothesis(prediction=prediction,
+                                  measurement=measurement)
+
+    # Run updater
+
+    updated_state = updater.update(hypothesis)
+
+    assert updated_state.timestamp == timestamp
+    assert updated_state.hypothesis.prediction == prediction
+    assert updated_state.hypothesis.measurement == measurement
+    assert updated_state.ndim == updated_state.hypothesis.prediction.ndim
+    # Test updater runs with measurement prediction already in hypothesis.
+    test_measurement_prediction = updater.predict_measurement(prediction)
+    hypothesis = SingleHypothesis(prediction=prediction,
+                                  measurement=measurement,
+                                  measurement_prediction=test_measurement_prediction)
+    updated_state = updater.update(hypothesis)
+
+    assert updated_state.timestamp == timestamp
+    assert updated_state.hypothesis.prediction == prediction
+    assert updated_state.hypothesis.measurement == measurement
+    assert updated_state.ndim == updated_state.hypothesis.prediction.ndim
+
+    eval_measurement_prediction = GaussianMeasurementPrediction(
+        measurement_model.matrix() @ prediction.mean,
+        measurement_model.matrix() @ prediction.covar
+        @ measurement_model.matrix().T
+        + n_steps * measurement_model.covar(),
+        cross_covar=prediction.covar @ measurement_model.matrix().T)
+    kalman_gain = eval_measurement_prediction.cross_covar @ np.linalg.inv(
+        eval_measurement_prediction.covar)
+    eval_posterior = GaussianState(
+        prediction.mean
+        + kalman_gain @ (measurement.state_vector
+                         - eval_measurement_prediction.mean),
+        prediction.covar
+        - kalman_gain @ eval_measurement_prediction.covar @ kalman_gain.T)
+
+    # Get and assert measurement prediction
+    measurement_prediction = updater.predict_measurement(prediction)
+    assert (np.allclose(measurement_prediction.mean,
+                        eval_measurement_prediction.mean,
+                        0, atol=1.e-14))
+
+    assert (np.allclose(measurement_prediction.covar,
+                        eval_measurement_prediction.covar,
+                        0, atol=1.e-14))
+    assert (np.allclose(measurement_prediction.cross_covar,
+                        eval_measurement_prediction.cross_covar,
+                        0, atol=1.e-14))
+
+    # Perform and assert state update (without measurement prediction)
+    posterior = updater.update(SingleHypothesis(
+        prediction=prediction,
+        measurement=measurement))
+    assert (np.allclose(posterior.mean, eval_posterior.mean, 0, atol=1.e-14))
+    assert (np.allclose(posterior.covar, eval_posterior.covar, 0, atol=1.e-14))
+    assert (np.array_equal(posterior.hypothesis.prediction, prediction))
+    assert (np.allclose(
+        posterior.hypothesis.measurement_prediction.state_vector,
+        measurement_prediction.state_vector, 0, atol=1.e-14))
+    assert (np.allclose(posterior.hypothesis.measurement_prediction.covar,
+                        measurement_prediction.covar, 0, atol=1.e-14))
+    assert (np.array_equal(posterior.hypothesis.measurement, measurement))
+    assert (posterior.timestamp == prediction.timestamp)
+
+    # Perform and assert state update
+    posterior = updater.update(SingleHypothesis(
+        prediction=prediction,
+        measurement=measurement,
+        measurement_prediction=measurement_prediction))
+    assert (np.allclose(posterior.mean, eval_posterior.mean, 0, atol=1.e-14))
+    assert (np.allclose(posterior.covar, eval_posterior.covar, 0, atol=1.e-14))
+    assert (np.array_equal(posterior.hypothesis.prediction, prediction))
+    assert (np.allclose(
+        posterior.hypothesis.measurement_prediction.state_vector,
+        measurement_prediction.state_vector, 0, atol=1.e-14))
+    assert (np.allclose(posterior.hypothesis.measurement_prediction.covar,
+                        measurement_prediction.covar, 0, atol=1.e-14))
+    assert (np.array_equal(posterior.hypothesis.measurement, measurement))
+    assert (posterior.timestamp == prediction.timestamp)
+
+
+def test_joseph_cov_ecbruf_multi_step(measurement_model, prediction, measurement, timestamp):
+
+    n_steps = 10
+
+    updater = ErrorControllerBayesianRecursiveUpdater(measurement_model=measurement_model,
+                                                      number_steps=n_steps,
+                                                      use_joseph_cov=True,
+                                                      atol=10e-3,
+                                                      rtol=10e-3,
+                                                      f=math.sqrt(0.38),
+                                                      fmin=0.2,
+                                                      fmax=6)
 
     hypothesis = SingleHypothesis(prediction=prediction,
                                   measurement=measurement)


### PR DESCRIPTION
This pull request is an extension of PR #889. #889 will be closed as it is superseded by this.

New Updater classes:
- VariableStepBayesianRecursiveUpdater
- ErrorControllerBayesianRecursiveUpdater

Extensions of the BayesianRecursiveUpdater. Unlike how the BayesianRecursiveUpdater uses equal measurement noise for each recursive step, the VariableStepBayesianUpdater over-inflates measurement noise in the earlier steps, requiring the use of a smaller number of steps. The ErrorControllerBayesianRecursiveUpdater is a further extension in which error control parameters are introduced.
