### PR TITLE
Added Version Requirement for Plotly

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ dev =
     pandas
     ortools
     pillow
-    plotly
+    plotly>=5.0
     pytest-cov
     pytest-remotedata
     pytest-skip-slow


### PR DESCRIPTION
``stonesoup.plotter.Plotterly`` uses the 'legendrank' key word which was only introduced in [plotly 5.0.0](https://github.com/plotly/plotly.py/releases/tag/v5.0.0). Therefore the Plotly requirement needs a version designator.