### PR TITLE
Suppress warnings with Sphinx config cache

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -162,6 +162,8 @@ pygments_style = 'sphinx'
 # If true, keep warnings as "system message" paragraphs in the built documents.
 # keep_warnings = False
 
+suppress_warnings = ["config.cache"]
+
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = False
 


### PR DESCRIPTION
This is causing failure on CI with fresh docs builds, but can be ignored as not concerned with caching config.