### PR TITLE
Simplify (or at least make more standard) control models

### DIFF
--- a/stonesoup/models/control/base.py
+++ b/stonesoup/models/control/base.py
@@ -8,8 +8,8 @@ from ...base import Property
 class ControlModel(Model):
     """Control Model base class"""
 
-    ndim_state: int = Property(doc="Number of state dimensions")
-    mapping: Sequence[int] = Property(doc="Mapping between control and state dims")
+    #ndim_state: int = Property(doc="Number of state dimensions")
+    #mapping: Sequence[int] = Property(doc="Mapping between control and state dims")
 
     @property
     def ndim(self) -> int:

--- a/stonesoup/models/control/base.py
+++ b/stonesoup/models/control/base.py
@@ -1,15 +1,10 @@
 from abc import abstractmethod
-from typing import Sequence
 
 from ..base import Model
-from ...base import Property
 
 
 class ControlModel(Model):
     """Control Model base class"""
-
-    #ndim_state: int = Property(doc="Number of state dimensions")
-    #mapping: Sequence[int] = Property(doc="Mapping between control and state dims")
 
     @property
     def ndim(self) -> int:

--- a/stonesoup/models/control/linear.py
+++ b/stonesoup/models/control/linear.py
@@ -20,7 +20,6 @@ class LinearControlModel(ControlModel, LinearModel, GaussianModel):
 
     """
 
-    # control_vector: np.ndarray = Property(doc="Control vector at time :math:`k`")
     control_matrix: np.ndarray = Property(
         doc="Control input model matrix at time :math:`k`, :math:`B_k`")
     control_noise: np.ndarray = Property(

--- a/stonesoup/models/control/linear.py
+++ b/stonesoup/models/control/linear.py
@@ -2,16 +2,17 @@ import numpy as np
 from scipy.stats import multivariate_normal
 
 from .base import ControlModel
-from ..base import LinearModel
+from ..base import LinearModel, GaussianModel
 from ...base import Property
+from ...types.array import StateVector
 
 
-class LinearControlModel(ControlModel, LinearModel):
+class LinearControlModel(ControlModel, LinearModel, GaussianModel):
     r"""Implements a linear effect to the state vector via,
 
     .. math::
 
-        \hat{x}_k = B_k \mathbf{u}_k + \gamma_k
+        \hat{x}_k = B_k (\mathbf{u}_k + \gamma_k)
 
     where :math:`B_k` is the control-input model matrix (i.e. control matrix),
     :math:`\mathbf{u}_k` is the control vector and :math:`\gamma_k` is
@@ -20,12 +21,19 @@ class LinearControlModel(ControlModel, LinearModel):
 
     """
 
-    control_vector: np.ndarray = Property(doc="Control vector at time :math:`k`")
+    # control_vector: np.ndarray = Property(doc="Control vector at time :math:`k`")
     control_matrix: np.ndarray = Property(
         doc="Control input model matrix at time :math:`k`, :math:`B_k`")
     control_noise: np.ndarray = Property(
         default=None,
         doc="Control input noise covariance at time :math:`k`")
+
+    def __init__(self, *args, **kwargs):
+        """Ensures that the None control noise defaults to a ndimxndim zero matrix"""
+        super().__init__(*args, **kwargs)
+
+        if self.control_noise is None:
+            self.control_noise = np.zeros([self.ndim_ctrl, self.ndim_ctrl])
 
     @property
     def ndim(self):
@@ -33,55 +41,37 @@ class LinearControlModel(ControlModel, LinearModel):
 
     @property
     def ndim_ctrl(self):
-        return self.control_vector.shape[0]
+        return self.control_matrix.shape[1]
 
-    def matrix(self):
+    def matrix(self, **kwargs) -> np.ndarray:
         """
         Returns
         -------
         : :class:`numpy.ndarray`
             the control-input model matrix, :math:`B_k`
         """
+
         return self.control_matrix
 
-    def control_input(self):
-        r"""The mean control input
+    def covar(self, **kwargs):
 
-        Returns
-        -------
-        : :class:`numpy.ndarray`
-            the noiseless effect of the control input, :math:`B_k \mathbf{u}_k`
+        return self.control_noise
 
-        """
-        return self.control_matrix @ self.control_vector
-
-    def rvs(self):
-        r"""Sample (once) from the multivariate normal distribution determined
-        from the mean and covariance control parameters
-
-        Returns
-        -------
-        : :class:`numpy.ndarray`
-            a sample from :math:`\mathcal{N}(B_k \mathbf{u}_k, \Gamma_k)`
+    def function(self, control_input, noise=False, **kwargs) -> StateVector:
+        """This needs to be overwritten because noise is added before the transformation
+        rather than after it.
 
         """
-        return multivariate_normal.rvs(self.control_input(),
-                                       self.control_noise).reshape(-1, 1)
+        # have to accept that control input might be None and then adjust (including to add noise).
+        if control_input is None:
+            control_vector = StateVector(np.zeros(self.ndim_ctrl))
+        else:
+            control_vector = control_input.state_vector
 
-    def pdf(self, control_vec):
-        """The value of the probability density function (pdf) at a test point
+        if isinstance(noise, bool) or noise is None:
+            if noise:
+                noise = self.rvs(num_samples=control_vector.shape[1], **kwargs)
+            else:
+                noise = 0
 
-        Parameters
-        ----------
-        control_vec : :class:`numpy.ndarray`
-            The control vector at the test point
-
-        Returns
-        -------
-        float
-            The value of the pdf at :obj:`control_vec`
-
-        """
-        return multivariate_normal.pdf(control_vec,
-                                       mean=self.control_input(),
-                                       cov=self.control_noise).reshape(-1, 1)
+        return self.matrix(**kwargs) @ (control_vector + noise)

--- a/stonesoup/models/control/linear.py
+++ b/stonesoup/models/control/linear.py
@@ -1,5 +1,4 @@
 import numpy as np
-from scipy.stats import multivariate_normal
 
 from .base import ControlModel
 from ..base import LinearModel, GaussianModel

--- a/stonesoup/models/control/tests/test_control.py
+++ b/stonesoup/models/control/tests/test_control.py
@@ -1,0 +1,26 @@
+import numpy as np
+import pytest
+
+from ..linear import LinearControlModel
+from ....types.array import StateVector
+from ....types.state import State
+
+
+@pytest.mark.parametrize("control_input, control_model", [
+        (State(StateVector([1])),
+            LinearControlModel(np.array([[0.25], [1]]))),
+        (State(StateVector([1, 2, 5])),
+            LinearControlModel(np.array([[0.25, 0, 0],
+                                         [1, 0, 0],
+                                         [0, 0.25, 0],
+                                         [0, 1, 0],
+                                         [0, 0, 0.25],
+                                         [0, 0, 1]]), control_noise=np.eye(3)))
+    ],
+    ids=["Control1D", "Control3D"]
+)
+def test_linear_model(control_input, control_model):
+
+    assert np.all(np.isclose(control_model.function(control_input, noise=False),
+           control_model.matrix() @ control_input.state_vector))
+    assert control_model.ndim == np.shape(control_model.control_noise)[1]

--- a/stonesoup/predictor/kalman.py
+++ b/stonesoup/predictor/kalman.py
@@ -18,16 +18,15 @@ from ..functions import gauss2sigma, unscented_transform
 class KalmanPredictor(Predictor):
     r"""A predictor class which forms the basis for the family of Kalman
     predictors. This class also serves as the (specific) Kalman Filter
-    :class:`~.Predictor` class. Here
+    :class:`~.Predictor` class. Here transition and control models must be linear:
 
     .. math::
 
-      f_k( \mathbf{x}_{k-1}) = F_k \mathbf{x}_{k-1},  \ b_k( \mathbf{u}_k) =
-      B_k \mathbf{u}_k \ \mathrm{and} \ \mathbf{\nu}_k \sim \mathcal{N}(0,Q_k)
+      f_k( \mathbf{x}_{k-1}, \mathbf{\nu}_k) &= F_k \mathbf{x}_{k-1} + \mathbf{\nu}_k , \
+      \mathbf{\nu}_k \sim \mathcal{N}(0,Q_k)
 
-    Notes
-    -----
-    In the Kalman filter, transition and control models must be linear.
+      \ b_k( \mathbf{u}_k, \mathbf{\eta}_k) &= B_k (\mathbf{u}_k + \mathbf{\eta}_k), \
+      \mathbf{\eta}_k \sim \mathcal{N}(0,\Gamma_k).
 
     Raises
     ------
@@ -169,7 +168,7 @@ class KalmanPredictor(Predictor):
         timestamp : :class:`datetime.datetime`, optional
             :math:`k`
         control_input : :class:`StateVector`, optional
-            :math:`u`
+            :math:`\mathbf{u}_k`
         **kwargs :
             These are passed, via :meth:`~.KalmanFilter.transition_function` to
             :meth:`~.LinearGaussianTransitionModel.matrix` and

--- a/stonesoup/predictor/kalman.py
+++ b/stonesoup/predictor/kalman.py
@@ -333,17 +333,17 @@ class UnscentedKalmanPredictor(KalmanPredictor):
             self.control_model.function(**kwargs)
 
     @predict_lru_cache()
-    def predict(self, prior, control_input=None, timestamp=None, **kwargs):
+    def predict(self, prior, timestamp=None, control_input=None, **kwargs):
         r"""The unscented version of the predict step
 
         Parameters
         ----------
         prior : :class:`~.State`
             Prior state, :math:`\mathbf{x}_{k-1}`
-        control_input: :class:`~.State`
-            Control input vector, :math:`\mathbf{u}_k`
         timestamp : :class:`datetime.datetime`
             Time to transit to (:math:`k`)
+        control_input: :class:`~.State`
+            Control input vector, :math:`\mathbf{u}_k`
         **kwargs : various, optional
             These are passed to :meth:`~.TransitionModel.covar`
 

--- a/stonesoup/predictor/kalman.py
+++ b/stonesoup/predictor/kalman.py
@@ -170,8 +170,9 @@ class KalmanPredictor(Predictor):
         control_input : :class:`StateVector`, optional
             :math:`\mathbf{u}_k`
         **kwargs :
-            These are passed, via :meth:`~.KalmanFilter.transition_function` to
-            :meth:`~.LinearGaussianTransitionModel.matrix` and
+            These are passed, via :meth:`~.KalmanFilter.transition_function()` to
+            :meth:`~.LinearGaussianTransitionModel.matrix()` and 
+            :meth:`~.LinearControlModel.function()`
 
         Returns
         -------

--- a/stonesoup/predictor/kalman.py
+++ b/stonesoup/predictor/kalman.py
@@ -171,7 +171,7 @@ class KalmanPredictor(Predictor):
             :math:`\mathbf{u}_k`
         **kwargs :
             These are passed, via :meth:`~.KalmanFilter.transition_function()` to
-            :meth:`~.LinearGaussianTransitionModel.matrix()` and 
+            :meth:`~.LinearGaussianTransitionModel.matrix()` and
             :meth:`~.LinearControlModel.function()`
 
         Returns


### PR DESCRIPTION
Problem: current control models, both in their stand-alone state and as part of the predictor, are somewhat peculiar (that's my fault). This change is designed to make them look a bit more like other models, and so hopefully make their use more intuitive. 

See here for an example of use: https://gist.github.com/jmbarr/1f9cfb06eea9dd051bb7adea9f75d3a8

Should have implications for sensor and platform management.