### PR TITLE
Adapted the square root components

### DIFF
--- a/stonesoup/predictor/kalman.py
+++ b/stonesoup/predictor/kalman.py
@@ -384,7 +384,7 @@ class UnscentedKalmanPredictor(KalmanPredictor):
                                      transition_model=self.transition_model)
 
 
-class SqrtKalmanPredictor(KalmanPredictor):
+class SqrtKalmanPredictor(ExtendedKalmanPredictor):
     r"""The version of the Kalman predictor that operates on the square root parameterisation of
     the Gaussian state, :class:`~.SqrtGaussianState`.
 

--- a/stonesoup/updater/kalman.py
+++ b/stonesoup/updater/kalman.py
@@ -401,7 +401,7 @@ class UnscentedKalmanUpdater(KalmanUpdater):
             predicted_state, meas_pred_mean, meas_pred_covar, cross_covar=cross_covar)
 
 
-class SqrtKalmanUpdater(KalmanUpdater):
+class SqrtKalmanUpdater(ExtendedKalmanUpdater):
     r"""The Square root version of the Kalman Updater.
 
     The input :class:`~.State` is a :class:`~.SqrtGaussianState` which means


### PR DESCRIPTION
Adapted the square root version of the Kalman predictor and updater to inherit from the extended, rather than standard, counterparts. This gives them access to `jacobian()` which means non-linear models can now be used. Previously an error would be chucked.