### PR TITLE
Add pyehm plugin as optional tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
             python -m venv venv
             . venv/bin/activate
             pip install --upgrade pip
-            pip install -e .[dev,orbital] opencv-python-headless
+            pip install -e .[dev,orbital] opencv-python-headless pyehm
       - save_cache:
           paths:
             - ./venv

--- a/stonesoup/dataassociator/tests/test_probability.py
+++ b/stonesoup/dataassociator/tests/test_probability.py
@@ -7,14 +7,26 @@ from ..probability import PDA, JPDA
 from ...types.detection import Detection, MissedDetection
 from ...types.state import GaussianState
 from ...types.track import Track
+try:
+    from ...plugins.pyehm import JPDAWithEHM, JPDAWithEHM2
+except ImportError:
+    JPDAWithEHM = None
+    JPDAWithEHM2 = None
 
 
-@pytest.fixture(params=[PDA, JPDA])
+@pytest.fixture(
+    params=[
+        PDA,
+        JPDA,
+        pytest.param(
+            JPDAWithEHM,
+            marks=pytest.mark.skipif(JPDAWithEHM is None, reason="pyehm required")),
+        pytest.param(
+            JPDAWithEHM2,
+            marks=pytest.mark.skipif(JPDAWithEHM2 is None, reason="pyehm required")),
+    ])
 def associator(request, probability_hypothesiser):
-    if request.param is PDA:
-        return request.param(probability_hypothesiser)
-    elif request.param is JPDA:
-        return request.param(probability_hypothesiser)
+    return request.param(probability_hypothesiser)
 
 
 def test_probability(associator):

--- a/stonesoup/plugins.py
+++ b/stonesoup/plugins.py
@@ -36,7 +36,7 @@ try:
 except TypeError:  # Older interface, doesn't accept group keyword
     try:
         _plugin_points = entry_points()['stonesoup.plugins']
-    except KeyError:
+    except KeyError:  # pragma: no cover
         _plugin_points = []
 
 for entry_point in _plugin_points:
@@ -45,5 +45,5 @@ for entry_point in _plugin_points:
         plugin_module = f'{__name__}.{name}'
         sys.modules[plugin_module] = entry_point.load()
 
-    except (ImportError, ModuleNotFoundError) as e:
+    except (ImportError, ModuleNotFoundError) as e:  # pragma: no cover
         warnings.warn(f'Failed to load module. {e}')


### PR DESCRIPTION
This enables us to flag plugin compatibility issues as well as enable tests for the Stone Soup plugin system