### PR TITLE
Avoid test collection failure with optional dependency astropy

### DIFF
--- a/stonesoup/reader/tests/test_astronomical.py
+++ b/stonesoup/reader/tests/test_astronomical.py
@@ -3,9 +3,11 @@ from datetime import datetime
 
 import pytest
 import numpy as np
-from astropy.io import fits
 
-from ..astronomical import FITSReader, TLEFileReader
+pytest.importorskip("astropy")
+from astropy.io import fits  # noqa: E402
+
+from ..astronomical import FITSReader, TLEFileReader  # noqa: E402
 
 
 def test_fits(tmpdir):

--- a/stonesoup/types/tests/test_orbital.py
+++ b/stonesoup/types/tests/test_orbital.py
@@ -50,12 +50,15 @@ Equinoctial
 
 
 """
-import numpy as np
-import pytest
 from datetime import datetime
 
-from ...types.array import StateVector, StateVectors
-from ..orbitalstate import OrbitalState
+import numpy as np
+import pytest
+
+pytest.importorskip("astropy")
+
+from ...types.array import StateVector, StateVectors  # noqa: E402
+from ..orbitalstate import OrbitalState  # noqa: E402
 
 # Time
 dtime = datetime.now()


### PR DESCRIPTION
Tests are now skipped if astropy is missing.