### PR TITLE
Allow generation of predicted measurement without measurement noise

### DIFF
--- a/stonesoup/updater/alphabeta.py
+++ b/stonesoup/updater/alphabeta.py
@@ -66,19 +66,28 @@ class AlphaBetaUpdater(Updater):
                                                   "the position elements in the state vector.")
 
     @lru_cache()
-    def predict_measurement(self, prediction, measurement_model=None, **kwargs):
+    def predict_measurement(self, prediction, measurement_model=None, measurement_noise=False,
+                            **kwargs):
         """Return the predicted measurement
 
         Parameters
         ----------
         prediction : :class:`~.StatePrediction`
             The state prediction
+        measurement_model : :class:`~.MeasurementModel`
+            The measurement model. If omitted, the model in the updater object
+            is used
+        measurement_noise : bool
+            Whether to include measurement noise, in this case on `False` is valid.
+            Default `False`
 
         Returns
         -------
          : :class:`~.StateVector`
             The predicted measurement
         """
+        if measurement_noise:
+            raise ValueError("measurement noise must be False")
         # This necessary if predict_measurement called on its own
         measurement_model = self._check_measurement_model(measurement_model)
         pred_meas = measurement_model.matrix(**kwargs) @ prediction.state_vector

--- a/stonesoup/updater/asd.py
+++ b/stonesoup/updater/asd.py
@@ -22,7 +22,7 @@ class ASDKalmanUpdater(KalmanUpdater):
         vol. 47, no. 4, pp. 2766-2778, OCTOBER 2011, doi: 10.1109/TAES.2011.6034663.
     """
     @lru_cache()
-    def predict_measurement(self, predicted_state, measurement_model=None,
+    def predict_measurement(self, predicted_state, measurement_model=None, measurement_noise=True,
                             **kwargs):
         r"""Predict the measurement implied by the predicted state mean
 
@@ -33,6 +33,8 @@ class ASDKalmanUpdater(KalmanUpdater):
         measurement_model : :class:`~.MeasurementModel`
             The measurement model. If omitted, the model in the updater
             object is used
+        measurement_noise : bool
+            Whether to include measurement noise :math:`R` with innovation covariance
         **kwargs : various
             These are passed to :meth:`~.MeasurementModel.function` and
             :meth:`~.MeasurementModel.matrix`
@@ -53,7 +55,9 @@ class ASDKalmanUpdater(KalmanUpdater):
         hh = self._measurement_matrix(predicted_state=state_at_t,
                                       measurement_model=measurement_model,
                                       **kwargs)
-        innov_cov = hh@state_at_t.covar@hh.T + measurement_model.covar()
+        innov_cov = hh@state_at_t.covar@hh.T
+        if measurement_noise:
+            innov_cov += measurement_model.covar()
 
         t2t_plus = slice(t_index * predicted_state.ndim, (t_index+1) * predicted_state.ndim)
         meas_cross_cov = predicted_state.multi_covar[:, t2t_plus] @ hh.T

--- a/stonesoup/updater/base.py
+++ b/stonesoup/updater/base.py
@@ -47,12 +47,12 @@ class Updater(Base):
 
     @abstractmethod
     def predict_measurement(
-            self, state_prediction, measurement_model=None, **kwargs):
+            self, predicted_state, measurement_model=None, measurement_noise=True, **kwargs):
         """Get measurement prediction from state prediction
 
         Parameters
         ----------
-        state_prediction : :class:`~.StatePrediction`
+        predicted_state : :class:`~.StatePrediction`
             The state prediction
         measurement_model: :class:`~.MeasurementModel`, optional
             The measurement model used to generate the measurement prediction.
@@ -60,6 +60,8 @@ class Updater(Base):
             on the received measurement. The default is `None`, in which case
             the updater will use the measurement model specified on
             initialisation
+        measurement_noise : bool
+            Whether to include measurement noise predicted measurement. Default `True`
 
         Returns
         -------

--- a/stonesoup/updater/categorical.py
+++ b/stonesoup/updater/categorical.py
@@ -101,7 +101,8 @@ class HMMUpdater(Updater):
 
         return measurement_model
 
-    def predict_measurement(self, predicted_state, measurement_model, **kwargs):
+    def predict_measurement(self, predicted_state, measurement_model=None, measurement_noise=False,
+                            **kwargs):
         r"""Predict the measurement implied by the predicted state.
 
         Parameters
@@ -110,8 +111,8 @@ class HMMUpdater(Updater):
             The predicted state.
         measurement_model : :class:`~.MeasurementModel`
             The measurement model. If omitted, the model in the updater object is used.
-        measurement : :class:`~.CategoricalState`.
-            The measurement.
+        measurement_noise : bool
+            Whether to include measurement noise. Default `False`
         **kwargs : various
             These are passed to :meth:`~.MeasurementModel.function`.
 
@@ -123,7 +124,7 @@ class HMMUpdater(Updater):
 
         measurement_model = self._check_measurement_model(measurement_model)
 
-        pred_meas = measurement_model.function(predicted_state, **kwargs)
+        pred_meas = measurement_model.function(predicted_state, noise=measurement_noise, **kwargs)
 
         return MeasurementPrediction.from_state(
             predicted_state,

--- a/stonesoup/updater/chernoff.py
+++ b/stonesoup/updater/chernoff.py
@@ -81,7 +81,8 @@ class ChernoffUpdater(Updater):
         doc="A weighting parameter in the range :math:`(0,1]`")
 
     @lru_cache()
-    def predict_measurement(self, predicted_state, measurement_model=None,  **kwargs):
+    def predict_measurement(self, predicted_state, measurement_model=None, measurement_noise=True,
+                            **kwargs):
         r"""
         This function predicts the measurement of a state in situations where measurements consist
         of a covariance and state vector.
@@ -93,6 +94,9 @@ class ChernoffUpdater(Updater):
         measurement_model : :class:`~.MeasurementModel`
             The measurement model. If omitted, the updater will use the model that was specified
             on initialization.
+        measurement_noise : bool
+            Whether to include measurement noise. Default `True`. Where `False` the
+            predicted state covariance is used directly without omega factor.
 
         Returns
         -------
@@ -102,9 +106,12 @@ class ChernoffUpdater(Updater):
 
         measurement_model = self._check_measurement_model(measurement_model)
 
-        # The innovation covariance uses the noise covariance from the measurement model
-        state_covar_m = measurement_model.noise_covar
-        innov_covar = 1/(1-self.omega)*state_covar_m + 1/self.omega*predicted_state.covar
+        if measurement_noise:
+            # The innovation covariance uses the noise covariance from the measurement model
+            state_covar_m = measurement_model.noise_covar
+            innov_covar = 1/(1-self.omega)*state_covar_m + 1/self.omega*predicted_state.covar
+        else:
+            innov_covar = predicted_state.covar
 
         # The predicted measurement and measurement cross covariance can be taken from
         # the predicted state

--- a/stonesoup/updater/ensemble.py
+++ b/stonesoup/updater/ensemble.py
@@ -108,7 +108,7 @@ class EnsembleUpdater(KalmanUpdater):
         return hypothesis
 
     @lru_cache()
-    def predict_measurement(self, predicted_state, measurement_model=None,
+    def predict_measurement(self, predicted_state, measurement_model=None, measurement_noise=True,
                             **kwargs):
         r"""Predict the measurement implied by the predicted state mean
 
@@ -119,7 +119,8 @@ class EnsembleUpdater(KalmanUpdater):
         measurement_model : :class:`~.MeasurementModel`
             The measurement model. If omitted, the model in the updater object
             is used
-
+        measurement_noise : bool
+            Whether to include measurement noise :math:`R` when generating ensemble. Default `True`
 
         Returns
         -------
@@ -132,10 +133,10 @@ class EnsembleUpdater(KalmanUpdater):
         measurement_model = self._check_measurement_model(measurement_model)
 
         # Propagate each vector through the measurement model.
-        pred_meas_ensemble = measurement_model.function(predicted_state, noise=True)
+        pred_meas_ensemble = measurement_model.function(
+            predicted_state, noise=measurement_noise, **kwargs)
 
-        return MeasurementPrediction.from_state(
-                   predicted_state, pred_meas_ensemble)
+        return MeasurementPrediction.from_state(predicted_state, state_vector=pred_meas_ensemble)
 
     def update(self, hypothesis, **kwargs):
         r"""The Ensemble Kalman update method. The Ensemble Kalman filter

--- a/stonesoup/updater/recursive.py
+++ b/stonesoup/updater/recursive.py
@@ -28,7 +28,8 @@ class BayesianRecursiveUpdater(ExtendedKalmanUpdater):
     def _get_meas_cov_scale_factor(cls, n=1, step_no=None):
         return n
 
-    def _innovation_covariance(self, m_cross_cov, meas_mat, meas_mod, scale_factor=1):
+    def _innovation_covariance(self, m_cross_cov, meas_mat, meas_mod, measurement_noise,
+                               scale_factor=1, **kwargs):
         """Compute the innovation covariance
 
         Parameters
@@ -39,6 +40,10 @@ class BayesianRecursiveUpdater(ExtendedKalmanUpdater):
             Measurement matrix
         meas_mod : :class:~.MeasurementModel`
             Measurement model
+        measurement_noise : bool
+            Include measurement noise or not
+        scale_factor : float
+            Scaling factor between 0 and 1. Default 1 (no scaling)
 
         Returns
         -------
@@ -46,7 +51,10 @@ class BayesianRecursiveUpdater(ExtendedKalmanUpdater):
             The innovation covariance
 
         """
-        return meas_mat@m_cross_cov + scale_factor*meas_mod.covar()
+        innov_covar = meas_mat@m_cross_cov
+        if measurement_noise:
+            innov_covar += scale_factor*meas_mod.covar(**kwargs)
+        return innov_covar
 
     def _posterior_covariance(self, hypothesis, scale_factor=1):
         """

--- a/stonesoup/updater/tests/test_alphabeta.py
+++ b/stonesoup/updater/tests/test_alphabeta.py
@@ -76,3 +76,6 @@ def test_alphabeta(measurement_model, prediction, measurement, alpha, beta):
     updater.measurement_model = None
     with pytest.raises(ValueError):
         updater._check_measurement_model(None)
+
+    with pytest.raises(ValueError):
+        updater.predict_measurement(prediction, measurement_noise=True)

--- a/stonesoup/updater/tests/test_asd.py
+++ b/stonesoup/updater/tests/test_asd.py
@@ -46,6 +46,18 @@ def test_asdkalman():
     # Initialise a kalman updater
     updater = ASDKalmanUpdater(measurement_model=measurement_model)
 
+    # Get and assert measurement prediction without measurement noise
+    measurement_prediction = updater.predict_measurement(prediction, measurement_noise=False)
+    assert np.allclose(measurement_prediction.mean,
+                       eval_measurement_prediction.mean,
+                       0, atol=1.e-14)
+    assert np.allclose(measurement_prediction.covar,
+                       eval_measurement_prediction.covar - measurement_model.covar(),
+                       0, atol=1.e-14)
+    assert np.allclose(measurement_prediction.cross_covar,
+                       eval_measurement_prediction.cross_covar,
+                       0, atol=1.e-14)
+
     # Get and assert measurement prediction
     measurement_prediction = updater.predict_measurement(prediction)
     assert np.allclose(measurement_prediction.mean,

--- a/stonesoup/updater/tests/test_chernoff.py
+++ b/stonesoup/updater/tests/test_chernoff.py
@@ -49,6 +49,18 @@ def test_chernoff(UpdaterClass, measurement_model, prediction, measurement, omeg
     # Initialise a Chernoff updater
     updater = UpdaterClass(measurement_model=measurement_model, omega=omega)
 
+    # Get and assert measurement prediction without measurement noise
+    measurement_prediction = updater.predict_measurement(prediction, measurement_noise=False)
+    assert np.allclose(measurement_prediction.mean,
+                       eval_measurement_prediction.mean,
+                       0, atol=1.e-14)
+    assert np.allclose(measurement_prediction.covar,
+                       prediction.covar,
+                       0, atol=1.e-14)
+    assert np.allclose(measurement_prediction.cross_covar,
+                       eval_measurement_prediction.cross_covar,
+                       0, atol=1.e-14)
+
     # Get and assert measurement prediction
     measurement_prediction = updater.predict_measurement(prediction)
     assert np.allclose(measurement_prediction.mean,

--- a/stonesoup/updater/tests/test_ensemble.py
+++ b/stonesoup/updater/tests/test_ensemble.py
@@ -64,6 +64,14 @@ def test_ensemble():
     assert np.allclose(updated_state.sqrt_covar @ updated_state.sqrt_covar.T,
                        updated_state.covar)
 
+    measurement_model.noise_covar += 1.  # Increase noise to confirm test
+    updater = EnsembleUpdater(measurement_model)
+    noise_measurement_prediction = updater.predict_measurement(prediction)
+    no_noise_measurement_prediction = updater.predict_measurement(
+        prediction, measurement_noise=False)
+    assert np.sum(np.trace(no_noise_measurement_prediction.covar)) \
+        < np.sum(np.trace(noise_measurement_prediction.covar))
+
 
 def test_sqrt_ensemble():
 
@@ -118,6 +126,14 @@ def test_sqrt_ensemble():
     assert np.allclose(updated_state.sqrt_covar @ updated_state.sqrt_covar.T,
                        updated_state.covar)
 
+    measurement_model.noise_covar += 1.  # Increase noise to confirm test
+    updater = EnsembleUpdater(measurement_model)
+    noise_measurement_prediction = updater.predict_measurement(prediction)
+    no_noise_measurement_prediction = updater.predict_measurement(
+        prediction, measurement_noise=False)
+    assert np.sum(np.trace(no_noise_measurement_prediction.covar)) \
+           < np.sum(np.trace(noise_measurement_prediction.covar))
+
 
 def test_linearised_ensemble_updater():
     # Initialize variables
@@ -171,3 +187,11 @@ def test_linearised_ensemble_updater():
            updated_state.hypothesis.prediction.num_vectors
     assert np.allclose(updated_state.sqrt_covar @ updated_state.sqrt_covar.T,
                        updated_state.covar)
+
+    measurement_model.noise_covar += 1.  # Increase noise to confirm test
+    updater = EnsembleUpdater(measurement_model)
+    noise_measurement_prediction = updater.predict_measurement(prediction)
+    no_noise_measurement_prediction = updater.predict_measurement(
+        prediction, measurement_noise=False)
+    assert np.sum(np.trace(no_noise_measurement_prediction.covar)) \
+           < np.sum(np.trace(noise_measurement_prediction.covar))

--- a/stonesoup/updater/tests/test_information.py
+++ b/stonesoup/updater/tests/test_information.py
@@ -53,6 +53,10 @@ def test_information(UpdaterClass, measurement_model, prediction, measurement):
     # Does the measurement prediction work?
     assert np.allclose(kupdater.predict_measurement(prediction).state_vector,
                        updater.predict_measurement(info_prediction).state_vector, 0, atol=1.e-14)
+    assert np.allclose(
+        kupdater.predict_measurement(prediction, measurement_noise=False).state_vector,
+        updater.predict_measurement(info_prediction, measurement_noise=False).state_vector,
+        0, atol=1.e-14)
 
     # Do the
     assert np.allclose(kposterior.state_vector,

--- a/stonesoup/updater/tests/test_kalman.py
+++ b/stonesoup/updater/tests/test_kalman.py
@@ -89,6 +89,18 @@ def test_kalman(UpdaterClass, measurement_model, prediction, measurement):
     # Initialise a kalman updater
     updater = UpdaterClass(measurement_model=measurement_model)
 
+    # Get and assert measurement prediction without measurement noise
+    measurement_prediction = updater.predict_measurement(prediction, measurement_noise=False)
+    assert np.allclose(measurement_prediction.mean,
+                       eval_measurement_prediction.mean,
+                       0, atol=1.e-14)
+    assert np.allclose(measurement_prediction.covar,
+                       eval_measurement_prediction.covar - measurement_model.covar(),
+                       0, atol=1.e-14)
+    assert np.allclose(measurement_prediction.cross_covar,
+                       eval_measurement_prediction.cross_covar,
+                       0, atol=1.e-14)
+
     # Get and assert measurement prediction
     measurement_prediction = updater.predict_measurement(prediction)
     assert np.allclose(measurement_prediction.mean,

--- a/stonesoup/updater/tests/test_particle.py
+++ b/stonesoup/updater/tests/test_particle.py
@@ -74,9 +74,13 @@ def test_particle(updater):
                                             for i in particles],
                                             timestamp=timestamp)
 
-    measurement_prediction = updater.predict_measurement(prediction)
-
+    measurement_prediction = updater.predict_measurement(prediction, measurement_noise=False)
     assert np.all(eval_measurement_prediction.state_vector == measurement_prediction.state_vector)
+    assert measurement_prediction.timestamp == timestamp
+
+    # With measurement noise
+    measurement_prediction = updater.predict_measurement(prediction)
+    assert np.all(eval_measurement_prediction.state_vector != measurement_prediction.state_vector)
     assert measurement_prediction.timestamp == timestamp
 
     updated_state = updater.update(SingleHypothesis(
@@ -251,20 +255,19 @@ def test_regularised_particle(transition_model, model_flag):
     eval_measurement_prediction = ParticleMeasurementPrediction(
         StateVectors([prediction.state_vector[0, :]]), timestamp=timestamp)
 
-    measurement_prediction = updater.predict_measurement(prediction)
+    measurement_prediction = updater.predict_measurement(prediction, measurement_noise=False)
 
     assert np.all(eval_measurement_prediction.state_vector == measurement_prediction.state_vector)
     assert measurement_prediction.timestamp == timestamp
 
     updated_state = updater.update(SingleHypothesis(
-        prediction, measurement, measurement_prediction))
+        prediction, measurement, None))
 
     # Don't know what the particles will exactly be due to randomness so check
     # some obvious properties
 
     assert np.all(weight == 1 / 9 for weight in updated_state.weight)
     assert updated_state.timestamp == timestamp
-    assert updated_state.hypothesis.measurement_prediction == measurement_prediction
     assert updated_state.hypothesis.prediction == prediction
     assert updated_state.hypothesis.measurement == measurement
 


### PR DESCRIPTION
This standardises the `Updater.predict_measurement` method to include an optional `measurement_noise` Boolean argument to whether noise should be included in the predicted measurement. Defaults to `True`.

Note this does change the default behaviour of particle filter, as that did not included noise by default before. As this isn't used in the update step, it'll only have an impact on data association stage.

Resolves #961