### PR TITLE
Add iterated module to documentation

### DIFF
--- a/docs/source/stonesoup.updater.rst
+++ b/docs/source/stonesoup.updater.rst
@@ -31,6 +31,12 @@ Recursive
 .. automodule:: stonesoup.updater.recursive
     :show-inheritance:
 
+Iterated
+--------
+
+.. automodule:: stonesoup.updater.iterated
+    :show-inheritance:
+
 Information
 -----------
 


### PR DESCRIPTION
Quick fix to add `stonesoup.updater.iterated` module to the documentation