### PR TITLE
NumPy 2 compatibility

### DIFF
--- a/docs/examples/Custom_Pandas_Dataloader.py
+++ b/docs/examples/Custom_Pandas_Dataloader.py
@@ -137,7 +137,7 @@ class DataFrameGroundTruthReader(GroundTruthReader, _DataFrameReader):
 
             state = GroundTruthState(np.array([[row[col_name]] for col_name
                                               in self.state_vector_fields],
-                                              dtype=np.float_),
+                                              dtype=np.float64),
                                      timestamp=time,
                                      metadata=self._get_metadata(row))
 
@@ -270,7 +270,7 @@ class DataFrameDetectionReader(DetectionReader, _DataFrameReader):
 
             detections.add(Detection(
                 np.array([[row[col_name]] for col_name in self.state_vector_fields],
-                         dtype=np.float_),
+                         dtype=np.float64),
                 timestamp=time,
                 metadata=self._get_metadata(row)))
 

--- a/stonesoup/functions/__init__.py
+++ b/stonesoup/functions/__init__.py
@@ -91,7 +91,7 @@ def jacobian(fun, x,  **kwargs):
 
     # For numerical reasons the step size needs to large enough. Aim for 1e-8
     # relative to spacing between floating point numbers for each dimension
-    delta = 1e8*np.spacing(x.state_vector.astype(np.float_).ravel())
+    delta = 1e8*np.spacing(x.state_vector.astype(np.float64).ravel())
     # But at least 1e-8
     # TODO: Is this needed? If not, note special case at zero.
     delta[delta < 1e-8] = 1e-8
@@ -103,7 +103,7 @@ def jacobian(fun, x,  **kwargs):
     F = fun(x2, **kwargs)
 
     jac = np.divide(F[:, :ndim] - F[:, -1:], delta)
-    return jac.astype(np.float_)
+    return jac.astype(np.float64)
 
 
 def gauss2sigma(state, alpha=1.0, beta=2.0, kappa=None):
@@ -626,7 +626,7 @@ def gm_reduce_single(means, covars, weights):
 
     # Calculate covar
     delta_means = means - mean
-    covar = np.sum(covars*weights, axis=2, dtype=np.float_) + weights*delta_means@delta_means.T
+    covar = np.sum(covars*weights, axis=2, dtype=np.float64) + weights*delta_means@delta_means.T
 
     return mean.view(StateVector), covar.view(CovarianceMatrix)
 

--- a/stonesoup/metricgenerator/ospametric.py
+++ b/stonesoup/metricgenerator/ospametric.py
@@ -324,7 +324,8 @@ class GOSPAMetric(MetricGenerator):
         else:
             m, n = len(track_states), len(truth_states)
 
-        cost_matrix = np.full((m, n), self.c, dtype=np.float_)  # c could be int, so force to float
+        # c could be int, so force to float
+        cost_matrix = np.full((m, n), self.c, dtype=np.float64)
 
         for i_track, track_state, in zip_longest(range(m), track_states):
             for i_truth, truth_state in zip_longest(range(n), truth_states):

--- a/stonesoup/models/measurement/nonlinear.py
+++ b/stonesoup/models/measurement/nonlinear.py
@@ -990,7 +990,7 @@ class CartesianToElevationBearingRangeRate(NonLinearGaussianMeasurement, Reversi
         xyz_pos = self.rotation_matrix @ xyz_pos
         xyz_vel = self.rotation_matrix @ xyz_vel
 
-        jac = np.zeros((4, 6), dtype=np.float_)
+        jac = np.zeros((4, 6), dtype=np.float64)
 
         x, y, z = xyz_pos
         vx, vy, vz = xyz_vel

--- a/stonesoup/models/measurement/tests/test_gas.py
+++ b/stonesoup/models/measurement/tests/test_gas.py
@@ -131,7 +131,7 @@ def test_isotropic_plume(state, mapping, translation_offset):
     expected_log_likelihood = model.logpdf(conc, state)
     expected_likelihood = model.pdf(conc, state)
 
-    assert np.all(np.isclose(expected_likelihood.astype(np.float_),
+    assert np.all(np.isclose(expected_likelihood.astype(np.float64),
                              np.exp(expected_log_likelihood)))
 
     pred_conc = isoplume_h(unmapped_state, translation_offset=translation_offset)

--- a/stonesoup/platform/tests/test_platform_base.py
+++ b/stonesoup/platform/tests/test_platform_base.py
@@ -652,7 +652,7 @@ def test_range_and_angles_to_other(first_state, second_state, expected_measureme
     range_, azimuth, elevation = platform1.range_and_angles_to_other(platform2)
     # Assert difference close to zero, to handle angle wrapping (-pi == pi)
     delta = np.array([elevation, Bearing(azimuth), range_]) - expected_measurement[0:3]
-    assert np.allclose(np.asfarray(delta), 0.0)
+    assert np.allclose(np.asarray(delta, dtype=np.float64), 0.0)
 
 
 # @pytest.mark.parametrize('platform_class', [FixedPlatform, MovingPlatform])

--- a/stonesoup/plotter.py
+++ b/stonesoup/plotter.py
@@ -1133,7 +1133,7 @@ class Plotterly(_Plotter):
                 measurement_kwargs['showlegend'] = True
             else:
                 measurement_kwargs['showlegend'] = False
-            detection_array = np.asfarray(list(plot_detections.values()))
+            detection_array = np.asarray(list(plot_detections.values()), dtype=np.float64)
 
             if len(mapping) == 1:
                 self.fig.add_scatter(
@@ -1164,7 +1164,7 @@ class Plotterly(_Plotter):
                 measurement_kwargs['showlegend'] = True
             else:
                 measurement_kwargs['showlegend'] = False
-            clutter_array = np.asfarray(list(plot_clutter.values()))
+            clutter_array = np.asarray(list(plot_clutter.values()), dtype=np.float64)
 
             if len(mapping) == 1:
                 self.fig.add_scatter(

--- a/stonesoup/predictor/tests/test_particle.py
+++ b/stonesoup/predictor/tests/test_particle.py
@@ -161,7 +161,7 @@ def test_bernoulli_particle_no_detection():
     # check that the existence estimate is correct
     assert prediction.existence_probability == eval_existence
     # check that the weight prediction is correct
-    assert np.allclose(eval_weight, prediction.weight.astype(np.float_))
+    assert np.allclose(eval_weight, prediction.weight.astype(np.float64))
     # check that the weights are normalised
     assert np.around(float(np.sum(prediction.weight)), decimals=1) == 1
 
@@ -268,6 +268,6 @@ def test_bernoulli_particle_detection():
     # check that the existence estimate is correct
     assert prediction.existence_probability == eval_existence
     # check that the weight prediction is correct
-    assert np.allclose(eval_weight, prediction.weight.astype(np.float_))
+    assert np.allclose(eval_weight, prediction.weight.astype(np.float64))
     # check that the weights are normalised
     assert np.around(float(np.sum(prediction.weight)), decimals=1) == 1

--- a/stonesoup/reader/generic.py
+++ b/stonesoup/reader/generic.py
@@ -88,7 +88,7 @@ class CSVGroundTruthReader(GroundTruthReader, _CSVReader):
 
                 state = GroundTruthState(
                     np.array([[row[col_name]] for col_name in self.state_vector_fields],
-                             dtype=np.float_),
+                             dtype=np.float64),
                     timestamp=time,
                     metadata=self._get_metadata(row))
 
@@ -129,7 +129,7 @@ class CSVDetectionReader(DetectionReader, _CSVReader):
 
                 detections.add(Detection(
                     np.array([[row[col_name]] for col_name in self.state_vector_fields],
-                             dtype=np.float_),
+                             dtype=np.float64),
                     timestamp=time,
                     metadata=self._get_metadata(row)))
 

--- a/stonesoup/reader/kafka.py
+++ b/stonesoup/reader/kafka.py
@@ -144,7 +144,7 @@ class KafkaDetectionReader(DetectionReader, _KafkaReader):
         timestamp = self._get_time(data)
         state_vector = StateVector(
             [[data[field_name]] for field_name in self.state_vector_fields],
-            dtype=np.float_,
+            dtype=np.float64,
         )
         return Detection(
             state_vector=state_vector,
@@ -208,7 +208,7 @@ class KafkaGroundTruthReader(GroundTruthReader, _KafkaReader):
         timestamp = self._get_time(data)
         state_vector = StateVector(
             [[data[field_name]] for field_name in self.state_vector_fields],
-            dtype=np.float_,
+            dtype=np.float64,
         )
         return GroundTruthState(
             state_vector=state_vector,

--- a/stonesoup/reader/pandas_reader.py
+++ b/stonesoup/reader/pandas_reader.py
@@ -88,7 +88,7 @@ class DataFrameGroundTruthReader(GroundTruthReader, _DataFrameReader):
 
             state = GroundTruthState(np.array([[row[col_name]] for col_name
                                               in self.state_vector_fields],
-                                              dtype=np.float_), timestamp=time,
+                                              dtype=np.float64), timestamp=time,
                                      metadata=self._get_metadata(row))
 
             id_ = row[self.path_id_field]
@@ -128,7 +128,7 @@ class DataFrameDetectionReader(DetectionReader, _DataFrameReader):
 
             detections.add(Detection(
                 np.array([[row[col_name]] for col_name in self.state_vector_fields],
-                         dtype=np.float_),
+                         dtype=np.float64),
                 timestamp=time,
                 metadata=self._get_metadata(row)))
 

--- a/stonesoup/sensor/action/dwell_action.py
+++ b/stonesoup/sensor/action/dwell_action.py
@@ -51,7 +51,7 @@ class ChangeDwellAction(Action):
             # so rotate then stay
             duration = self.rotation_end_time - current_time
 
-        dwell_centre = np.asfarray(copy(init_value))  # in case value is mutable
+        dwell_centre = np.asarray(copy(init_value), dtype=np.float64)  # in case value is mutable
 
         angle_delta = duration.total_seconds() * self.generator.rps * 2 * np.pi
         if self.increasing_angle:

--- a/stonesoup/serialise.py
+++ b/stonesoup/serialise.py
@@ -71,7 +71,7 @@ def init_typ(yaml):
     yaml.representer.add_multi_representer(np.ndarray, ndarray_to_yaml)
     yaml.constructor.add_constructor("!numpy.ndarray", ndarray_from_yaml)
     yaml.representer.add_multi_representer(np.integer, yaml.representer.yaml_representers[int])
-    yaml.representer.add_multi_representer(np.floating, yaml.representer.yaml_representers[float])
+    yaml.representer.add_multi_representer(np.floating, npfloating_as_yaml)
 
     # Datetime
     yaml.representer.add_representer(datetime.timedelta, timedelta_to_yaml)
@@ -205,6 +205,11 @@ def angle_to_yaml(representer, node):
 def angle_from_yaml(constructor, tag_suffix, node):
     class_ = get_class(f'!stonesoup.types.angle.{tag_suffix}')
     return class_(float(constructor.construct_scalar(node)))
+
+
+def npfloating_as_yaml(representer, node):
+    """Convert np.floating to YAML."""
+    return representer.yaml_representers[float](representer, float(node))
 
 
 def ndarray_to_yaml(representer, node):

--- a/stonesoup/tests/test_serialise.py
+++ b/stonesoup/tests/test_serialise.py
@@ -143,7 +143,7 @@ def test_arrays(serialised_file, instance):
 @pytest.mark.parametrize(
     'values',
     [[np.int_(10), np.int16(20), np.int64(-30)],
-     [np.float_(10.0), np.float64(20.1), np.float32(-0.5), np.longfloat(10.5)]],
+     [np.float64(20.1), np.float32(-0.5), np.longfloat(10.5)]],
     ids=['int', 'float'])
 def test_numpy_dtypes(serialised_file, values):
     serialised_str = serialised_file.dumps(values)

--- a/stonesoup/tests/test_serialise.py
+++ b/stonesoup/tests/test_serialise.py
@@ -143,7 +143,7 @@ def test_arrays(serialised_file, instance):
 @pytest.mark.parametrize(
     'values',
     [[np.int_(10), np.int16(20), np.int64(-30)],
-     [np.float64(20.1), np.float32(-0.5), np.longfloat(10.5)]],
+     [np.float64(20.1), np.float32(-0.5), np.longdouble(10.5)]],
     ids=['int', 'float'])
 def test_numpy_dtypes(serialised_file, values):
     serialised_str = serialised_file.dumps(values)

--- a/stonesoup/types/array.py
+++ b/stonesoup/types/array.py
@@ -31,8 +31,9 @@ class Matrix(np.ndarray):
     def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
         if ufunc in (np.isfinite, np.matmul):
             # Custom types break here, so simply convert to floats.
-            inputs = [np.asfarray(input_) if isinstance(input_, Matrix) else input_
-                      for input_ in inputs]
+            inputs = [
+                np.asarray(input_, dtype=np.float64) if isinstance(input_, Matrix) else input_
+                for input_ in inputs]
         else:
             # Change to standard ndarray
             inputs = [np.asarray(input_) if isinstance(input_, Matrix) else input_
@@ -194,7 +195,8 @@ class StateVectors(Matrix):
                     state_vector[dim, 0] = type_.average(row, weights=weights)
                 else:
                     # Else use numpy built in, converting to float array
-                    state_vector[dim, 0] = type_(np.average(np.asfarray(row), weights=weights))
+                    state_vector[dim, 0] = type_(
+                        np.average(np.asarray(row, dtype=np.float64), weights=weights))
         else:
             return NotImplemented
 
@@ -214,11 +216,11 @@ class StateVectors(Matrix):
             # Only really handle simple usage here
             avg, w_sum = np.average(state_vectors, axis=1, weights=aweights, returned=True)
 
-            X = np.asfarray(state_vectors - avg)
+            X = np.asarray(state_vectors - avg, dtype=np.float64)
             if aweights is None:
                 X_T = X.T
             else:
-                X_T = (X*np.asfarray(aweights)).T
+                X_T = (X*np.asarray(aweights, dtype=np.float64)).T
             cov = X @ X_T.conj()
             cov *= np.true_divide(1, float(w_sum))
         else:

--- a/stonesoup/types/array.py
+++ b/stonesoup/types/array.py
@@ -184,7 +184,7 @@ class StateVectors(Matrix):
             # Can just use standard numpy averaging if not using custom objects
             state_vector = np.average(np.asarray(state_vectors), axis=axis, weights=weights)
             # Convert type as may have type of weights
-            state_vector = StateVector(state_vector.astype(np.float_, copy=False))
+            state_vector = StateVector(state_vector.astype(np.float64, copy=False))
         elif axis == 1:  # Need to handle special cases of averaging potentially
             state_vector = StateVector(
                 np.empty((state_vectors.shape[0], 1), dtype=state_vectors.dtype))

--- a/stonesoup/types/state.py
+++ b/stonesoup/types/state.py
@@ -638,7 +638,7 @@ class ParticleState(State):
         if weight is not None and log_weight is not None:
             raise ValueError("Cannot provide both weight and log weight")
         elif log_weight is None and weight is not None:
-            log_weight = np.log(np.asfarray(weight))
+            log_weight = np.log(np.asarray(weight, dtype=np.float64))
             if idx is not None:
                 args[idx] = log_weight
             else:
@@ -748,7 +748,7 @@ class ParticleState(State):
         if value is None:
             self.log_weight = None
         else:
-            self.log_weight = np.log(np.asfarray(value))
+            self.log_weight = np.log(np.asarray(value, dtype=np.float64))
             self.__dict__['weight'] = np.asanyarray(value)
 
     @weight.getter

--- a/stonesoup/updater/particle.py
+++ b/stonesoup/updater/particle.py
@@ -375,12 +375,12 @@ class RaoBlackwellisedParticleUpdater(MultiModelParticleUpdater):
 
             # Looks up p(m_k|m_k-1)
             log_prob_of_transition = np.log(
-                np.asfarray(predictor.transition_matrix)[model_index, :])
+                np.asarray(predictor.transition_matrix)[model_index, :], dtype=np.float64)
 
             log_product_of_probs = \
-                np.asfarray(np.log(prob_position_given_model_and_old_position)) \
+                np.asarray(np.log(prob_position_given_model_and_old_position), dtype=np.float64) \
                 + log_prob_of_transition[:, np.newaxis] \
-                + np.asfarray(np.log(prediction.model_probabilities))  # p(m_k-1|x_1:k-1)
+                + np.asarray(np.log(prediction.model_probabilities), dtype=np.float64)
 
             denominator_components.append(logsumexp(log_product_of_probs, axis=0))
 

--- a/stonesoup/updater/tests/test_particle.py
+++ b/stonesoup/updater/tests/test_particle.py
@@ -85,7 +85,7 @@ def test_particle(updater):
         indx = dummy_constraint_function(prediction)
         assert np.all(updated_state.weight[indx] == 0)
 
-    assert np.isclose(np.sum(updated_state.weight.astype(np.float_)), 1.0, rtol=1e-5)
+    assert np.isclose(np.sum(updated_state.weight.astype(np.float64)), 1.0, rtol=1e-5)
     assert updated_state.timestamp == timestamp
     assert updated_state.hypothesis.measurement_prediction == measurement_prediction
     assert updated_state.hypothesis.prediction == prediction


### PR DESCRIPTION
Upcoming NumPy 2 release has a number of breaking changes, which are fixed in this PR. This has been tested against latest nightly builds of NumPy, SciPy and matplotlib.