### PR TITLE
Adding setting title functionality to AnimationPlotter

### DIFF
--- a/stonesoup/plotter.py
+++ b/stonesoup/plotter.py
@@ -1696,6 +1696,7 @@ class AnimationPlotter(_Plotter):
     def run(self,
             times_to_plot: List[datetime] = None,
             plot_item_expiry: Optional[timedelta] = None,
+            plot_title=None,
             **kwargs):
         """Run the animation
 
@@ -1710,6 +1711,8 @@ class AnimationPlotter(_Plotter):
         \\*\\*kwargs: dict
             Additional arguments to be passed to the animation.FuncAnimation function
         """
+        if plot_title:
+            plot_title += "\n"
 
         if times_to_plot is None:
             times_to_plot = sorted({
@@ -1725,7 +1728,8 @@ class AnimationPlotter(_Plotter):
             y_label=self.y_label,
             figure_kwargs=self.figure_kwargs,
             legend_kwargs=self.legend_kwargs,
-            animation_input_kwargs=kwargs
+            animation_input_kwargs=kwargs,
+            plot_title=plot_title
         )
         return self.animation_output
 
@@ -1774,7 +1778,7 @@ class AnimationPlotter(_Plotter):
         self.plot_state_mutable_sequence(truths, mapping, truths_label, **truths_kwargs)
 
     def plot_tracks(self, tracks, mapping: List[int], uncertainty=False, particle=False,
-                    track_label="Tracks",  **kwargs):
+                    track_label="Tracks", **kwargs):
         """Plots track(s)
 
         Plots each track generated, generating a legend automatically. Tracks are plotted as solid
@@ -1926,7 +1930,8 @@ class AnimationPlotter(_Plotter):
                       animation_input_kwargs: dict = {},
                       legend_kwargs: dict = {},
                       x_label: str = "$x$",
-                      y_label: str = "$y$"
+                      y_label: str = "$y$",
+                      plot_title: str = ""
                       ) -> animation.FuncAnimation:
         """
         Parameters
@@ -2019,7 +2024,7 @@ class AnimationPlotter(_Plotter):
         line_ani = animation.FuncAnimation(fig1, cls.update_animation,
                                            frames=len(times_to_plot),
                                            fargs=(the_lines, plotting_data, min_plot_times,
-                                                  times_to_plot),
+                                                  times_to_plot, plot_title),
                                            **animation_kwargs)
 
         plt.draw()
@@ -2028,7 +2033,7 @@ class AnimationPlotter(_Plotter):
 
     @staticmethod
     def update_animation(index: int, lines: List[Line2D], data_list: List[List[State]],
-                         start_times: List[datetime], end_times: List[datetime]):
+                         start_times: List[datetime], end_times: List[datetime], title: str):
         """
         Parameters
         ----------
@@ -2052,7 +2057,9 @@ class AnimationPlotter(_Plotter):
         min_time = start_times[index]
         max_time = end_times[index]
 
-        plt.title(max_time)
+        if title is None:
+            title = ""
+        plt.title(title + str(max_time))
         for i, data_source in enumerate(data_list):
 
             if data_source is not None:

--- a/stonesoup/plotter.py
+++ b/stonesoup/plotter.py
@@ -1958,6 +1958,8 @@ class AnimationPlotter(_Plotter):
             Label for the x axis
         y_label: str
             Label for the y axis
+        plot_title: str
+            Title for the plot
 
         Returns
         -------
@@ -2047,6 +2049,8 @@ class AnimationPlotter(_Plotter):
             lowest (earliest) time for an item to be plotted
         end_times : List[datetime]
             highest (latest) time for an item to be plotted
+        title: str
+            Title for the plot
 
         Returns
         -------

--- a/stonesoup/plotter.py
+++ b/stonesoup/plotter.py
@@ -1676,7 +1676,7 @@ class _AnimationPlotterDataClass(Base):
 class AnimationPlotter(_Plotter):
 
     def __init__(self, dimension=Dimension.TWO, x_label: str = "$x$", y_label: str = "$y$",
-                 legend_kwargs: dict = {}, **kwargs):
+                 title: str = None, legend_kwargs: dict = {}, **kwargs):
 
         self.figure_kwargs = {"figsize": (10, 6)}
         self.figure_kwargs.update(kwargs)
@@ -1689,6 +1689,10 @@ class AnimationPlotter(_Plotter):
         self.x_label: str = x_label
         self.y_label: str = y_label
 
+        if title:
+            title += "\n"
+        self.title: str = title
+
         self.plotting_data: List[_AnimationPlotterDataClass] = []
 
         self.animation_output: animation.FuncAnimation = None
@@ -1696,7 +1700,6 @@ class AnimationPlotter(_Plotter):
     def run(self,
             times_to_plot: List[datetime] = None,
             plot_item_expiry: Optional[timedelta] = None,
-            plot_title=None,
             **kwargs):
         """Run the animation
 
@@ -1711,9 +1714,6 @@ class AnimationPlotter(_Plotter):
         \\*\\*kwargs: dict
             Additional arguments to be passed to the animation.FuncAnimation function
         """
-        if plot_title:
-            plot_title += "\n"
-
         if times_to_plot is None:
             times_to_plot = sorted({
                 state.timestamp
@@ -1729,7 +1729,7 @@ class AnimationPlotter(_Plotter):
             figure_kwargs=self.figure_kwargs,
             legend_kwargs=self.legend_kwargs,
             animation_input_kwargs=kwargs,
-            plot_title=plot_title
+            plot_title=self.title
         )
         return self.animation_output
 
@@ -1931,7 +1931,7 @@ class AnimationPlotter(_Plotter):
                       legend_kwargs: dict = {},
                       x_label: str = "$x$",
                       y_label: str = "$y$",
-                      plot_title: str = ""
+                      plot_title: str = None
                       ) -> animation.FuncAnimation:
         """
         Parameters

--- a/stonesoup/tests/test_plotter.py
+++ b/stonesoup/tests/test_plotter.py
@@ -1,5 +1,5 @@
 import numpy as np
-from stonesoup.plotter import Plotter, Dimension, AnimatedPlotterly
+from stonesoup.plotter import Plotter, Dimension, AnimatedPlotterly, AnimationPlotter
 import pytest
 import matplotlib.pyplot as plt
 
@@ -209,6 +209,12 @@ def test_plot_complex_uncertainty():
                                          "eignevalues or eigenvectors"):
 
         plotter.plot_tracks(track, mapping=[0, 1], uncertainty=True)
+
+
+def test_animationplotter():
+    animation_plotter = AnimationPlotter()
+    animation_plotter.plot_ground_truths(truth, [0, 2])
+    animation_plotter.run(plot_title="Plot title")
 
 
 def test_animated_plotterly():

--- a/stonesoup/tests/test_plotter.py
+++ b/stonesoup/tests/test_plotter.py
@@ -214,7 +214,13 @@ def test_plot_complex_uncertainty():
 def test_animationplotter():
     animation_plotter = AnimationPlotter()
     animation_plotter.plot_ground_truths(truth, [0, 2])
-    animation_plotter.run(plot_title="Plot title")
+    animation_plotter.plot_measurements(all_measurements, [0, 2])
+    animation_plotter.run()
+
+    animation_plotter_with_title = AnimationPlotter()
+    animation_plotter_with_title.plot_ground_truths(truth, [0, 2])
+    animation_plotter_with_title.plot_tracks(track, [0, 2])
+    animation_plotter_with_title.run(plot_title="Plot title")
 
 
 def test_animated_plotterly():

--- a/stonesoup/tests/test_plotter.py
+++ b/stonesoup/tests/test_plotter.py
@@ -211,16 +211,16 @@ def test_plot_complex_uncertainty():
         plotter.plot_tracks(track, mapping=[0, 1], uncertainty=True)
 
 
-def test_animationplotter():
+def test_animation_plotter():
     animation_plotter = AnimationPlotter()
     animation_plotter.plot_ground_truths(truth, [0, 2])
     animation_plotter.plot_measurements(all_measurements, [0, 2])
     animation_plotter.run()
 
-    animation_plotter_with_title = AnimationPlotter()
+    animation_plotter_with_title = AnimationPlotter(title="Plot title")
     animation_plotter_with_title.plot_ground_truths(truth, [0, 2])
     animation_plotter_with_title.plot_tracks(track, [0, 2])
-    animation_plotter_with_title.run(plot_title="Plot title")
+    animation_plotter_with_title.run()
 
 
 def test_animated_plotterly():


### PR DESCRIPTION
This PR adds the functionality to set the title of an AnimationPlotter plot.
This solves Issue #858.
Usage:
```
plotter = AnimationPlotter(title="Plot Name")
plotter.plot_ground_truths(truth, [0, 2])
plotter.run()
```