### PR TITLE
Shorten sensor management tutorials' simulation length

### DIFF
--- a/docs/tutorials/sensormanagement/01_SingleSensorManagement.py
+++ b/docs/tutorials/sensormanagement/01_SingleSensorManagement.py
@@ -131,7 +131,7 @@ transition_model = CombinedLinearGaussianTransitionModel([ConstantVelocity(0.005
 yps = range(0, 100, 10)  # y value for prior state
 truths = OrderedSet()
 ntruths = 3  # number of ground truths in simulation
-time_max = 50  # timestamps the simulation is observed over
+time_max = 20  # timestamps the simulation is observed over
 timesteps = [start_time + timedelta(seconds=k) for k in range(time_max)]
 
 xdirection = 1

--- a/docs/tutorials/sensormanagement/02_MultiSensorManagement.py
+++ b/docs/tutorials/sensormanagement/02_MultiSensorManagement.py
@@ -82,7 +82,7 @@ transition_model = CombinedLinearGaussianTransitionModel([ConstantVelocity(0.005
 yps = range(0, 100, 10)  # y value for prior state
 truths = OrderedSet()
 ntruths = 3  # number of ground truths in simulation
-time_max = 50  # timestamps the simulation is observed over
+time_max = 20  # timestamps the simulation is observed over
 timesteps = [start_time + timedelta(seconds=k) for k in range(time_max)]
 
 xdirection = 1

--- a/docs/tutorials/sensormanagement/03_OptimisedSensorManagement.py
+++ b/docs/tutorials/sensormanagement/03_OptimisedSensorManagement.py
@@ -75,7 +75,7 @@ transition_model = CombinedLinearGaussianTransitionModel([ConstantVelocity(0.005
 yps = range(0, 100, 10)  # y value for prior state
 truths = OrderedSet()
 ntruths = 3  # number of ground truths in simulation
-time_max = 50  # timestamps the simulation is observed over
+time_max = 20  # timestamps the simulation is observed over
 timesteps = [start_time + timedelta(seconds=k) for k in range(time_max)]
 
 xdirection = 1


### PR DESCRIPTION
When building the docs to test changes, the sensor management tutorials take the longest to load by far. Shortening their length from 50 to 20 shortens the loading time without compromising on the information - it is still clear that the brute force sensor managers far outperform the random one.