### PR TITLE
Use walrus operator to omit cases where no tracks exist in associations

### DIFF
--- a/stonesoup/metricgenerator/tracktotruthmetrics.py
+++ b/stonesoup/metricgenerator/tracktotruthmetrics.py
@@ -450,8 +450,9 @@ class SIAPMetrics(MetricGenerator):
         float
             Average rate of track number changes
         """
-        numerator = sum(self.min_num_tracks_needed_to_track(manager, truth) - 1
-                        for truth in ground_truths)
+        numerator = sum(value - 1
+                        for truth in ground_truths
+                        if (value := self.min_num_tracks_needed_to_track(manager, truth)) > 0)
         denominator = sum(self.total_time_tracked(manager, truth)
                           for truth in ground_truths)
 


### PR DESCRIPTION
The SIAP Rate of Track Number Change is the average rate of track number changes for true objects held by the metric manager defined on $(0, \infty]$. 
$$\frac{\sum_{truth=0}^{max(truths)} min(\mathrm{tracks\ needed\ to\ track\ } (truth)) - 1}{\sum_{truth=0}^{max(truths)}(\mathrm{total\ time\ tracked}(truth))}$$
Currently, this rate can be negative when the numerator function "min number tracks needed to track truth" is 0.

This fix excludes cases where the minimum number of tracks is zero from the numerator sum.