### PR TITLE
Update Plotterly tio name axis

### DIFF
--- a/docs/examples/plotting_3D.py
+++ b/docs/examples/plotting_3D.py
@@ -136,7 +136,7 @@ fig_ani.fig
 # that one target is spiralling around the other. Due to the way the plotter plots one trace at
 # a time, the rotating target appears to always be in front of the other. The user
 # must mentally combine these two plots to gather a full picture of target movement.
-fig = Plotterly()
+fig = Plotterly(axis_labels=["y", "z"])
 fig.plot_ground_truths(truths, [2, 4])
 fig.plot_measurements(measurements, [2, 4])
 fig.plot_tracks(tracks, [2, 4], uncertainty=True)

--- a/stonesoup/plotter.py
+++ b/stonesoup/plotter.py
@@ -968,6 +968,9 @@ class Plotterly(_Plotter):
     ----------
     dimension: enum \'Dimension\'
         Optional parameter to specify 1D, 2D, or 3D plotting.
+    axis_labels: list
+        Optional parameter to specify the axis labels for non-xy dimensions. Default None, i.e.,
+        "x" and "y".
     \\*\\*kwargs: dict
         Additional arguments to be passed to the Plotly.graph_objects Figure.
 
@@ -976,7 +979,9 @@ class Plotterly(_Plotter):
     fig: plotly.graph_objects.Figure
         Generated figure to display graphs.
     """
-    def __init__(self, dimension=Dimension.TWO, **kwargs):
+    def __init__(self, dimension=Dimension.TWO, axis_labels=None, **kwargs):
+        if not axis_labels:
+            axis_labels = ["x", "y"]
         if go is None:
             raise RuntimeError("Usage of Plotterly plotter requires installation of `plotly`")
 
@@ -985,8 +990,8 @@ class Plotterly(_Plotter):
 
         from plotly import colors
         layout_kwargs = dict(
-            xaxis_title="x",
-            yaxis_title="y",
+            xaxis_title=axis_labels[0],
+            yaxis_title=axis_labels[1],
             colorway=colors.qualitative.Plotly,  # Needed to match colours later.
         )
 


### PR DESCRIPTION
This PR adds the functionality to include axis labels when plotting non-xy plots, e.g., plotting y against z.

Currently all plots default to have axis names "x" and "y" regardless of the dimensions being plotted.  