### PR TITLE
Add SMC-PHD initiator implementation

### DIFF
--- a/docs/source/stonesoup.initiator.rst
+++ b/docs/source/stonesoup.initiator.rst
@@ -10,6 +10,9 @@ Initiators
 .. automodule:: stonesoup.initiator.simple
     :show-inheritance:
 
+.. automodule:: stonesoup.initiator.particle
+    :show-inheritance:
+
 Wrappers
 --------
 .. automodule:: stonesoup.initiator.wrapper

--- a/stonesoup/initiator/particle.py
+++ b/stonesoup/initiator/particle.py
@@ -1,0 +1,108 @@
+import numpy as np
+from scipy.special import logsumexp
+
+from stonesoup.base import Property
+from stonesoup.hypothesiser.simple import SimpleHypothesiser
+from stonesoup.initiator.base import ParticleInitiator
+from stonesoup.predictor.particle import SMCPHDPredictor
+from stonesoup.resampler import Resampler
+from stonesoup.types.multihypothesis import MultipleHypothesis
+from stonesoup.types.state import ParticleState
+from stonesoup.types.track import Track
+from stonesoup.types.update import Update
+from stonesoup.updater.particle import SMCPHDUpdater
+
+
+class SMCPHDInitiator(ParticleInitiator):
+    r"""Sequential Monte Carlo Probability Hypothesis Density (SMC-PHD) Initiator class
+
+    An implementation of a particle initiator that uses a Sequential Monte Carlo Probability
+    Hypothesis Density (SMC-PHD) filter to generate tracks from detections, based on [#phdi]_.
+
+    Note
+    ----
+    The current implementation does not support non-association weights (i.e. :math:`\rho_i` in
+    [#phdi]_).
+
+    Parameters
+    ----------
+
+    References
+    ----------
+    .. [#phdi] P. Horridge and S. Maskell,  “Using a probabilistic hypothesis density filter to
+           confirm tracks in a multi-target environment,” in 2011 Jahrestagung der Gesellschaft
+           fr Informatik, October 2011.
+    """
+
+    prior_state: ParticleState = Property(
+        doc="Prior particle state used to initialise the PHD density")
+    predictor: SMCPHDPredictor = Property(doc="SMC-PHD predictor used to predict the PHD density")
+    updater: SMCPHDUpdater = Property(doc="SMC-PHD updater used to update the PHD density")
+    threshold: float = Property(
+        default=0.9,
+        doc="Existence probability threshold for initiating tracks. Default is 0.9")
+    num_track_samples: int = Property(
+        default=None,
+        doc="Number of particles for initiated tracks. Default is None in which case the "
+            "number of particles will be set to the number of particles in the prior state.")
+    resampler: Resampler = Property(
+        default=None,
+        doc='Resampler used to resample the particles of output tracks before returning. Default '
+            'is None in which case the resampler of the updater will be used.')
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if self.resampler is None:
+            if self.updater.resampler is None:
+                raise ValueError("No resampler specified and updater has no resampler")
+            self.resampler = self.updater.resampler
+        self._state = self.prior_state
+        self._hypothesiser = SimpleHypothesiser(self.predictor)
+
+    def initiate(self, detections, timestamp, **kwargs):
+        tracks = set()
+
+        # Hypothesise
+        hypotheses = self._hypothesiser.hypothesise(self._state, detections, timestamp)
+
+        # Sort hypotheses, so that missed detection is always first
+        hypotheses.single_hypotheses.sort(key=bool)
+
+        # Calculate weights per hypothesis
+        log_weights_per_hyp = self.updater.get_log_weights_per_hypothesis(hypotheses)
+
+        # Calculate intensity per hypothesis
+        log_intensity_per_hyp = logsumexp(log_weights_per_hyp, axis=0)
+
+        # Find hypotheses with intensity above threshold and initiate
+        valid_hyp_inds = np.flatnonzero(np.exp(log_intensity_per_hyp) > self.threshold).astype(int)
+        for idx in valid_hyp_inds:
+
+            # Get hypothesis
+            hypothesis = hypotheses.single_hypotheses[idx]
+
+            # Skip missed detection
+            if not hypothesis:
+                continue
+
+            # Create state update
+            state = Update.from_state(state=hypothesis.prediction,
+                                      hypothesis=hypothesis,
+                                      timestamp=timestamp)
+            # Normalise weights
+            state.log_weight = log_weights_per_hyp[:, idx] - log_intensity_per_hyp[idx]
+
+            # Resample particles
+            state = self.resampler.resample(state, self.num_track_samples)
+
+            # Create track
+            tracks.add(Track([state]))
+
+        # Filter out hypotheses for detections above threshold (always keep missed detection)
+        remaining_hyp_inds = (set(range(len(hypotheses))) - set(valid_hyp_inds)) | {0}
+        remaining_hypotheses = MultipleHypothesis([hypotheses[i] for i in remaining_hyp_inds])
+
+        # Update PHD state
+        self._state = self.updater.update(remaining_hypotheses)
+
+        return tracks

--- a/stonesoup/initiator/simple.py
+++ b/stonesoup/initiator/simple.py
@@ -501,3 +501,46 @@ class EnsembleInitiator(GaussianInitiator):
                 hypothesis=track.hypothesis)
 
         return tracks
+
+
+class ParticleGaussianInitiator(GaussianInitiator):
+    """Particle Gaussian Initiator class
+
+    Utilising Particle Initiator, convert the resultant track's state to generate a Gaussian state,
+    overwriting with a :class:`~.GaussianState`.
+    """
+
+    initiator: ParticleInitiator = Property(
+        doc="Particle Initiator which will be used to generate tracks.")
+
+    def initiate(self, detections, timestamp, **kwargs):
+        """Initiates tracks given unassociated measurements
+
+        Parameters
+        ----------
+        detections : set of :class:`~.Detection`
+            A list of unassociated detections
+        timestamp: datetime.datetime
+            Current timestamp
+
+        Returns
+        -------
+        : set of :class:`~.Track`
+            A list of new tracks with an initial :class:`~.GaussianState`
+        """
+        tracks = self.initiator.initiate(detections, timestamp, **kwargs)
+
+        for track in tracks:
+            mu = track.mean
+            covar = track.covar
+            timestamp = track.timestamp
+
+            track[-1] = State.from_state(
+                state=track.state,
+                state_vector=mu,
+                covar=covar,
+                timestamp=timestamp,
+                target_type=GaussianState
+            )
+
+        return tracks

--- a/stonesoup/initiator/tests/test_particle.py
+++ b/stonesoup/initiator/tests/test_particle.py
@@ -1,0 +1,121 @@
+from datetime import datetime
+
+import numpy as np
+import pytest
+
+from stonesoup.predictor.particle import ParticlePredictor
+from stonesoup.resampler.particle import SystematicResampler
+from stonesoup.types.array import StateVector, StateVectors
+from stonesoup.types.detection import TrueDetection, Clutter
+from stonesoup.types.prediction import Prediction
+from stonesoup.types.state import ParticleState
+from stonesoup.types.update import Update
+from stonesoup.updater.particle import ParticleUpdater
+from stonesoup.initiator.particle import SMCPHDInitiator
+
+
+@pytest.fixture()
+def dummy_predictor():
+    class DummyPredictor(ParticlePredictor):
+        def predict(self, prior, control_input=None, timestamp=None, **kwargs):
+            return Prediction.from_state(prior,
+                                         parent=prior,
+                                         state_vector=prior.state_vector,
+                                         timestamp=timestamp,
+                                         transition_model=self.transition_model,
+                                         prior=prior)
+
+        @property
+        def transition_model(self):
+            return None
+
+    return DummyPredictor()
+
+
+@pytest.fixture(
+    params=[
+        SystematicResampler(),
+        None
+    ],
+    ids=['systematic_resampler', 'no_resampler']
+)
+def dummy_updater(request):
+    class DummyUpdater(ParticleUpdater):
+        resampler = request.param
+
+        def predict_measurement(self, state_prediction,
+                                measurement_model=None, **kwargs):
+            return None
+
+        def update(self, hypothesis, **kwargs):
+            prediction = hypothesis[0].prediction
+            return Update.from_state(state=prediction,
+                                     hypothesis=hypothesis,
+                                     timestamp=prediction.timestamp)
+
+        def get_log_weights_per_hypothesis(self, hypothesis):
+            prediction = hypothesis[0].prediction
+            num_samples = prediction.state_vector.shape[1]
+            log_weights_per_hyp = np.full((num_samples, len(hypothesis)), -np.inf)
+            for i, hyp in enumerate(hypothesis):
+                if not hyp:
+                    # Set missed detection high to ensure test covers this case
+                    log_weights_per_hyp[:, 0] = np.log(.9 / num_samples)
+                    continue
+                if isinstance(hyp.measurement, TrueDetection):
+                    log_weights_per_hyp[:, i] = np.log(.8 / num_samples)
+                else:
+                    log_weights_per_hyp[:, i] = np.log(.1 / num_samples)
+            return log_weights_per_hyp
+
+        @property
+        def measurement_model(self):
+            return None
+
+    return DummyUpdater()
+
+
+@pytest.mark.parametrize(
+    'num_particles, num_track_samples, threshold, resampler',
+    [(100, 150, 0.7, SystematicResampler()),
+     (100, 200, 0.7, None),
+     (100, 200, 0.9, None)]
+)
+def test_smc_phd_initiator(num_particles, num_track_samples, threshold, resampler,
+                           dummy_predictor, dummy_updater):
+    timestamp = datetime.now()
+    detections = {
+        TrueDetection(StateVector([0]), timestamp=timestamp, groundtruth_path=None),
+        Clutter(StateVector([5]), timestamp=timestamp),
+        TrueDetection(StateVector([10]), timestamp=timestamp, groundtruth_path=None),
+    }
+
+    prior_sv = StateVectors([[i for i in range(num_particles)]])
+    prior = ParticleState(state_vector=prior_sv,
+                          weight=np.array([1 / num_particles] * num_particles),
+                          timestamp=timestamp)
+
+    # Test if error is raised when no resampler is specified and updater has no resampler
+    if resampler is None and dummy_updater.resampler is None:
+        with pytest.raises(ValueError):
+            initiator = SMCPHDInitiator(prior_state=prior, predictor=dummy_predictor,
+                                        updater=dummy_updater, threshold=threshold,
+                                        num_track_samples=num_track_samples,
+                                        resampler=resampler)
+        return
+
+    initiator = SMCPHDInitiator(prior_state=prior, predictor=dummy_predictor,
+                                updater=dummy_updater, threshold=threshold,
+                                num_track_samples=num_track_samples,
+                                resampler=resampler)
+
+    tracks = initiator.initiate(detections, timestamp)
+
+    if threshold > 0.8:
+        assert len(tracks) == 0
+    else:
+        assert len(tracks) == 2
+
+    for track in tracks:
+        assert len(track.state) == num_track_samples
+        assert float(np.sum(track.state.weight)) == pytest.approx(1, abs=1e-10)

--- a/stonesoup/updater/particle.py
+++ b/stonesoup/updater/particle.py
@@ -576,11 +576,10 @@ class SMCPHDUpdater(ParticleUpdater):
         """
 
         prediction = hypotheses[0].prediction
-        detections = [hypothesis.measurement for hypothesis in hypotheses if hypothesis]
         num_samples = len(prediction) if self.num_samples is None else self.num_samples
 
         # Calculate w^{n,i} Eq. (20) of [#phd2]
-        log_weights_per_hyp = self.get_log_weights_per_hypothesis(prediction, detections)
+        log_weights_per_hyp = self.get_log_weights_per_hypothesis(hypotheses)
 
         # Update weights Eq. (8) of [phd1]
         # w_k^i = \sum_{z \in Z_k}{w^{n,i}}, where i is the index of z in Z_k
@@ -610,7 +609,24 @@ class SMCPHDUpdater(ParticleUpdater):
 
         return updated_state
 
-    def get_log_weights_per_hypothesis(self, prediction, detections):
+    def get_log_weights_per_hypothesis(self, hypotheses):
+        """Calculate the log particle weights per hypothesis
+
+        Parameters
+        ----------
+        hypotheses : :class:`~.MultipleHypothesis`
+            A container of :class:`~SingleHypothesis` objects. All hypotheses are assumed to have
+            the same prediction (and hence same timestamp).
+
+        Returns
+        -------
+        : :class:`~numpy.ndarray`
+            The log weights per hypothesis, where the first dimension is the number of particles
+            and the second dimension is the number of hypotheses. The first hypothesis (column) is
+            always the missed detection hypothesis.
+        """
+        prediction = hypotheses[0].prediction
+        detections = [hypothesis.measurement for hypothesis in hypotheses if hypothesis]
         num_samples = prediction.state_vector.shape[1]
 
         # Compute g(z|x) matrix as in [#phd1]


### PR DESCRIPTION
This PR adds the following components:
- ``SMCPHDInitiator``: A particle initiator that initiates tracks using a SMCPHD Predictor/Updater pair
- ``ParticleGaussianInitiator``: A wrapper that converts ``ParticleState`` based tracks to ``GaussianState`` based equivalents.

Here is a [gist](https://gist.github.com/sglvladi/0bfc78430d8ad66fd8882859acbf1185) that demonstrates both classes in action.