### PR TITLE
Correct calculation of net orientation of PlatformMountables

### DIFF
--- a/stonesoup/functions/__init__.py
+++ b/stonesoup/functions/__init__.py
@@ -685,6 +685,9 @@ def build_rotation_matrix(angle_vector: np.ndarray):
     Calculates and returns the (3D) axis rotation matrix given a vector of
     three angles:
     [roll, pitch/elevation, yaw/azimuth]
+    Order of rotations is in reverse: yaw, pitch, roll (z, y, x)
+    This is the rotation matrix that implements the rotations that convert the input
+    angle_vector to match the x-axis.
 
     Parameters
     ----------
@@ -702,6 +705,33 @@ def build_rotation_matrix(angle_vector: np.ndarray):
     theta_y = angle_vector[1, 0]  # pitch#elevation
     theta_z = -angle_vector[2, 0]  # yaw#azimuth
     return rotx(theta_x) @ roty(theta_y) @ rotz(theta_z)
+
+
+def build_rotation_matrix_xyz(angle_vector: np.ndarray):
+    """
+    Calculates and returns the (3D) axis rotation matrix given a vector of
+    three angles:
+    [roll, pitch/elevation, yaw/azimuth]
+    Order of rotations is roll, pitch, yaw (x, y, z)
+    This is the rotation matrix that implements the rotations that convert a vector aligned to the
+    x-axis to the input angle_vector.
+
+    Parameters
+    ----------
+        angle_vector : :class:`numpy.ndarray` of shape (3, 1): the rotations
+        about the :math:'x, y, z' axes.
+        In aircraft/radar terms these correspond to
+        [roll, pitch/elevation, yaw/azimuth]
+
+    Returns
+    -------
+        :class:`numpy.ndarray` of shape (3, 3)
+            The model (3D) rotation matrix.
+    """
+    theta_x = -angle_vector[0, 0]  # roll
+    theta_y = angle_vector[1, 0]  # pitch#elevation
+    theta_z = -angle_vector[2, 0]  # yaw#azimuth
+    return rotz(theta_z) @ roty(theta_y) @ rotx(theta_x)
 
 
 def dotproduct(a, b):

--- a/stonesoup/movable/movable.py
+++ b/stonesoup/movable/movable.py
@@ -255,9 +255,10 @@ class MovingMovable(Movable):
 
         This is defined as a 3x1 StateVector of angles (rad), specifying the sensor orientation in
         terms of the counter-clockwise rotation around each Cartesian axis in the order
-        :math:`x,y,z`. The rotation angles are positive if the rotation is in the counter-clockwise
-        direction when viewed by an observer looking along the respective rotation axis,
-        towards the origin.
+        :math:`x,y,z`. The x and z rotation angles are positive if the rotation is in the
+        counter-clockwise direction when viewed by an observer looking along the respective
+        rotation axis, towards the origin. The y rotation angle is the opposite (matching
+        'elevation')
 
         The orientation of this platform is defined as along the direction of its velocity, with
         roll always set to zero (as this is the angle the platform is rotated about the velocity

--- a/stonesoup/movable/movable.py
+++ b/stonesoup/movable/movable.py
@@ -258,7 +258,7 @@ class MovingMovable(Movable):
         :math:`x,y,z`. The x and z rotation angles are positive if the rotation is in the
         counter-clockwise direction when viewed by an observer looking along the respective
         rotation axis, towards the origin. The y rotation angle is the opposite (matching
-        'elevation')
+        'elevation').
 
         The orientation of this platform is defined as along the direction of its velocity, with
         roll always set to zero (as this is the angle the platform is rotated about the velocity

--- a/stonesoup/platform/tests/test_platform_simple.py
+++ b/stonesoup/platform/tests/test_platform_simple.py
@@ -444,9 +444,16 @@ def rotation_offsets_3d():
 
 def expected_orientations_3d():
     pi = np.pi
+    # Define some useful values for repeated use:
+    # The angle of elevation when looking from one corner of a unit square to its diagonally
+    # opposite, higher up, corner:
     offset_3d_movement = np.arctan(1 / np.sqrt(2))
+    # Starting with a line at az=45deg, el=0 (hence 'fwd_left'), rotate it 45deg in elevation
+    # (about y axis, not just adding 45deg to its el). The resultant az and el are:
     fwd_left_elevated_45_el = np.arcsin(np.sin(np.pi / 4) / np.sqrt(2))
     fwd_left_elevated_45_az = np.arctan(1 / np.cos(np.pi / 4))
+    # Starting with a line at az=45deg, el=0 (hence 'fwd_left'), rotate it by 'offset_3d_movement'
+    # in elevation (about y axis, not just adding el, again). The resultant az and el are:
     fwd_left_elevated_o3m_el = np.arcsin(np.sin(offset_3d_movement) / np.sqrt(2))
     fwd_left_elevated_o3m_az = np.arctan(1 / np.cos(offset_3d_movement))
 

--- a/stonesoup/platform/tests/test_platform_simple.py
+++ b/stonesoup/platform/tests/test_platform_simple.py
@@ -445,69 +445,91 @@ def rotation_offsets_3d():
 def expected_orientations_3d():
     pi = np.pi
     offset_3d_movement = np.arctan(1 / np.sqrt(2))
+    fwd_left_elevated_45_el = np.arcsin(np.sin(np.pi / 4) / np.sqrt(2))
+    fwd_left_elevated_45_az = np.arctan(1 / np.cos(np.pi / 4))
+    fwd_left_elevated_o3m_el = np.arcsin(np.sin(offset_3d_movement) / np.sqrt(2))
+    fwd_left_elevated_o3m_az = np.arctan(1 / np.cos(offset_3d_movement))
 
-    return [np.array([[0., 0., 0.], [pi/4, 0., 0.], [0., pi/4, 0.], [-pi/4, 0., 0.],
-                      [0., -pi/4, 0.], [0., 0., pi/4], [0., 0., -pi/4]]),
-            np.array([[0., pi/2, 0.], [pi/4, pi/2, 0.], [0., 3*pi/4, 0.], [-pi/4, pi/2, 0.],
-                      [0., pi/4, 0.], [0., pi/2, pi/4], [0., pi/2, -pi/4]]),
-            np.array([[0., 0., pi/2], [pi/4, 0., pi/2], [0., pi/4, pi/2], [-pi/4, 0., pi/2],
-                      [0., -pi/4, pi/2], [0., 0., 3*pi/4], [0., 0., pi/4]]),
-            np.array([[0., 0., 0.], [pi/4, 0., 0.], [0., pi/4, 0.], [-pi/4, 0., 0.],
-                      [0., -pi/4, 0.], [0., 0., pi/4], [0., 0., -pi/4]]),
-            np.array([[0., pi/2, 0.], [pi/4, pi/2, 0.], [0., 3*pi/4, 0.], [-pi/4, pi/2, 0.],
-                      [0., pi/4, 0.], [0., pi/2, pi/4], [0., pi/2, -pi/4]]),
-            np.array([[0., 0., pi/2], [pi/4, 0., pi/2], [0., pi/4, pi/2], [-pi/4, 0., pi/2],
-                      [0., -pi/4, pi/2], [0., 0., 3*pi/4], [0., 0., pi/4]]),
-            np.array([[0., pi/4, 0.], [pi/4, pi/4, 0.], [0., pi/2, 0.], [-pi/4, pi/4, 0.],
-                      [0., 0., 0.], [0., pi/4, pi/4], [0., pi/4, -pi/4]]),
-            np.array([[0., pi/4, pi/2], [pi/4, pi/4, pi/2], [0., pi/2, pi/2],
-                      [-pi/4, pi/4, pi/2], [0., 0., pi/2], [0., pi/4, 3*pi/4], [0., pi/4, pi/4]]),
-            np.array([[0., offset_3d_movement, pi/4], [pi/4, offset_3d_movement, pi/4],
-                      [0., pi/4+offset_3d_movement, pi/4], [-pi/4, offset_3d_movement, pi/4],
-                      [0., -pi/4+offset_3d_movement, pi/4], [0., offset_3d_movement, pi/2],
-                      [0., offset_3d_movement, 0.]]),
-            np.array([[0., 0., pi], [pi/4, 0., pi], [0., pi/4, pi], [-pi/4, 0., pi],
-                      [0., -pi/4, pi], [0., 0., 5*pi/4], [0., 0., 3*pi/4]]),
-            np.array([[0., 0., -pi/2], [pi/4, 0., -pi/2], [0., pi/4, -pi/2], [-pi/4, 0., -pi/2],
-                      [0., -pi/4, -pi/2], [0., 0., -pi/4], [0., 0., -3*pi/4]]),
-            np.array([[0., -pi/2, 0.], [pi/4, -pi/2, 0.], [0., -pi/4, 0.], [-pi/4, -pi/2, 0.],
-                      [0., -3*pi/4, 0.], [0., -pi/2, pi/4], [0., -pi/2, -pi/4]]),
-            np.array([[0., 0., pi], [pi/4, 0., pi], [0., pi/4, pi], [-pi/4, 0., pi],
-                      [0., -pi/4, pi], [0., 0., 5*pi/4], [0., 0., 3*pi/4]]),
-            np.array([[0., 0., -pi/2], [pi/4, 0., -pi/2], [0., pi/4, -pi/2], [-pi/4, 0., -pi/2],
-                      [0., -pi/4, -pi/2], [0., 0., -pi/4], [0., 0., -3*pi/4]]),
-            np.array([[0., -pi/2, 0.], [pi/4, -pi/2, 0.], [0., -pi/4, 0.], [-pi/4, -pi/2, 0.],
-                      [0., -3*pi/4, 0.], [0., -pi/2, pi/4], [0., -pi/2, -pi/4]]),
-            np.array([[0., -pi/4, pi], [pi/4, -pi/4, pi], [0., 0., pi], [-pi/4, -pi/4, pi],
-                      [0., -pi/2, pi], [0., -pi/4, 5*pi/4], [0., -pi/4, 3*pi/4]]),
-            np.array([[0., -pi/4, -pi/2], [pi/4, -pi/4, -pi/2], [0., 0., -pi/2],
-                      [-pi/4, -pi/4, -pi/2], [0., -pi/2, -pi/2], [0., -pi/4, -pi/4],
-                      [0., -pi/4, -3*pi/4]])]
+    return [np.array([[0., 0., 0.], [pi / 4, 0., 0.], [0., pi / 4, 0.], [-pi / 4, 0., 0.],
+                      [0., -pi / 4, 0.], [0., 0., pi / 4], [0., 0., -pi / 4]]),
+            np.array([[0., pi / 2, 0.], [pi / 4, pi / 2, 0.], [0., pi / 4, pi],
+                      [-pi / 4, pi / 2, 0.], [0., pi / 4, 0.], [0., pi / 4, pi / 2],
+                      [0., pi / 4, -pi / 2]]),
+            np.array([[0., 0., pi / 2], [pi / 4, 0., pi / 2], [0., pi / 4, pi / 2],
+                      [-pi / 4, 0., pi / 2],
+                      [0., -pi / 4, pi / 2], [0., 0., 3 * pi / 4], [0., 0., pi / 4]]),
+            np.array([[0., 0., 0.], [pi / 4, 0., 0.], [0., pi / 4, 0.], [-pi / 4, 0., 0.],
+                      [0., -pi / 4, 0.], [0., 0., pi / 4], [0., 0., -pi / 4]]),
+            np.array([[0., pi / 2, 0.], [pi / 4, pi / 2, 0.], [0., pi / 4, pi],
+                      [-pi / 4, pi / 2, 0.], [0., pi / 4, 0.], [0., pi / 4, pi / 2],
+                      [0., pi / 4, -pi / 2]]),
+            np.array([[0., 0., pi / 2], [pi / 4, 0., pi / 2], [0., pi / 4, pi / 2],
+                      [-pi / 4, 0., pi / 2],
+                      [0., -pi / 4, pi / 2], [0., 0., 3 * pi / 4], [0., 0., pi / 4]]),
+            np.array(
+                [[0., pi / 4, 0.], [pi / 4, pi / 4, 0.], [0., pi / 2, 0.], [-pi / 4, pi / 4, 0.],
+                 [0., 0., 0.], [0., fwd_left_elevated_45_el, fwd_left_elevated_45_az],
+                 [0., fwd_left_elevated_45_el, -fwd_left_elevated_45_az]]),
+            np.array([[0., pi / 4, pi / 2], [pi / 4, pi / 4, pi / 2], [0., pi / 2, pi / 2],
+                      [-pi / 4, pi / 4, pi / 2], [0., 0., pi / 2],
+                      [0., fwd_left_elevated_45_el, pi / 2 + fwd_left_elevated_45_az],
+                      [0., fwd_left_elevated_45_el, pi / 2 - fwd_left_elevated_45_az]]),
+            np.array([[0., offset_3d_movement, pi / 4], [pi / 4, offset_3d_movement, pi / 4],
+                      [0., pi / 4 + offset_3d_movement, pi / 4],
+                      [-pi / 4, offset_3d_movement, pi / 4],
+                      [0., -pi / 4 + offset_3d_movement, pi / 4],
+                      [0., fwd_left_elevated_o3m_el, fwd_left_elevated_o3m_az + np.pi / 4],
+                      [0., fwd_left_elevated_o3m_el, np.pi / 4 - fwd_left_elevated_o3m_az]]),
+            np.array([[0., 0., pi], [pi / 4, 0., pi], [0., pi / 4, pi], [-pi / 4, 0., pi],
+                      [0., -pi / 4, pi], [0., 0., - 3 * pi / 4], [0., 0., 3 * pi / 4]]),
+            np.array([[0., 0., -pi / 2], [pi / 4, 0., -pi / 2], [0., pi / 4, -pi / 2],
+                      [-pi / 4, 0., -pi / 2],
+                      [0., -pi / 4, -pi / 2], [0., 0., -pi / 4], [0., 0., -3 * pi / 4]]),
+            np.array([[0., -pi / 2, 0.], [pi / 4, -pi / 2, 0.], [0., -pi / 4, 0.],
+                      [-pi / 4, -pi / 2, 0.],
+                      [0., - pi / 4, pi], [0., -pi / 4, pi / 2], [0., -pi / 4, -pi / 2]]),
+            np.array([[0., 0., pi], [pi / 4, 0., pi], [0., pi / 4, pi], [-pi / 4, 0., pi],
+                      [0., -pi / 4, pi], [0., 0., -3 * pi / 4], [0., 0., 3 * pi / 4]]),
+            np.array([[0., 0., -pi / 2], [pi / 4, 0., -pi / 2], [0., pi / 4, -pi / 2],
+                      [-pi / 4, 0., -pi / 2],
+                      [0., -pi / 4, -pi / 2], [0., 0., -pi / 4], [0., 0., -3 * pi / 4]]),
+            np.array([[0., -pi / 2, 0.], [pi / 4, -pi / 2, 0.], [0., -pi / 4, 0.],
+                      [-pi / 4, -pi / 2, 0.],
+                      [0., - pi / 4, pi], [0., -pi / 4, pi / 2], [0., -pi / 4, -pi / 2]]),
+            np.array(
+                [[0., -pi / 4, pi], [pi / 4, -pi / 4, pi], [0., 0., pi], [-pi / 4, -pi / 4, pi],
+                 [0., -pi / 2, pi],
+                 [0., -fwd_left_elevated_45_el, -pi + fwd_left_elevated_45_az],
+                 [0., -fwd_left_elevated_45_el, pi - fwd_left_elevated_45_az]]),
+            np.array([[0., -pi / 4, -pi / 2], [pi / 4, -pi / 4, -pi / 2], [0., 0., -pi / 2],
+                      [-pi / 4, -pi / 4, -pi / 2], [0., -pi / 2, -pi / 2],
+                      [0., -fwd_left_elevated_45_el, -pi / 2 + fwd_left_elevated_45_az],
+                      [0., -fwd_left_elevated_45_el, -pi / 2 - fwd_left_elevated_45_az]])]
 
 
 def expected_orientations_2d():
     pi = np.pi
     return [
-        np.array([[0., 0., 0.], [0., 0., pi/4],  [0., 0., -pi/4], [0., 0., pi/2],
-                  [0., 0., -pi/2]]),
-        np.array([[0., 0., pi/2],  [0., 0., 3 * pi/4], [0., 0., pi/4], [0., 0., pi],
+        np.array([[0., 0., 0.], [0., 0., pi / 4], [0., 0., -pi / 4], [0., 0., pi / 2],
+                  [0., 0., -pi / 2]]),
+        np.array([[0., 0., pi / 2], [0., 0., 3 * pi / 4], [0., 0., pi / 4], [0., 0., pi],
                   [0., 0., 0.]]),
-        np.array([[0., 0., 0.],  [0., 0., pi/4], [0., 0., -pi/4], [0., 0., pi/2],
-                  [0., 0., -pi/2]]),
-        np.array([[0., 0., pi/2],  [0., 0., 3 * pi/4], [0., 0., pi/4], [0., 0., pi],
+        np.array([[0., 0., 0.], [0., 0., pi / 4], [0., 0., -pi / 4], [0., 0., pi / 2],
+                  [0., 0., -pi / 2]]),
+        np.array([[0., 0., pi / 2], [0., 0., 3 * pi / 4], [0., 0., pi / 4], [0., 0., pi],
                   [0., 0., 0.]]),
-        np.array([[0., 0., pi/4], [0., 0., pi/2], [0., 0., 0.], [0., 0., 3 * pi/4],
-                  [0., 0., -pi/4]]),
-        np.array([[0., 0., pi],  [0., 0., 5*pi/4], [0., 0., 3 * pi/4], [0., 0., 3 * pi/2],
-                  [0., 0., pi/2]]),
-        np.array([[0., 0., -pi/2], [0., 0., -pi/4], [0., 0., -3 * pi/4], [0., 0., 0.],
+        np.array([[0., 0., pi / 4], [0., 0., pi / 2], [0., 0., 0.], [0., 0., 3 * pi / 4],
+                  [0., 0., -pi / 4]]),
+        np.array([[0., 0., pi], [0., 0., -3 * pi / 4], [0., 0., 3 * pi / 4], [0., 0., -pi / 2],
+                  [0., 0., pi / 2]]),
+        np.array([[0., 0., -pi / 2], [0., 0., -pi / 4], [0., 0., -3 * pi / 4], [0., 0., 0.],
                   [0., 0., -pi]]),
-        np.array([[0., 0., pi], [0., 0., 5 * pi/4], [0., 0., 3 * pi/4], [0., 0., 3 * pi/2],
-                  [0., 0., pi/2]]),
-        np.array([[0., 0., -pi/2],  [0., 0., -pi/4], [0., 0., -3 * pi/4], [0., 0., 0.],
+        np.array([[0., 0., pi], [0., 0., -3 * pi / 4], [0., 0., 3 * pi / 4], [0., 0., - pi / 2],
+                  [0., 0., pi / 2]]),
+        np.array([[0., 0., -pi / 2], [0., 0., -pi / 4], [0., 0., -3 * pi / 4], [0., 0., 0.],
                   [0., 0., -pi]]),
-        np.array([[0., 0., -3 * pi/4],  [0., 0., -pi/2], [0., 0., -pi], [0., 0., -pi/4],
-                  [0., 0., -5 * pi/4]])
+        np.array([[0., 0., -3 * pi / 4], [0., 0., -pi / 2], [0., 0., -pi], [0., 0., -pi / 4],
+                  [0., 0., 3 * pi / 4]])
     ]
 
 
@@ -555,7 +577,7 @@ def test_rotation_offsets_3d(state, expected_platform_orientation, expected_sens
         [model_1d] * (radars_3d[0].ndim_state // 2))
     platform_state = State(state, timestamp)
 
-    # This defines the position_mapping to the platforms state vector (i.e. x and y)
+    # This defines the position_mapping to the platforms state vector (i.e. x, y and z)
     mounting_mapping = np.array([0, 2, 4])
     # create a platform with the simple radar mounted
     for sensor, offset in zip(radars_3d, rotation_offsets_3d):

--- a/stonesoup/platform/tests/test_platform_simple.py
+++ b/stonesoup/platform/tests/test_platform_simple.py
@@ -623,10 +623,10 @@ def test_defaults(radars_3d, platform_type, add_sensor):
                                  position_mapping=[0, 2, 4], **platform_args)
 
     for sensor in radars_3d:
-        assert np.array_equal(sensor.mounting_offset, StateVector([0, 0, 0]))
-        assert np.array_equal(sensor.rotation_offset, StateVector([0, 0, 0]))
-        assert np.array_equal(sensor.position, platform.position)
-        assert np.array_equal(sensor.orientation, platform.orientation)
+        assert np.allclose(sensor.mounting_offset, StateVector([0, 0, 0]))
+        assert np.allclose(sensor.rotation_offset, StateVector([0, 0, 0]))
+        assert np.allclose(sensor.position, platform.position)
+        assert np.allclose(sensor.orientation, platform.orientation)
 
 
 def sensor_positions_test(expected_offset, platform):

--- a/stonesoup/platform/tests/test_platform_simple.py
+++ b/stonesoup/platform/tests/test_platform_simple.py
@@ -445,7 +445,7 @@ def rotation_offsets_3d():
 def expected_orientations_3d():
     pi = np.pi
     # Define some useful values for repeated use:
-    # The angle of elevation when looking from one corner of a unit square to its diagonally
+    # The angle of elevation when looking from one corner of a unit cube to its diagonally
     # opposite, higher up, corner:
     offset_3d_movement = np.arctan(1 / np.sqrt(2))
     # Starting with a line at az=45deg, el=0 (hence 'fwd_left'), rotate it 45deg in elevation
@@ -454,8 +454,7 @@ def expected_orientations_3d():
     fwd_left_elevated_45_az = np.arctan(np.sqrt(2))
     # Starting with a line at az=45deg, el=0 (hence 'fwd_left'), rotate it by 'offset_3d_movement'
     # in elevation (about y axis, not just adding el, again). The resultant az and el are:
-    fwd_left_elevated_o3m_el = np.arctan(np.sin(offset_3d_movement)/
-                                         np.sqrt(1+np.cos(offset_3d_movement)**2))
+    fwd_left_elevated_o3m_el = np.arcsin(np.sin(offset_3d_movement)/np.sqrt(2))
     fwd_left_elevated_o3m_az = np.arctan(1 / np.cos(offset_3d_movement))
 
     return [np.array([[0., 0., 0.], [pi / 4, 0., 0.], [0., pi / 4, 0.], [-pi / 4, 0., 0.],

--- a/stonesoup/platform/tests/test_platform_simple.py
+++ b/stonesoup/platform/tests/test_platform_simple.py
@@ -450,11 +450,12 @@ def expected_orientations_3d():
     offset_3d_movement = np.arctan(1 / np.sqrt(2))
     # Starting with a line at az=45deg, el=0 (hence 'fwd_left'), rotate it 45deg in elevation
     # (about y axis, not just adding 45deg to its el). The resultant az and el are:
-    fwd_left_elevated_45_el = np.arcsin(np.sin(np.pi / 4) / np.sqrt(2))
-    fwd_left_elevated_45_az = np.arctan(1 / np.cos(np.pi / 4))
+    fwd_left_elevated_45_el = np.arctan(np.sqrt(1/3))
+    fwd_left_elevated_45_az = np.arctan(np.sqrt(2))
     # Starting with a line at az=45deg, el=0 (hence 'fwd_left'), rotate it by 'offset_3d_movement'
     # in elevation (about y axis, not just adding el, again). The resultant az and el are:
-    fwd_left_elevated_o3m_el = np.arcsin(np.sin(offset_3d_movement) / np.sqrt(2))
+    fwd_left_elevated_o3m_el = np.arctan(np.sin(offset_3d_movement)/
+                                         np.sqrt(1+np.cos(offset_3d_movement)**2))
     fwd_left_elevated_o3m_az = np.arctan(1 / np.cos(offset_3d_movement))
 
     return [np.array([[0., 0., 0.], [pi / 4, 0., 0.], [0., pi / 4, 0.], [-pi / 4, 0., 0.],

--- a/stonesoup/sensor/base.py
+++ b/stonesoup/sensor/base.py
@@ -118,8 +118,8 @@ class PlatformMountable(Base, ABC):
         if self.movement_controller is None:
             return None
         x_axis = (1, 0, 0)
-        rotmat = build_rotation_matrix_xyz(-self.movement_controller.orientation) @ \
-            build_rotation_matrix_xyz(-self.rotation_offset)
+        rotmat = (build_rotation_matrix_xyz(-self.movement_controller.orientation) @ 
+            build_rotation_matrix_xyz(-self.rotation_offset))
         offset_axis = rotmat @ x_axis
         roll = mod_bearing(self.movement_controller.orientation[0] + self.rotation_offset[0])
         # convert cartesian direction, 'offset_axis', into an orientation

--- a/stonesoup/sensor/base.py
+++ b/stonesoup/sensor/base.py
@@ -118,8 +118,8 @@ class PlatformMountable(Base, ABC):
         if self.movement_controller is None:
             return None
         x_axis = (1, 0, 0)
-        rotmat = (build_rotation_matrix_xyz(-self.movement_controller.orientation) @ 
-            build_rotation_matrix_xyz(-self.rotation_offset))
+        rotmat = (build_rotation_matrix_xyz(-self.movement_controller.orientation) @
+                  build_rotation_matrix_xyz(-self.rotation_offset))
         offset_axis = rotmat @ x_axis
         roll = mod_bearing(self.movement_controller.orientation[0] + self.rotation_offset[0])
         # convert cartesian direction, 'offset_axis', into an orientation

--- a/stonesoup/sensor/base.py
+++ b/stonesoup/sensor/base.py
@@ -119,7 +119,7 @@ class PlatformMountable(Base, ABC):
             return None
         x_axis = (1, 0, 0)
         rotmat = build_rotation_matrix_xyz(-self.movement_controller.orientation) @ \
-                 build_rotation_matrix_xyz(-self.rotation_offset)
+            build_rotation_matrix_xyz(-self.rotation_offset)
         offset_axis = rotmat @ x_axis
         roll = mod_bearing(self.movement_controller.orientation[0] + self.rotation_offset[0])
         # convert cartesian direction, 'offset_axis', into an orientation

--- a/stonesoup/sensor/tests/test_sensor.py
+++ b/stonesoup/sensor/tests/test_sensor.py
@@ -34,12 +34,12 @@ class DummyBaseSensor(PlatformMountable):
 
 def test_sensor_position_orientation_setting():
     sensor = DummySensor(position=StateVector([0, 0, 1]))
-    assert np.array_equal(sensor.position, StateVector([0, 0, 1]))
-    assert np.array_equal(sensor.orientation, StateVector([0, 0, 0]))
+    assert np.allclose(sensor.position, StateVector([0, 0, 1]))
+    assert np.allclose(sensor.orientation, StateVector([0, 0, 0]))
     sensor.position = StateVector([0, 1, 0])
-    assert np.array_equal(sensor.position, StateVector([0, 1, 0]))
+    assert np.allclose(sensor.position, StateVector([0, 1, 0]))
     sensor.orientation = StateVector([0, 1, 0])
-    assert np.array_equal(sensor.orientation, StateVector([0, 1, 0]))
+    assert np.allclose(sensor.orientation, StateVector([0, 1, 0]))
 
     position = StateVector([0, 0, 1])
     sensor = DummySensor()
@@ -54,12 +54,12 @@ def test_sensor_position_orientation_setting():
 
 def test_default_platform():
     sensor = DummySensor(position=StateVector([0, 0, 1]))
-    assert np.array_equal(sensor.position, StateVector([0, 0, 1]))
-    assert np.array_equal(sensor.orientation, StateVector([0, 0, 0]))
+    assert np.allclose(sensor.position, StateVector([0, 0, 1]))
+    assert np.allclose(sensor.orientation, StateVector([0, 0, 0]))
 
     sensor = DummySensor(orientation=StateVector([0, 0, 1]))
-    assert np.array_equal(sensor.orientation, StateVector([0, 0, 1]))
-    assert np.array_equal(sensor.position, StateVector([0, 0, 0]))
+    assert np.allclose(sensor.orientation, StateVector([0, 0, 1]))
+    assert np.allclose(sensor.position, StateVector([0, 0, 0]))
 
 
 def test_internal_platform_flag():


### PR DESCRIPTION
Calculation of the net orientation of a PlatformMountable on a Platform looks incorrect for 3D cases. It adds the platform's (MovementController's) orientation to the sensor's rotation_offset. Think of a sensor oriented to the left when its platform pitches up: addition would orient the sensor up too, when it should just roll. Instead, this PR rotates a vector aligned to the x-axis by the platform's orientation and the sensor's rotation_offset. This requires rotations in order: x, y, z. The current functions.init.build_rotation_matrix() does it the other way round (as required for other use cases) so a new build_rotation_matrix_xyz() has been added. Tests have been updated to match: rotation instead of addition requires orientation about x and z to be within +/-pi and in y to be within +/-pi/2.