### PR TITLE
Added TrackingStateSpaceDistanceGater

### DIFF
--- a/stonesoup/gater/distance.py
+++ b/stonesoup/gater/distance.py
@@ -38,7 +38,7 @@ class DistanceGater(Gater):
         return MultipleHypothesis(sorted(gated_hypotheses, reverse=True))
 
 
-class StateSpaceDistanceGater(Gater):
+class TrackingStateSpaceDistanceGater(Gater):
     """
     This Distance Gater measures in the track state space (not measurement state space).
 

--- a/stonesoup/gater/distance.py
+++ b/stonesoup/gater/distance.py
@@ -1,7 +1,15 @@
+from typing import Sequence
+
+import numpy as np
+
+from .base import Gater
 from ..base import Property
 from ..measures import Measure
+from ..models.base import LinearModel, ReversibleModel
+from ..types.detection import MissedDetection
+from ..types.hypothesis import Hypothesis, SingleHypothesis
 from ..types.multihypothesis import MultipleHypothesis
-from .base import Gater
+from ..types.state import State
 
 
 class DistanceGater(Gater):
@@ -28,3 +36,71 @@ class DistanceGater(Gater):
                                                 hypothesis.measurement) < self.gate_threshold)]
 
         return MultipleHypothesis(sorted(gated_hypotheses, reverse=True))
+
+
+class StateSpaceDistanceGater(Gater):
+    """
+    This Distance Gater measures in the track state space (not measurement state space).
+
+    Each measurement is transformed into the state space of the track. In this state space a
+    measure is used to calculate the distance between a hypothesis' prediction and the
+    measurement. Any hypotheses whose calculated distance exceeds the specified gate threshold are
+    removed.
+    """
+
+    measure: Measure = Property(
+        doc="Measure class used to calculate the distance between the measurement (in state space)"
+            " and the track prediction.")
+    gate_threshold: float = Property(
+        doc="The gate threshold. Measurements whose calculated distance "
+            "exceeds this threshold will be filtered out.")
+    allow_non_reversible_detections: bool = Property(
+        default=True,
+        doc="Should detections with non-reversible measurement models be allowed passed the gate.")
+
+    def hypothesise(self, track, detections, *args, **kwargs) -> Sequence[Hypothesis]:
+
+        hypotheses: Sequence[Hypothesis] = \
+            self.hypothesiser.hypothesise(track, detections, *args, **kwargs)
+
+        return [hypothesis for hypothesis in hypotheses
+                if self.check_hypothesise(hypothesis)]
+
+    def check_hypothesise(self, hypothesis: Hypothesis) -> bool:
+        if isinstance(hypothesis, SingleHypothesis):
+            return self.check_single_hypothesise(hypothesis)
+        else:
+            raise NotImplementedError(f"Cannot gate hypothesis with type: '{type(hypothesis)}'.")
+
+    def check_single_hypothesise(self, hypothesis: SingleHypothesis) -> bool:
+
+        detection = hypothesis.measurement
+
+        if isinstance(detection, MissedDetection):
+            return True
+
+        if detection.measurement_model is not None:
+            measurement_model = detection.measurement_model
+        else:
+            raise ValueError("No measurement model specified in detection.")
+
+        if isinstance(measurement_model, LinearModel):
+            model_matrix = measurement_model.matrix()
+            inv_model_matrix = np.linalg.pinv(model_matrix)
+            state_vector = inv_model_matrix @ detection.state_vector
+        elif isinstance(measurement_model, ReversibleModel):
+            try:
+                state_vector = measurement_model.inverse_function(detection)
+            except NotImplementedError:
+                # Model failed to be reversed
+                return self.allow_non_reversible_detections
+        else:
+            # Invalid measurement model used. Must be an instance of linear or reversible
+            return self.allow_non_reversible_detections
+
+        measurement_in_state_space = State(state_vector)
+
+        track_prediction = hypothesis.prediction
+        distance = self.measure(track_prediction, measurement_in_state_space)
+
+        return distance < self.gate_threshold

--- a/stonesoup/gater/tests/test_distance.py
+++ b/stonesoup/gater/tests/test_distance.py
@@ -7,7 +7,9 @@ from ..distance import DistanceGater, TrackingStateSpaceDistanceGater
 from ... import measures as measures
 from ...hypothesiser.distance import DistanceHypothesiser
 from ...hypothesiser.probability import PDAHypothesiser
-from ...models.measurement.nonlinear import CartesianToBearingRange
+from ...models.measurement.linear import LinearGaussian
+from ...models.measurement.nonlinear import CartesianToBearingRange, Cartesian2DToBearing, \
+    CombinedReversibleGaussianMeasurementModel
 from ...models.transition.linear import CombinedLinearGaussianTransitionModel, \
     ConstantVelocity
 from ...predictor.kalman import ExtendedKalmanPredictor
@@ -81,7 +83,7 @@ def standard_distance_hypothesiser():
     transition_model = CombinedLinearGaussianTransitionModel([ConstantVelocity(0.05),
                                                               ConstantVelocity(0.05)])
     predictor = ExtendedKalmanPredictor(transition_model)
-    updater = ExtendedKalmanUpdater(measurement_model)
+    updater = ExtendedKalmanUpdater(bearing_range_measurement_model)
     hypothesiser = DistanceHypothesiser(predictor, updater, measure=measures.Euclidean())
     return hypothesiser
 
@@ -104,13 +106,19 @@ track = Track([GaussianState(
     covar=np.diag([1.5, 0.5, 1.5, 0.5])
 )])
 
-measurement_model = CartesianToBearingRange(
+bearing_range_measurement_model = CartesianToBearingRange(
     ndim_state=4,
     mapping=(0, 2),
     noise_covar=np.diag([np.radians(0.2), 1]),  # Covariance matrix. 0.2 degree variance in
     # bearing and 1 metre in range
     translation_offset=np.array([[0], [0]])  # Offset measurements to location of
     # sensor in cartesian.
+)
+
+linear_measurement_model = LinearGaussian(
+    ndim_state=4,
+    mapping=(0, 2),
+    noise_covar=np.diag([1, 1]),  # Covariance matrix. 1 each in x and y
 )
 
 
@@ -120,17 +128,21 @@ measurement_model = CartesianToBearingRange(
         # Perfect detection
         Detection(state_vector=[np.pi/2, 100],
                   timestamp=start_time,
-                  measurement_model=measurement_model),
+                  measurement_model=bearing_range_measurement_model),
         # Detection with slightly wrong range
         Detection(state_vector=[np.pi/2, 109],
                   timestamp=start_time,
-                  measurement_model=measurement_model),
+                  measurement_model=bearing_range_measurement_model),
         # Detection with slightly wrong bearing
         Detection(state_vector=[0.01 + np.pi/2, 109],
                   timestamp=start_time,
-                  measurement_model=measurement_model),
+                  measurement_model=bearing_range_measurement_model),
+        # Perfect Linear Detection
+        Detection(state_vector=[0, 100],
+                  timestamp=start_time,
+                  measurement_model=linear_measurement_model),
     ],
-    ids=["test1", "test2", "test3"]
+    ids=["bearing_range_1", "bearing_range_2", "bearing_range_3", "linear_4"]
 )
 def test_tracking_state_space_distance_gater_good_detections(
         detection, standard_distance_hypothesiser,
@@ -152,21 +164,26 @@ def test_tracking_state_space_distance_gater_good_detections(
         # Correct range. Wrong bearing
         Detection(state_vector=[0, 100],
                   timestamp=start_time,
-                  measurement_model=measurement_model),
+                  measurement_model=bearing_range_measurement_model),
         # Correct bearing. Wrong range
         Detection(state_vector=[np.pi / 2, 111],
                   timestamp=start_time,
-                  measurement_model=measurement_model),
+                  measurement_model=bearing_range_measurement_model),
         # Detection with slightly wrong bearing
         Detection(state_vector=[-np.pi / 2, 109],
                   timestamp=start_time,
-                  measurement_model=measurement_model),
+                  measurement_model=bearing_range_measurement_model),
+        # Wrong Linear Detection
+        Detection(state_vector=[10, 110],
+                  timestamp=start_time,
+                  measurement_model=linear_measurement_model),
     ],
-    ids=["test1", "test2", "test3"]
+    ids=["bearing_range_1", "bearing_range_2", "bearing_range_3", "linear_4"]
 )
 def test_tracking_state_space_distance_gater_bad_detections(
         detection, standard_distance_hypothesiser,
         hypothesiser_with_tracking_state_space_distance_gater):
+
     hypothesiser_with_gate = hypothesiser_with_tracking_state_space_distance_gater
 
     hypotheses_no_gate = standard_distance_hypothesiser.hypothesise(
@@ -176,3 +193,53 @@ def test_tracking_state_space_distance_gater_bad_detections(
 
     assert len(hypotheses_no_gate) == 2
     assert len(hypotheses_with_gate) == 1
+
+
+def test_tracking_state_space_distance_gater_value_error(
+        hypothesiser_with_tracking_state_space_distance_gater):
+
+    detection = Detection(state_vector=[0, 100], timestamp=start_time, measurement_model=None)
+
+    hypothesiser_with_gate = hypothesiser_with_tracking_state_space_distance_gater
+
+    with pytest.raises(ValueError):
+        hypothesiser_with_gate.hypothesise(track, {detection}, timestamp=start_time)
+
+
+bearing_measurement_model = Cartesian2DToBearing(ndim_state=4,
+                                                 mapping=(0, 2),
+                                                 noise_covar=np.diag([1]))
+
+
+@pytest.mark.parametrize(
+    "detection",
+    [
+        # Irreversible detection
+        Detection(state_vector=[0, 100],
+                  timestamp=start_time,
+                  measurement_model=bearing_measurement_model
+                  ),
+        # Irreversible detection 2
+        Detection(state_vector=[0, 100],
+                  timestamp=start_time,
+                  measurement_model=CombinedReversibleGaussianMeasurementModel(
+                      [bearing_measurement_model])
+                  ),
+    ],
+    ids=["test_1", "test_2"]
+)
+@pytest.mark.parametrize("allow_non_reversible_detections", [True, False])
+def test_tracking_state_space_distance_gater_irreversible_detections(
+        detection, allow_non_reversible_detections,
+        hypothesiser_with_tracking_state_space_distance_gater):
+
+    hypothesiser_with_gate = hypothesiser_with_tracking_state_space_distance_gater
+    hypothesiser_with_gate.allow_non_reversible_detections = allow_non_reversible_detections
+
+    hypotheses_with_gate = hypothesiser_with_gate.hypothesise(
+        track, {detection}, timestamp=start_time)
+
+    if allow_non_reversible_detections:
+        assert len(hypotheses_with_gate) == 2
+    else:
+        assert len(hypotheses_with_gate) == 1


### PR DESCRIPTION
Data association in stone soup occurs in the measurement state space. This pull request introduces `TrackingStateSpaceDistanceGater`, a gater than operates in the tracking state space (not the measurement state space). As the gate is in the tracking state space, measurements must use a measurement model that is either a `ReversibleModel` or a `LinearModel`.

This model will be particularly useful in the following example:
The sensor is located at [0, 0]. 
A target is located at [0, 1000]. This corresponds to a bearing-range measurement of [pi/2, 1000]. 
A clutter detection has a measurement of [0, 1000] (x, y = [1000, 0]). 
The `Euclidean` distance in measurement state space between the target and the clutter measurement is only 1.57 (pi/2). Unless the gate size is small, this would pass a `DistanceGater`. 
While the `Euclidean` distance in tracking state space between the target and the clutter measurement is 1414. Unless the gate size was very large this wouldn’t pass a `TrackingStateSpaceDistanceGater`. 
