### PR TITLE
Change ParticleState Length check in KLD measure for efficiency

### DIFF
--- a/stonesoup/measures/state.py
+++ b/stonesoup/measures/state.py
@@ -443,7 +443,7 @@ class KLDivergence(Measure):
 
         """
         if isinstance(state1, ParticleState) and isinstance(state2, ParticleState):
-            if len(state1.particles) == len(state2.particles):
+            if len(state1) == len(state2):
 
                 log_term = np.zeros(state1.log_weight.shape)
 
@@ -457,7 +457,7 @@ class KLDivergence(Measure):
                 kld = np.sum(np.exp(state1.log_weight)*log_term)
             else:
                 raise ValueError(f'The input sizes are not compatible '
-                                 f'({len(state1.particles)} != {len(state2.particles)})')
+                                 f'({len(state1)} != {len(state2)})')
 
         elif isinstance(state1, GaussianState) and isinstance(state2, GaussianState):
 


### PR DESCRIPTION
The original implementation of input checking for the Kullback Leibler divergence measure used `len()` on the `state.particles` object, slowing down execution for the measure and usage in sensor management. The check has been changed in this pull request to use `len()` on the `state` object itself. This change has also reduced the time taken to complete sensor management tests, perhaps removing the requirement of the `--slow` marker.