### PR TITLE
Add 3D plotting option to Plotterly

### DIFF
--- a/docs/examples/Polar_Plotting.py
+++ b/docs/examples/Polar_Plotting.py
@@ -124,7 +124,8 @@ for t in timesteps:
 # Time (s) vs Azimuth Angle (Radians)
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 mapping = [0]
-plotter_az_t_cart = Plotterly(title="Cartesian - Time (s) vs Azimuth Angle (Radians)",
+plotter_az_t_cart = Plotterly(dimension=1,
+                              title="Cartesian - Time (s) vs Azimuth Angle (Radians)",
                               xaxis=dict(title=dict(text="Time (seconds)")),
                               yaxis=dict(title=dict(text="Bearing (Radians)"))
                               )

--- a/stonesoup/plotter.py
+++ b/stonesoup/plotter.py
@@ -988,9 +988,6 @@ class Plotterly(_Plotter):
 
         self.dimension = Dimension(dimension)  # allows 2, 3, Dimension(2), Dimension(3)
 
-        if self.dimension != 2:
-            raise TypeError("Only 2D plotting currently supported")
-
         from plotly import colors
         layout_kwargs = dict(
             xaxis=dict(title=dict(text="<i>x</i>")),

--- a/stonesoup/plotter.py
+++ b/stonesoup/plotter.py
@@ -986,7 +986,8 @@ class Plotterly(_Plotter):
         if go is None:
             raise RuntimeError("Usage of Plotterly plotter requires installation of `plotly`")
 
-        self.dimension = Dimension(dimension)  # allows 2, 3, Dimension(2), Dimension(3)
+        self.dimension = Dimension(dimension)  # allows 1, 2, 3,
+        # Dimension(1), Dimension(2) or Dimension(3)
 
         from plotly import colors
         layout_kwargs = dict(

--- a/stonesoup/plotter.py
+++ b/stonesoup/plotter.py
@@ -1420,8 +1420,6 @@ class Plotterly(_Plotter):
                     data = state.state_vector[mapping[:2], :]
                     self.fig.add_scattergl(x=data[0], y=data[1], **particle_kwargs)
 
-
-
     @staticmethod
     def _generate_ellipse_points(state, mapping, n_points=30):
         """Generate error ellipse points for given state and mapping"""


### PR DESCRIPTION
This PR gives the option of plotting in 3D using Plotterly. It also adds more tests and makes dimension checking in Plotterly more holistic. More details are:

- Plotting is now supported in 3D for ground truth, measurements, and tracks. Sensor plotting is not here but no reason why it can't be added in the future.
- Dimension checking has been simplified so that integers can always be used in cases like `if self.dimension == 1:`
- Track uncertainty has been added in the way of error bars in the x, y, and z direction, as suggested by @Carlson-J [here](https://github.com/dstl/Stone-Soup/pull/887/commits/2ee65f3b3622ebeef784a12647bc386d96388e6b). It is not perfect because it does not show times where covariance is large, but it's a simple way of getting an idea of track uncertainty. It makes use of scatterplot3d's error arguments - making custom error bars that plot the eigenvectors would require significant effort to implement. Unfortunately, I think a bug in Plotly means 3d error bars are fixed at 1 pixel wide, so they are quite hard to see. I think it's still better than not having them, but the functionality can be removed from this PR if desired. See the pictures below:

![image](https://github.com/dstl/Stone-Soup/assets/117291860/6c738c87-95d5-493a-897b-cb0bc3bc13b7)
