### PR TITLE
Example of Ensemble Kalman filter with Out-Of-Sequence measurements

### DIFF
--- a/docs/examples/KalmanFilterOOSMExample.py
+++ b/docs/examples/KalmanFilterOOSMExample.py
@@ -7,7 +7,7 @@ Kalman filter with Out-of-Sequence measurements
 ===============================================
 """
 
-# %
+# %%
 # In this example we present how to deal with
 # out of sequence measurements (OOSM) using
 # Kalman filters. This problem is significant
@@ -176,9 +176,6 @@ ensemble = EnsembleState.generate_ensemble(
 # priors for the Particle filter tracking
 prior = EnsembleState(state_vector=ensemble, timestamp=start_time)
 
-from stonesoup.types.hypothesis import SingleHypothesis
-from stonesoup.types.track import Track
-
 # %%
 # 4) Run the tracker and visualise the results.
 # ---------------------------------------------
@@ -189,6 +186,9 @@ from stonesoup.types.track import Track
 # detections by the delay so we can process them
 # correctly. Finally we can plot the resulting track.
 #
+
+from stonesoup.types.hypothesis import SingleHypothesis
+from stonesoup.types.track import Track
 
 # Evaluate the delay between the measurements
 delay = measurements2[0].timestamp - measurements1[0].timestamp
@@ -207,10 +207,10 @@ for k in range(num_steps):  # loop over the timestep
     hypothesis = SingleHypothesis(prediction, measurements2[k])
     post = updater2.update(hypothesis)
     track.append(post)
-    prior = track[-1]
+    prior = track[-2]
 
 plotter.plot_tracks(track, [0, 2], uncertainty=True, particle=True)
-plotter.fig
+plotter.fig.show()
 
 # %%
 # Conclusions
@@ -220,8 +220,8 @@ plotter.fig
 # with the presence of out of sequence or delayed
 # measurements from a sensor. We have employed
 # an Ensemble Kalman filter to ease the tracking.
-#
 
+# %%
 # References
 # ----------
 # .. [#] S. Pornsarayouth and M. Yamakita, "Ensemble Kalman

--- a/docs/examples/KalmanFilterOOSMExample.py
+++ b/docs/examples/KalmanFilterOOSMExample.py
@@ -210,7 +210,7 @@ for k in range(num_steps):  # loop over the timestep
     prior = track[-2]
 
 plotter.plot_tracks(track, [0, 2], uncertainty=True, particle=True)
-plotter.fig.show()
+plotter.fig
 
 # %%
 # Conclusions

--- a/docs/examples/KalmanFilterOOSMExample.py
+++ b/docs/examples/KalmanFilterOOSMExample.py
@@ -8,13 +8,18 @@ Kalman filter with Out-of-Sequence measurements
 """
 
 # %%
-# In this example we present how to deal with out of sequence measurements (OOSM) using Kalman
-# filters. This problem is significant in real-world applications where data from different sources
-# can have some delays and different timesteps (e.g., two sensors observing a target).
+# In other examples we have shown how to deal with out-of-sequence measurements (OOSM)
+# with methods using inverse-time dynamics or creating a buffer where store and re-order
+# the measurements.
+# In this example we present how to deal with OOS measurements using Kalman
+# filters. The problem of OOS measurements is significant in real-world applications
+# where data from different sources can have some delays and different timesteps
+# (e.g., two sensors observing a target).
 # In the literature, there are examples (e.g., [#]_) on how to deal with such time-delays and
 # uncertain timesteps.
 # In this example, we present a simpler application using the Ensemble Kalman Filter algorithm
-# available in Stone Soup to tackle this problem.
+# available in Stone Soup to tackle this problem and we compare against an Extended Kalman
+# filter to measure the differences.
 #
 # This example follows the following structure:
 #
@@ -44,8 +49,8 @@ from stonesoup.types.groundtruth import GroundTruthPath, GroundTruthState
 from stonesoup.types.state import GaussianState
 
 # instantiate the transition model
-transition_model = CombinedLinearGaussianTransitionModel([ConstantVelocity(0.05),
-                                                          ConstantVelocity(0.05)])
+transition_model = CombinedLinearGaussianTransitionModel([ConstantVelocity(0.5),
+                                                          ConstantVelocity(0.5)])
 
 # %%
 # 1) Prepare the ground truth;
@@ -78,13 +83,13 @@ from stonesoup.models.measurement.nonlinear import CartesianToBearingRange
 measurement_model_1 = CartesianToBearingRange(  # relative to the first sensor
     ndim_state=4,
     mapping=(0, 2),
-    noise_covar=np.diag([np.radians(0.1), 3]),
+    noise_covar=np.diag([np.radians(1), 20]),
     translation_offset=np.array([[-60], [0]]))
 
 measurement_model_2 = CartesianToBearingRange(  # relative to the second sensor
     ndim_state=4,
     mapping=(0, 2),
-    noise_covar=np.diag([np.radians(0.1), 3]),
+    noise_covar=np.diag([np.radians(1), 20]),
     translation_offset=np.array([[20], [60]]))
 
 # Generate the detections
@@ -141,21 +146,35 @@ plotter.show()
 # 3) Instantiate the tracking components;
 # ---------------------------------------
 # In this example we employ an Ensemble Kalman filter by loading the predictor and updater using
-# :class:`~.EnsemblePredictor` and :class:`~.EnsembleUpdater`. This filter combines the
-# functionality of the Kalman filter and the particle filter. To access the two sets of detections
-# we initialise two different updaters, with the correct measurement models, to take into account
-# the detection translation offset.
+# :class:`~.EnsemblePredictor` and :class:`~.EnsembleUpdater` and an Extended Kalman filter using
+# :class:`~.ExtendedKalmanPredictor` and :class:`~.ExtendedKalmanUpdater`.
+# The Ensemble Kalman filter combines the functionality of the Kalman filter and the
+# particle filter. To access the two sets of detections we initialise two different updaters,
+# with the correct measurement models, to take into account the detection translation offset.
 # For simplicity, we assume that the detections obtained by the second sensor can be corrected by
 # the delay and correspond to the first set of measurements.
 #
 
+# Load the ensemble components
 from stonesoup.predictor.ensemble import EnsemblePredictor
 from stonesoup.updater.ensemble import EnsembleUpdater
 
-predictor = EnsemblePredictor(transition_model)
+# load the extended kalman filter components
+from stonesoup.updater.kalman import ExtendedKalmanUpdater
+from stonesoup.predictor.kalman import ExtendedKalmanPredictor
+
+# EKF components
+predictor = ExtendedKalmanPredictor(transition_model)
+
 # We employ two updaters to account for the different sensor translation offsets
-updater1 = EnsembleUpdater(measurement_model_1)
-updater2 = EnsembleUpdater(measurement_model_2)
+updater1 = ExtendedKalmanUpdater(measurement_model_1)
+updater2 = ExtendedKalmanUpdater(measurement_model_2)
+
+# EnKF componens
+EnKFpredictor = EnsemblePredictor(transition_model)
+
+EnKFupdater1 = EnsembleUpdater(measurement_model_1)
+EnKFupdater2 = EnsembleUpdater(measurement_model_2)
 
 # Load the Ensemble for the prior
 from stonesoup.types.state import EnsembleState
@@ -165,12 +184,17 @@ ensemble = EnsembleState.generate_ensemble(
     covar=np.diag([5, 2, 5, 2]),
     num_vectors=100)
 # This approach is similar to setting up the priors for Particle filter tracking
-prior = EnsembleState(state_vector=ensemble, timestamp=start_time)
+EnKFprior = EnsembleState(state_vector=ensemble, timestamp=start_time)
+
+# EKF prior
+prior = GaussianState(state_vector=np.array([0, 1, 0, 1]),
+                        covar=np.diag([1, 1, 1, 1]),
+                        timestamp=start_time)
 
 # %%
 # 4) Run the tracker and visualise the results.
 # ---------------------------------------------
-# We have prepared the tracker components and we are ready to generate the final track.
+# We have prepared the tracker components and we are ready to generate the final tracks.
 # Before passing the measurements to the tracking algorithm we need to correct the detections by
 # the delay so we can process them correctly. Finally we can plot the resulting track.
 #
@@ -182,9 +206,12 @@ from stonesoup.types.track import Track
 delay = measurements2[0].timestamp - measurements1[0].timestamp
 
 # Initiate the empty track
-track = Track()
+track = Track(prior)
+EnKFtrack = Track(EnKFprior)
+
 for k in range(num_steps):  # loop over the timestep
-    # We consider the same prior
+
+    # We consider the same prior - EKF
     prediction = predictor.predict(prior, timestamp=measurements1[k].timestamp)
     hypothesis = SingleHypothesis(prediction, measurements1[k])
     post = updater1.update(hypothesis)
@@ -194,18 +221,37 @@ for k in range(num_steps):  # loop over the timestep
     prediction = predictor.predict(prior, timestamp=measurements2[k].timestamp - delay)
     hypothesis = SingleHypothesis(prediction, measurements2[k])
     post = updater2.update(hypothesis)
-    track.append(post)
+    EnKFtrack.append(post)
     prior = track[-2]
 
-plotter.plot_tracks(track, [0, 2], uncertainty=True, particle=True)
+    # EnKF
+    prediction = EnKFpredictor.predict(EnKFprior, timestamp=measurements1[k].timestamp)
+    hypothesis = SingleHypothesis(prediction, measurements1[k])
+    post = EnKFupdater1.update(hypothesis)
+    EnKFtrack.append(post)
+
+    # correct the measurements timestamp with the delay
+    prediction = EnKFpredictor.predict(EnKFprior, timestamp=measurements2[k].timestamp - delay)
+    hypothesis = SingleHypothesis(prediction, measurements2[k])
+    post = EnKFupdater2.update(hypothesis)
+    EnKFtrack.append(post)
+    EnKFprior = EnKFtrack[-2]
+
+plotter.plot_tracks(track, [0, 2], track_label='EKF')
+plotter.plot_tracks(EnKFtrack, [0, 2], uncertainty=False, particle=False,
+                    track_label='EnKF', line=dict(color='red'))
 plotter.show()
 
 # %%
 # Conclusions
 # -----------
 # In this simple example we have presented how it is possible to perform the tracking with the
-# presence of out of sequence or delayed measurements from a sensor. We have employed an Ensemble
-# Kalman filter to ease the tracking.
+# presence of out of sequence or delayed measurements from a sensor.
+# We have shown two cases one using an Extended Kalman filter and the Ensemble Kalman filter.
+# In both cases we have corrected the measurements with delay and we have performed the tracking,
+# in this simpler example we don't appreciate significant differences between the two algorithms.
+# In more complex scenario (multi-target and/or cluttered scans) the particle-filter like approach of the
+# Ensemble Kalman Filter can provide better tracking performances.
 
 # %%
 # References

--- a/docs/examples/KalmanFilterOOSMExample.py
+++ b/docs/examples/KalmanFilterOOSMExample.py
@@ -9,24 +9,36 @@ Kalman filter with Out-of-Sequence measurements
 
 # %%
 # In other examples we have shown how to deal with out-of-sequence measurements (OOSM)
-# with methods using inverse-time dynamics or creating a buffer where store and re-order
-# the measurements.
+# with methods like using inverse-time dynamics or creating a buffer where store and re-order
+# the measurements according to their lag.
 # In this example we present how to deal with OOS measurements using Kalman
 # filters. The problem of OOS measurements is significant in real-world applications
 # where data from different sources can have some delays and different timesteps
-# (e.g., two sensors observing a target).
+# (e.g., two sensors observing a target) due to systems configuration and different processing
+# chain lenght.
+#
 # In the literature, there are examples (e.g., [#]_) on how to deal with such time-delays and
 # uncertain timesteps.
-# In this example, we present a simpler application using the Ensemble Kalman Filter algorithm
-# available in Stone Soup to tackle this problem and we compare against an Extended Kalman
-# filter to measure the differences.
+# In this example we consider different approaches on how to deal with the OOSM,
+# we have a tracker (called Tracker 1) which will run as the measurements arrive without any
+# treatment of delay, in this tracker we are looping every timestep as :math:`t_{now}` and
+# process every new detection without any adjustments on their time arrival.
+# A second tracker (Tracker 2), built with the same components of Tracker 1, iterates
+# at :math:`t_{now}`-:math:`t_{delay}` basically waiting for the delayed detections to arrive
+# and adjusting for the delay. This tracker will lag behind the ground-truth detections which
+# arrive at :math:`t_{now}`.
+# As control we consider a third tracker (Tracker 3) which will work excluding all the
+# delayed detections (in this case considering only the detections from one sensor).
+# The third tracker is a valid application and it is often suggested as viable option when dealing
+# with OOSM.
+# In this example, we consider Extended Kalman Filter algorithm components for each tracker.
 #
 # This example follows the following structure:
 #
 # 1. prepare the ground truth;
 # 2. set up the sensors and generate the measurements;
 # 3. instantiate the tracking components;
-# 4. run the tracker and visualise the results.
+# 4. run the trackers and visualise the results.
 #
 
 # %%
@@ -34,6 +46,7 @@ Kalman filter with Out-of-Sequence measurements
 # ^^^^^^^^^^^^^^^
 import numpy as np
 from datetime import datetime, timedelta
+from copy import deepcopy
 
 # Simulations parameters
 start_time = datetime.now().replace(microsecond=0)
@@ -41,20 +54,23 @@ np.random.seed(2000)
 num_steps = 50  # number of timesteps of the simulation
 
 # %%
-# Stone soup imports
+# Stone Soup imports
 # ^^^^^^^^^^^^^^^^^^
 from stonesoup.models.transition.linear import CombinedLinearGaussianTransitionModel, \
     ConstantVelocity
 from stonesoup.types.groundtruth import GroundTruthPath, GroundTruthState
 from stonesoup.types.state import GaussianState
 
+
 # instantiate the transition model
 transition_model = CombinedLinearGaussianTransitionModel([ConstantVelocity(0.5),
                                                           ConstantVelocity(0.5)])
 
 # %%
-# 1) Prepare the ground truth;
+# 1. Prepare the ground truth;
 # ----------------------------
+# In this example we consider a single target moving on a
+# nearly constant transition model.
 
 # initiate the groundtruth
 truth = GroundTruthPath([GroundTruthState([0, 1, 0, 1], timestamp=start_time)])
@@ -63,19 +79,18 @@ truth = GroundTruthPath([GroundTruthState([0, 1, 0, 1], timestamp=start_time)])
 for k in range(1, num_steps):
     truth.append(GroundTruthState(
         transition_model.function(truth[k - 1], noise=True,
-                                  time_interval=timedelta(seconds=1)),
-        timestamp=start_time + timedelta(seconds=k)))
+                                  time_interval=timedelta(seconds=2)),
+        timestamp=start_time + timedelta(seconds=2*k)))
 
 # %%
-# 2) Set up the sensors and generate the measurements;
+# 2. Set up the sensors and generate the measurements;
 # -----------------------------------------------------
-# In this example we consider two ideal radars using :class:`~.CartesianToBearingRange` measurement
+# We consider two ideal sensors using :class:`~.CartesianToBearingRange` measurement
 # model.
-# The second sensor sends the detections with a fixed delay of 5 seconds. So the two sets of
-# detections have a fixed, constant, delay.
-# Now, we can collect the measurements from the two sensors.
-# The two measurement model have different translation offset from the location of the sensors.
-#
+# The second sensor sends the detections with a fixed delay of 5 seconds.
+# In this way the two sets of detections have a fixed, constant, delay.
+# The two measurement model have different translation offset due to the location of the sensors.
+# In this scenario we consider a negligible clutter noise.
 
 # Load the measurement model
 from stonesoup.models.measurement.nonlinear import CartesianToBearingRange
@@ -83,14 +98,14 @@ from stonesoup.models.measurement.nonlinear import CartesianToBearingRange
 measurement_model_1 = CartesianToBearingRange(  # relative to the first sensor
     ndim_state=4,
     mapping=(0, 2),
-    noise_covar=np.diag([np.radians(1), 20]),
+    noise_covar=np.diag([np.radians(3), 20]),
     translation_offset=np.array([[-60], [0]]))
 
 measurement_model_2 = CartesianToBearingRange(  # relative to the second sensor
     ndim_state=4,
     mapping=(0, 2),
-    noise_covar=np.diag([np.radians(1), 20]),
-    translation_offset=np.array([[20], [60]]))
+    noise_covar=np.diag([np.radians(3), 20]),
+    translation_offset=np.array([[-150], [60]]))
 
 # Generate the detections
 from stonesoup.types.detection import Detection
@@ -98,20 +113,31 @@ from stonesoup.types.detection import Detection
 # Instantiate two list for the detections
 measurements1 = []
 measurements2 = []
+measurements1p = []
+measurements2p = []
+
 for state in truth:  # loop over the ground truth detections
     measurement = measurement_model_1.function(state, noise=True)
-    measurements1.append(Detection(measurement, timestamp=state.timestamp,
-                                   measurement_model=measurement_model_1))
+    measurements1.append((state.timestamp,
+                          Detection(measurement, timestamp=state.timestamp,
+                                    measurement_model=measurement_model_1)))
+    measurements1p.append(Detection(measurement, timestamp=state.timestamp,
+                                    measurement_model=measurement_model_1))
     # collect the measurements for the delayed radar
     measurement = measurement_model_2.function(state, noise=True)
-    measurements2.append(Detection(measurement, timestamp=state.timestamp + timedelta(seconds=5),
-                                   measurement_model=measurement_model_2))
+    measurements2.append((state.timestamp + timedelta(seconds=5),
+                          Detection(measurement, timestamp=state.timestamp + timedelta(seconds=5),
+                                    measurement_model=measurement_model_2)))
+    measurements2p.append(Detection(measurement, timestamp=state.timestamp + timedelta(seconds=5),
+                                    measurement_model=measurement_model_2))
 
 # %%
-# We have generated two sets of detections of the same target, one for each radar, with the latter
-# where the detection timestamp has a fixed delay of 5 seconds. Let's visualise the track and the
-# set of detections. To plot the sensors we use a :class:`~.FixedPlatform`.
+# We have generated two sets of detections of the same target, one for each sensor, with the latter
+# where the detection timestamp has a fixed delay of 5 seconds.
 #
+# Let's visualise the track and the set of detections, we use :class:`~.FixedPlatform` to show the
+# sensors locations.
+
 from stonesoup.platform.base import FixedPlatform
 
 # Only for plotting purposes
@@ -122,140 +148,178 @@ sensor1_platform = FixedPlatform(
     sensors=None)
 
 sensor2_platform = FixedPlatform(
-    states=GaussianState([20, 0, 60, 0],
+    states=GaussianState([-200, 0, 60, 0],
                          np.diag([1, 0, 1, 0])),
     position_mapping=(0, 2),
     sensors=None)
 
 from stonesoup.plotter import AnimatedPlotterly
 
-time_steps = [start_time + timedelta(seconds=i) for i in range(num_steps + 10)]
+time_steps = [start_time + timedelta(seconds=2*i) for i in range(num_steps + 5)]
 
 plotter = AnimatedPlotterly(timesteps=time_steps)
 plotter.plot_ground_truths(truth, [0, 2])
-plotter.plot_measurements(measurements1, [0, 2], marker=dict(color='blue', symbol='0'),
+plotter.plot_measurements(measurements1p, [0, 2], marker=dict(color='blue', symbol='0'),
                           measurements_label='Detections with no lag')
-plotter.plot_measurements(measurements2, [0, 2], marker=dict(color='orange', symbol='0'),
+plotter.plot_measurements(measurements2p, [0, 2], marker=dict(color='orange', symbol='0'),
                           measurements_label='Detections with lag')
 plotter.plot_sensors([sensor1_platform, sensor2_platform],
                      marker=dict(color='black', symbol='129', size=15),
                      sensor_label='Fixed Platforms')
-plotter.show()
+plotter.fig
 
 # %%
 # 3) Instantiate the tracking components;
 # ---------------------------------------
-# In this example we employ an Ensemble Kalman filter by loading the predictor and updater using
-# :class:`~.EnsemblePredictor` and :class:`~.EnsembleUpdater` and an Extended Kalman filter using
+# In this example we employ an Extended Kalman components by loading the predictor and updater using
 # :class:`~.ExtendedKalmanPredictor` and :class:`~.ExtendedKalmanUpdater`.
-# The Ensemble Kalman filter combines the functionality of the Kalman filter and the
-# particle filter. To access the two sets of detections we initialise two different updaters,
-# with the correct measurement models, to take into account the detection translation offset.
-# For simplicity, we assume that the detections obtained by the second sensor can be corrected by
-# the delay and correspond to the first set of measurements.
+# The choice of these components comes from the non-linear nature of the measurement
+# model chosen.
 #
-
-# Load the ensemble components
-from stonesoup.predictor.ensemble import EnsemblePredictor
-from stonesoup.updater.ensemble import EnsembleUpdater
 
 # load the extended kalman filter components
 from stonesoup.updater.kalman import ExtendedKalmanUpdater
 from stonesoup.predictor.kalman import ExtendedKalmanPredictor
 
-# EKF components
+# EKF predictor
 predictor = ExtendedKalmanPredictor(transition_model)
 
 # We employ two updaters to account for the different sensor translation offsets
 updater1 = ExtendedKalmanUpdater(measurement_model_1)
 updater2 = ExtendedKalmanUpdater(measurement_model_2)
 
-# EnKF componens
-EnKFpredictor = EnsemblePredictor(transition_model)
-
-EnKFupdater1 = EnsembleUpdater(measurement_model_1)
-EnKFupdater2 = EnsembleUpdater(measurement_model_2)
-
-# Load the Ensemble for the prior
-from stonesoup.types.state import EnsembleState
-
-ensemble = EnsembleState.generate_ensemble(
-    mean=np.array([0, 1, 0, 1]),
-    covar=np.diag([5, 2, 5, 2]),
-    num_vectors=100)
-# This approach is similar to setting up the priors for Particle filter tracking
-EnKFprior = EnsembleState(state_vector=ensemble, timestamp=start_time)
-
-# EKF prior
-prior = GaussianState(state_vector=np.array([0, 1, 0, 1]),
+# Track priors
+prior1 = GaussianState(state_vector=np.array([0, 1, 0, 1]),
                         covar=np.diag([1, 1, 1, 1]),
                         timestamp=start_time)
 
+prior2 = GaussianState(state_vector=np.array([0, 1, 0, 1]),
+                        covar=np.diag([1, 1, 1, 1]),
+                        timestamp=start_time+timedelta(seconds=5))
+prior3 = deepcopy(prior1)
+
 # %%
-# 4) Run the tracker and visualise the results.
-# ---------------------------------------------
+# 4) Run the trackers and visualise the results.
+# ----------------------------------------------
 # We have prepared the tracker components and we are ready to generate the final tracks.
-# Before passing the measurements to the tracking algorithm we need to correct the detections by
-# the delay so we can process them correctly. Finally we can plot the resulting track.
 #
+# Tracker 1 will consider all the detections as they are arriving from the sensors considering
+# each timestep as :math:`t_{now}`, we should expect that as the delayed detections start to
+# arrive the tracking quality will significantly drop.
+#
+# Tracker 2 will be lagging behind the timesteps, :math:`t_{now}-t_{delay}`, in this way
+# the tracker will wait for the delayed detections to arrive and will consider them in the
+# correct order and correct timestep. However the tracks will be behind the ground-truth track.
+#
+# The final tracker (3) will ignore all detections from delayed sensor.
+#
+# As we have obtained all the tracks for each tracker we will visualise them.
 
 from stonesoup.types.hypothesis import SingleHypothesis
 from stonesoup.types.track import Track
 
 # Evaluate the delay between the measurements
-delay = measurements2[0].timestamp - measurements1[0].timestamp
+delay = measurements2p[0].timestamp - measurements1p[0].timestamp
 
-# Initiate the empty track
-track = Track(prior)
-EnKFtrack = Track(EnKFprior)
+# Initiate the empty track for each tracker
+track1 = Track(prior1)  # Tracker 1 prior
+track2 = Track(prior2)  # Tracker 2 prior
+track3 = Track(prior3)  # Tracker 3 prior
 
-for k in range(num_steps):  # loop over the timestep
 
-    # We consider the same prior - EKF
-    prediction = predictor.predict(prior, timestamp=measurements1[k].timestamp)
-    hypothesis = SingleHypothesis(prediction, measurements1[k])
-    post = updater1.update(hypothesis)
-    track.append(post)
+for k in range(num_steps+5):  # loop over the timestep
 
-    # correct the measurements timestamp with the delay
-    prediction = predictor.predict(prior, timestamp=measurements2[k].timestamp - delay)
-    hypothesis = SingleHypothesis(prediction, measurements2[k])
-    post = updater2.update(hypothesis)
-    EnKFtrack.append(post)
-    prior = track[-2]
+    # Check if we have already get the delay
+    check_delay = timedelta(seconds=k)
 
-    # EnKF
-    prediction = EnKFpredictor.predict(EnKFprior, timestamp=measurements1[k].timestamp)
-    hypothesis = SingleHypothesis(prediction, measurements1[k])
-    post = EnKFupdater1.update(hypothesis)
-    EnKFtrack.append(post)
+    # When we reach the delay fix the number of timestep
+    if check_delay == delay:
+        timestep_delay = k
 
-    # correct the measurements timestamp with the delay
-    prediction = EnKFpredictor.predict(EnKFprior, timestamp=measurements2[k].timestamp - delay)
-    hypothesis = SingleHypothesis(prediction, measurements2[k])
-    post = EnKFupdater2.update(hypothesis)
-    EnKFtrack.append(post)
-    EnKFprior = EnKFtrack[-2]
+    if check_delay < delay:  # if we are below the delay, use only the first detections
+        prediction = predictor.predict(prior1, timestamp=measurements1p[k].timestamp)
+        hypothesis = SingleHypothesis(prediction, measurements1p[k])
+        post = updater1.update(hypothesis)
+        track1.append(post)
+        prior1 = track1[-1]
 
-plotter.plot_tracks(track, [0, 2], track_label='EKF')
-plotter.plot_tracks(EnKFtrack, [0, 2], uncertainty=False, particle=False,
-                    track_label='EnKF', line=dict(color='red'))
-plotter.show()
+    else:  # got the delay
+        if k < num_steps:  # if we are not at the end of first scans
+            prediction = predictor.predict(prior1, timestamp=measurements1p[k].timestamp)
+            hypothesis = SingleHypothesis(prediction, measurements1p[k])
+            post = updater1.update(hypothesis)
+            track1.append(post)
+    #        prior = track[-1]
+            prediction = predictor.predict(prior1,
+                                           timestamp=measurements2p[k - timestep_delay].timestamp)
+            hypothesis = SingleHypothesis(prediction,
+                                          measurements2p[k - timestep_delay])
+            post = updater2.update(hypothesis)
+            track1.append(post)
+            prior1 = track1[-1]
+
+        else:  # consider only the second sensors detections
+            prediction = predictor.predict(prior1,
+                                           timestamp=measurements2p[k - timestep_delay].timestamp)
+            hypothesis = SingleHypothesis(prediction,
+                                          measurements2p[k - timestep_delay])
+            post = updater2.update(hypothesis)
+            track1.append(post)
+            prior1 = track1[-1]
+
+    # Tracker 2
+    if check_delay >= delay:
+        prediction = predictor.predict(prior2,
+                                       timestamp=measurements1p[k - timestep_delay].timestamp +
+                                                 delay)
+        hypothesis = SingleHypothesis(prediction, measurements1p[k - timestep_delay])
+        post = updater1.update(hypothesis)
+        track2.append(post)
+        prediction = predictor.predict(prior2,
+                                       timestamp=measurements2p[k - timestep_delay].timestamp)
+        hypothesis = SingleHypothesis(prediction,
+                                      measurements2p[k - timestep_delay])
+        post = updater2.update(hypothesis)
+        track2.append(post)
+        prior2 = track2[-1]
+
+    # Tracker 3, the "control tracker"
+    if k < num_steps:
+        prediction = predictor.predict(prior3,
+                                       timestamp=measurements1p[k].timestamp)
+        hypothesis = SingleHypothesis(prediction,
+                                      measurements1p[k])
+        post = updater1.update(hypothesis)
+        track3.append(post)
+        prior3 = track3[-1]
+
+
+# %%
+# Visualise the tracks
+
+plotter.plot_tracks(track1, [0, 2], track_label='Tracker 1')
+plotter.plot_tracks(track2, [0, 2], track_label='Tracker 2',
+                    line=dict(color='red'))
+plotter.plot_tracks(track3, [0, 2], track_label='Tracker 3',
+                    line=dict(color='green'))
+plotter.fig
 
 # %%
 # Conclusions
 # -----------
 # In this simple example we have presented how it is possible to perform the tracking with the
 # presence of out of sequence or delayed measurements from a sensor.
-# We have shown two cases one using an Extended Kalman filter and the Ensemble Kalman filter.
-# In both cases we have corrected the measurements with delay and we have performed the tracking,
-# in this simpler example we don't appreciate significant differences between the two algorithms.
-# In more complex scenario (multi-target and/or cluttered scans) the particle-filter like approach of the
-# Ensemble Kalman Filter can provide better tracking performances.
+# We have shown a comparison between three different approaches using the same algorithm.
+# Tracker 1, which ignores the time of arrival, has a more uncertain track when the delayed
+# detections are arriving. Tracker 2, fixes the time arrival of the detections and runs behind live
+# time (which can be considered Tracker 1). The final one, which ignores the delayed detections
+# is used as control, and in this simplistic case with no clutter and a simple trajectory performs
+# quite as well as the second tracker.
 
 # %%
 # References
 # ----------
-# .. [#] S. Pornsarayouth and M. Yamakita, "Ensemble Kalman filtering of out-of-sequence
-#        measurements for continuous-time model," 2012 American Control Conference (ACC),
-#        Montreal, QC, Canada, 2012, pp. 4801-4806, doi: 10.1109/ACC.2012.6315469.
+# .. [#] S. R. Maskell, R. G. Everitt, R. Wright, M. Briers, 2005,
+#        Multi-target out-of-sequence data association: Tracking using
+#        graphical models, Information Fusion.
+

--- a/docs/examples/KalmanFilterOOSMExample.py
+++ b/docs/examples/KalmanFilterOOSMExample.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+"""
+===============================================
+Kalman filter with Out-of-Sequence measurements
+===============================================
+"""
+
+# %
+# In this example we present how to deal with
+# out of sequence measurements (OOSM) using
+# Kalman filters. This problem is significant
+# in real-world applications where data
+# from different sources can have some delays
+# and different timesteps (e.g., two sensors
+# observing a target). In literature there are
+# examples (e.g., [#]_) on how to deal with
+# such time-delays and uncertain timesteps.
+# In this example we present a simpler application
+# using the Ensemble Kalman Filter algorithm
+# available in Stone Soup to tackle this problem.
+#
+# This example follows the following structure:
+# 1) prepare the ground truth;
+# 2) set up the sensors and generate the measaurements;
+# 3) instantiate the tracking components;
+# 4) run the tracker and visualise the results.
+#
+
+# %%
+# General imports
+# ^^^^^^^^^^^^^^^
+import numpy as np
+from datetime import datetime, timedelta
+
+# Simulations parameters
+start_time = datetime.now().replace(microsecond=0)
+np.random.seed(2000)
+num_steps = 50  # number of timesteps of the simulation
+
+# %%
+# Stone soup imports
+# ^^^^^^^^^^^^^^^^^^
+from stonesoup.models.transition.linear import CombinedLinearGaussianTransitionModel, \
+    ConstantVelocity
+from stonesoup.types.groundtruth import GroundTruthPath, GroundTruthState
+from stonesoup.types.state import GaussianState
+
+# instantiate the transition model
+transition_model = CombinedLinearGaussianTransitionModel([ConstantVelocity(0.05),
+                                                          ConstantVelocity(0.05)])
+
+# initiate the groundtruth
+truth = GroundTruthPath([GroundTruthState([0, 1, 0, 1], timestamp=start_time)])
+
+# iterate over the various timesteps
+for k in range(1, num_steps):
+    truth.append(GroundTruthState(
+        transition_model.function(truth[k - 1], noise=True,
+                                  time_interval=timedelta(seconds=1)),
+        timestamp=start_time + timedelta(seconds=k)))
+
+# %%
+# 2) Set up the sensors and generate the measaurements;
+# -----------------------------------------------------
+# In this example we consider two ideal radars using
+# :class:`~.CartesianToBearingRange` measurement model.
+# The second sensor sends the detections with a
+# fixed delay of 5 seconds. So the two sets of
+# detections have a fixed, constant, delay.
+# Now, we can collect the measurements from the
+# two sensors. The two measurement model have
+# differnet translation offset from the location of
+# the sensors.
+#
+
+# Load the measurement model
+from stonesoup.models.measurement.nonlinear import CartesianToBearingRange
+
+measurement_model_1 = CartesianToBearingRange(  # relative to the first sensor
+    ndim_state=4,
+    mapping=(0, 2),
+    noise_covar=np.diag([np.radians(0.1), 3]),
+    translation_offset=np.array([[-60], [0]]))
+
+measurement_model_2 = CartesianToBearingRange(  # relative to the first sensor
+    ndim_state=4,
+    mapping=(0, 2),
+    noise_covar=np.diag([np.radians(0.1), 3]),
+    translation_offset=np.array([[20], [60]]))
+
+# Generate the detections
+from stonesoup.types.detection import Detection
+
+# Instantiate two list for the detections
+measurements1 = []
+measurements2 = []
+for state in truth:  # loop over the groud truth detections
+    measurement = measurement_model_1.function(state, noise=True)
+    measurements1.append(Detection(measurement, timestamp=state.timestamp,
+                                  measurement_model=measurement_model_1))
+    # collect the measurements for the delayed radar
+    measurement = measurement_model_2.function(state, noise=True)
+    measurements2.append(Detection(measurement, timestamp=state.timestamp + timedelta(seconds=5),
+                                  measurement_model=measurement_model_2))
+
+# %%
+# We have generated two sets of
+# detections of the same target, one for each radar,
+# with the latter where the detection timestamp
+# has a fixed delay of 5 seconds. Let's visualise the track and the
+# set of detections. To plot the sensors we use a
+# :class:`~.FixedPlatform` object.
+#
+from stonesoup.platform.base import FixedPlatform
+
+# Only for plotting purposes
+sensor1_platform = FixedPlatform(
+    states=GaussianState([-60, 0, 0, 0],
+                         np.diag([1, 0, 1, 0])),
+    position_mapping=(0, 2),
+    sensors=None)
+
+sensor2_platform = FixedPlatform(
+    states=GaussianState([20, 0, 60, 0],
+                         np.diag([1, 0, 1, 0])),
+    position_mapping=(0, 2),
+    sensors=None)
+
+from stonesoup.plotter import Plotterly
+
+plotter = Plotterly()
+plotter.plot_ground_truths(truth, [0, 2])
+plotter.plot_measurements(measurements1, [0, 2], marker=dict(color='blue', symbol='0'),
+                          measurements_label='Detections with no lag')
+plotter.plot_measurements(measurements2, [0, 2], marker=dict(color='orange', symbol='0'),
+                          measurements_label='Detections with lag')
+plotter.plot_sensors([sensor1_platform, sensor2_platform],
+                     [0, 1], marker=dict(color='black', symbol='129', size=15),
+                     sensor_label='Fixed Platforms')
+plotter.fig
+
+# %%
+# 3) Instantiate the tracking components;
+# ---------------------------------------
+# In this example we employ an Ensemble Kalman filter
+# by loading the predictor and updater using :class:`~.EnsemblePredictor`
+# and :class:`~.EnsembleUpdater`. This filter combines
+# the functionality of the Kalman filter and the particle
+# filter. To access the two sets of detections we
+# initialise two different updaters, with the correct
+# measurement models, to take into account the
+# detection translation offset.
+# For simplicity, we assume that the detections
+# obtained by the second sensor can be corrected by the delay
+# and correspond to the first set of measurements.
+#
+
+from stonesoup.predictor.ensemble import EnsemblePredictor
+from stonesoup.updater.ensemble import EnsembleUpdater
+
+predictor = EnsemblePredictor(transition_model)
+# We employ two updaters for accounting the translation offset
+updater1 = EnsembleUpdater(measurement_model_1)
+updater2 = EnsembleUpdater(measurement_model_2)
+
+# Load the Ensemble for the prior
+from stonesoup.types.state import EnsembleState
+
+ensemble = EnsembleState.generate_ensemble(
+    mean=np.array([0, 1, 0, 1]),
+    covar=np.diag([5, 2, 5, 2]),
+    num_vectors=100)
+# This approach is similar to setting up the
+# priors for the Particle filter tracking
+prior = EnsembleState(state_vector=ensemble, timestamp=start_time)
+
+from stonesoup.types.hypothesis import SingleHypothesis
+from stonesoup.types.track import Track
+
+# %%
+# 4) Run the tracker and visualise the results.
+# ---------------------------------------------
+# We have prepared the tracker components and we
+# are ready to generate the final track.
+# Before passing the measurements to the
+# tracking algorithm we need to correct the
+# detections by the delay so we can process them
+# correctly. Finally we can plot the resulting track.
+#
+
+# Evaluate the delay between the measurements
+delay = measurements2[0].timestamp - measurements1[0].timestamp
+
+# Initiate the empty track
+track = Track()
+for k in range(num_steps):  # loop over the timestep
+    # We consider the same prior
+    prediction = predictor.predict(prior, timestamp=measurements1[k].timestamp)
+    hypothesis = SingleHypothesis(prediction, measurements1[k])
+    post = updater1.update(hypothesis)
+    track.append(post)
+
+    # correct the measurements timestamp with the delay
+    prediction = predictor.predict(prior, timestamp=measurements2[k].timestamp - delay)
+    hypothesis = SingleHypothesis(prediction, measurements2[k])
+    post = updater2.update(hypothesis)
+    track.append(post)
+    prior = track[-1]
+
+plotter.plot_tracks(track, [0, 2], uncertainty=True, particle=True)
+plotter.fig
+
+# %%
+# Conclusions
+# -----------
+# In this simple example we have presented
+# how it is possible to perform the tracking
+# with the presence of out of sequence or delayed
+# measurements from a sensor. We have employed
+# an Ensemble Kalman filter to ease the tracking.
+#
+
+# References
+# ----------
+# .. [#] S. Pornsarayouth and M. Yamakita, "Ensemble Kalman
+#        filtering of out-of-sequence measurements for
+#        continuous-time model," 2012 American Control
+#        Conference (ACC), Montreal, QC, Canada, 2012,
+#        pp. 4801-4806, doi: 10.1109/ACC.2012.6315469.

--- a/docs/examples/KalmanFilterOOSMExample.py
+++ b/docs/examples/KalmanFilterOOSMExample.py
@@ -128,18 +128,20 @@ sensor2_platform = FixedPlatform(
     position_mapping=(0, 2),
     sensors=None)
 
-from stonesoup.plotter import Plotterly
+from stonesoup.plotter import AnimatedPlotterly
 
-plotter = Plotterly()
+time_steps = [start_time + timedelta(seconds=i) for i in range(num_steps + 10)]
+
+plotter = AnimatedPlotterly(timesteps=time_steps)
 plotter.plot_ground_truths(truth, [0, 2])
 plotter.plot_measurements(measurements1, [0, 2], marker=dict(color='blue', symbol='0'),
                           measurements_label='Detections with no lag')
 plotter.plot_measurements(measurements2, [0, 2], marker=dict(color='orange', symbol='0'),
                           measurements_label='Detections with lag')
 plotter.plot_sensors([sensor1_platform, sensor2_platform],
-                     [0, 1], marker=dict(color='black', symbol='129', size=15),
+                     marker=dict(color='black', symbol='129', size=15),
                      sensor_label='Fixed Platforms')
-plotter.fig
+plotter.show()
 
 # %%
 # 3) Instantiate the tracking components;
@@ -210,7 +212,7 @@ for k in range(num_steps):  # loop over the timestep
     prior = track[-2]
 
 plotter.plot_tracks(track, [0, 2], uncertainty=True, particle=True)
-plotter.fig
+plotter.show()
 
 # %%
 # Conclusions

--- a/docs/examples/KalmanFilterOOSMExample.py
+++ b/docs/examples/KalmanFilterOOSMExample.py
@@ -12,23 +12,23 @@ Kalman filter with Out-of-Sequence measurements
 # with methods like using inverse-time dynamics or creating a buffer where store and re-order
 # the measurements according to their delay.
 # In this example we present a method on how to deal with OOS measurements using Kalman
-# filters, my making the assumption that the delay of the delayed measurements is known, and constant.
+# filters, by making the assumption that the delay of the delayed measurements is known, and constant.
 # The problem of OOS measurements is significant in real-world applications
 # where data from different sources can have some delays and different timesteps
 # (e.g., two sensors observing a target) due to systems configuration and different processing
 # chain length.
 #
-# In the literature, there are examples (e.g. [#]_) on how to deal with such time-delays and
-# uncertain timesteps.
+# In the literature, there are examples on how to deal with such time-delays and
+# uncertain timesteps [#]_.
 # In this example we consider different approaches on how to deal with the OOSM,
 # we have a tracker (called Tracker 1) which will run as the measurements arrive without any
-# treatment of delay, in this tracker we are looping every timestep as :math:`t_{now}` and
+# treatment of delay, in this tracker we are looping every timestep as :math:`t_{\text{now}}` and
 # process every new detection without any adjustments on their time arrival.
 #
 # A second tracker (Tracker 2), built with the same components of Tracker 1, iterates
-# at :math:`t_{now}`-:math:`t_{delay}` basically waiting for the delayed detections to arrive
+# at :math:`t_{\text{now}}`-:math:`t_{\text{delay}}` basically waiting for the delayed detections to arrive
 # and adjusting for the delay. This tracker will lag behind the ground-truth detections which
-# arrive at :math:`t_{now}`.
+# arrive at :math:`t_{\text{now}}`.
 #
 # As a control, we consider a third tracker (Tracker 3) which will work by excluding all the
 # delayed detections (in this case considering only the detections from one sensor).
@@ -198,10 +198,10 @@ prior3 = deepcopy(prior1)
 # We have prepared the tracker components and we are ready to generate the final tracks.
 #
 # Tracker 1 will consider all the detections as they are arriving from the sensors considering
-# each timestep as :math:`t_{now}`. We should expect that as the delayed detections start to
+# each timestep as :math:`t_{\text{now}}`. We should expect that as the delayed detections start to
 # arrive the tracking quality will significantly drop.
 #
-# Tracker 2 will be lagging behind the timesteps, at :math:`t_{now}+t_{delay}`, in this way
+# Tracker 2 will be lagging behind the timesteps, at :math:`t_{\text{now}}+t_{\text{delay}}`, in this way
 # the tracker will wait for the delayed detections to arrive and will consider them in the
 # correct order and correct timestep. However the tracks will be behind the ground-truth track.
 #
@@ -292,8 +292,8 @@ for k in range(num_steps+5):  # loop over the timestep
 # ^^^^^^^^^^^^^^^^^^^^
 # The current implementation of :class:`~.AnimatedPlotterly` does not allow for a
 # "live" representation of the tracks with out of sequence measurements and tracks lagging
-# behind the :math:`t_{now}`. As well, the tracks are produced after the end of the simulation
-# with the latest :math:`t_{delay}` timesteps of the track are not yet available.
+# behind the :math:`t_{\text{now}}`. As well, the tracks are produced after the end of the simulation
+# with the latest :math:`t_{\text{delay}}` timesteps of the track are not yet available.
 # However, it is interesting to see a 1-to-1 comparison between the three trackers, even if the
 # Tracker 2 track is not, visually, lagging behind.
 


### PR DESCRIPTION
This PR adds a simple example of using a Kalman Filter with measurements with a fixed delay from a sensor.

As referenced by #940 and #939 , this is a series of examples that shows different methods to deal with OOSM. 
The example has been modified by adding a EK filter for comparison.