### PR TITLE
Handle linalg error in gauss2sigma with Cholesky decomposition

### DIFF
--- a/stonesoup/functions/__init__.py
+++ b/stonesoup/functions/__init__.py
@@ -1,5 +1,6 @@
 """Mathematical functions used within Stone Soup"""
 import copy
+import warnings
 
 import numpy as np
 
@@ -149,7 +150,11 @@ def gauss2sigma(state, alpha=1.0, beta=2.0, kappa=None):
         kappa = 3.0 - ndim_state
 
     # Compute Square Root matrix via Colesky decomp.
-    sqrt_sigma = np.linalg.cholesky(state.covar)
+    try:
+        sqrt_sigma = np.linalg.cholesky(state.covar)
+    except np.linalg.LinAlgError as e:
+        warnings.warn(repr(e))
+        sqrt_sigma = cholesky_eps(state.covar)
 
     # Calculate scaling factor for all off-center points
     alpha2 = np.power(alpha, 2)

--- a/stonesoup/functions/tests/test_functions.py
+++ b/stonesoup/functions/tests/test_functions.py
@@ -176,6 +176,18 @@ def test_gauss2sigma(mean):
         assert sigma_point_state.state_vector[0, 0] == approx(mean + n*covar**0.5)
 
 
+def test_gauss2sigma_bad_covar():
+    covar = np.array(
+        [[ 0.05201447,  0.02882126, -0.00569971, -0.00733617],  # noqa: E201
+         [ 0.02882126,  0.01642966, -0.00862847, -0.00673035],  # noqa: E201
+         [-0.00569971, -0.00862847,  0.06570757,  0.03251551],
+         [-0.00733617, -0.00673035,  0.03251551,  0.01648615]])
+    state = GaussianState([[0], [0], [0], [0]], covar)
+
+    with pytest.warns(UserWarning, match="Matrix is not positive definite"):
+        sigma_points_states, mean_weights, covar_weights = gauss2sigma(state, kappa=0)
+
+
 @pytest.mark.parametrize(
     "angle",
     [


### PR DESCRIPTION
In cases where linalg error is produced, fall back to `cholesky_eps` designed for nearly positive-definite matrix, producing a user warning when this occurs.