### PR TITLE
Monte Carlo Tree Search Sensor Manager and Autonomous STE Examples

### DIFF
--- a/docs/examples/sensormanagement/Autonomous_Source_Term_Estimation.py
+++ b/docs/examples/sensormanagement/Autonomous_Source_Term_Estimation.py
@@ -1,0 +1,364 @@
+#!/usr/bin/env python
+
+"""
+Autonomous Source Term Estimation
+=================================
+"""
+
+# %%
+# This example demonstrates how to perform airborne release source term estimation (STE)
+# using particle filtering and how to use sensor management to optimise sensing locations
+# and arrive at an estimate of the source term.
+#
+# STE involves taking concentration measurements of an airborne chemical in order to
+# estimate the release location, release rate, diffusivity and possibly other environment
+# factors. The problem can be considered as a state estimation with a large state dimension
+# and small measurement dimension as we can usually only measure the concentration at a
+# point location. The underlying models for STE are adapted from [#]_ and the scenario
+# presented here is based on work by Hutchinson et al [#]_.
+
+# %%
+# Setup
+# ^^^^^
+# First, some general packages that are used throughout this example are imported. The
+# random number generator will also be fixed here for repeatability.
+
+# General imports and environment setup
+import numpy as np
+from datetime import datetime, timedelta
+
+np.random.seed(1990)
+
+# %%
+# Generate ground truth
+# ^^^^^^^^^^^^^^^^^^^^^
+#
+# Here we need to generate the ground truth source term that we seek to estimate.
+#
+# Unlike the usual target tracking examples, the state we are estimating is static,
+# so we do not need to generate a ground truth trajectory.
+#
+# The source term is constructed of 8 variables, as shown below.
+#
+# .. math::
+#     \mathbf{S} = \left[\begin{array}{c}
+#             x \\
+#             y \\
+#             z \\
+#             Q \\
+#             u \\
+#             \phi \\
+#             \zeta_1 \\
+#             \zeta_2
+#         \end{array}\right],
+#
+# where :math:`x, y` and :math:`z` are the source position in 3D Cartesian space, :math:`Q`
+# is the release rate/strength in g/s, :math:`u` is the wind speed in m/s, :math:`\phi` is
+# the wind direction in radians, :math:`\zeta_1` is the diffusivity of the gas in the
+# environment and :math:`\zeta_2` is the lifetime of the gas.
+#
+
+from stonesoup.types.groundtruth import GroundTruthState
+
+start_time = datetime.now()
+theta = GroundTruthState([30,  # x
+                          40,  # y
+                          1,  # z
+                          5,  # Q
+                          4,  # u
+                          np.radians(90),  # phi
+                          1,  # ci
+                          8],  # cii
+                         timestamp=start_time)
+
+
+# %%
+# Plot the resulting plume from the source term. The :class:`~.IsotropicPlume`
+# measurement model is used under ideal conditions to provide concentration values in a
+# planar grid, to visualise the release. Although the source term contains :math:`z`,
+# the sensor will be constrained to a single plane in this example. Therefore,
+# the plume is generated at the same level as the sensor will be later on. The
+# plume is visualised by using the :class:`~.Plotter` class from Stone Soup.
+
+from stonesoup.plotter import Plotter
+from stonesoup.types.state import StateVector
+from stonesoup.models.measurement.gas import IsotropicPlume
+
+plotter = Plotter()
+measurement_model = IsotropicPlume()
+
+z = 0
+n_values = 200
+intensity = np.zeros([n_values, n_values])
+pos_x = np.zeros([n_values])
+pos_y = np.zeros([n_values])
+for n_x, x in enumerate(np.linspace(0, 50, n_values)):
+    pos_x[n_x] = x
+    for n_y, y in enumerate(np.linspace(0, 50, n_values)):
+        pos_y[n_y] = y
+        pos = StateVector([x, y, z])
+        measurement_model.translation_offset = pos
+        intensity[n_x, n_y] = measurement_model.function(theta)
+
+plotter.ax.set_xlim(left=0, right=50)
+plotter.ax.set_ylim(bottom=0, top=50)
+plotter.ax.set_box_aspect(1)
+gas_distribution = plotter.ax.pcolor(pos_x, pos_y, intensity.T)
+plotter.fig.colorbar(gas_distribution, label='Concentration')
+
+# %%
+# Create sensor and platform
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^
+#
+# The sensor used here is a :class:`~.GasIntensitySensor` that provides point concentration
+# measurements. The documentation for the sensor provides insight into the various noise
+# parameters used here.
+#
+# The sensor alone is not controllable and therefore will be mounted onto an
+# actionable platform with the :class:`~.NStepDirectionalGridMovable` movement controller,
+# that allows the platform to move on the :math:`xy` plane in fixed step sizes.
+# The resulting trajectory from a controller of this type can be seen later
+# in the results.
+#
+
+from stonesoup.types.state import State
+from stonesoup.platform import FixedPlatform
+from stonesoup.movable.grid import NStepDirectionalGridMovable
+from stonesoup.sensor.gas import GasIntensitySensor
+
+gas_sensor = GasIntensitySensor(min_noise=1e-4,
+                                missed_detection_probability=0.3,
+                                sensing_threshold=5e-4)
+
+sensor_platform = FixedPlatform(
+    movement_controller=NStepDirectionalGridMovable(states=[State([[5], [5], [0.]],
+                                                                  timestamp=start_time)],
+                                                    position_mapping=(0, 1, 2),
+                                                    resolution=1,
+                                                    n_steps=2,
+                                                    step_size=2,
+                                                    action_mapping=(0, 1),
+                                                    action_space=np.array([[0, 50], [0, 50]])),
+    sensors=[gas_sensor])
+
+# %%
+# Create particle predictor and updater
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+#
+# Now the :class:`~.ParticlePredictor` and :class:`~.ParticleUpdater` are constructed.
+# The particle predictor will be created with a :class:`~.RandomWalk` motion model with 0
+# magnitude, meaning that the predictor will not change the estimated source term. This
+# is due to the static nature of the source term in this work. If a mobile release was
+# to be estimated, this assumption should change.
+#
+# The :class:`~.ParticleUpdater` is created with an effective sample size resampling
+# technique (:class:`~.ESSResampler`) and Markov Chain Monte Carlo regularisation
+# (:class:`~.MCMCRegulariser`). A constraint function is also provided to the
+# :class:`~.ParticleUpdater` and :class:`~.MCMCRegulariser` which enforces the fact
+# that :math:`Q`, :math:`u`, :math:`\zeta_1` and :math:`\zeta_2` can not be negative.
+
+from stonesoup.resampler.particle import ESSResampler
+from stonesoup.regulariser.particle import MCMCRegulariser
+from stonesoup.predictor.particle import ParticlePredictor
+from stonesoup.updater.particle import ParticleUpdater
+from stonesoup.models.transition.linear import RandomWalk, CombinedGaussianTransitionModel
+
+
+def constraint_function(particle_state):
+    logical_indx = ((particle_state.state_vector[3, :] < 0) |
+                    (particle_state.state_vector[4, :] < 0) |
+                    (particle_state.state_vector[6, :] < 0) |
+                    (particle_state.state_vector[7, :] < 0))
+    return logical_indx
+
+
+resampler = ESSResampler()
+regulariser = MCMCRegulariser(constraint_func=constraint_function)
+predictor = ParticlePredictor(CombinedGaussianTransitionModel([RandomWalk(0.0)] * 8))
+updater = ParticleUpdater(measurement_model,
+                          resampler=resampler,
+                          regulariser=regulariser,
+                          constraint_func=constraint_function)
+
+# %%
+# Create reward function and sensor manager
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+#
+# The Kullback-Leibler divergence (KLD) is used to decide on future sensing locations.
+# To do this, a :class:`~.MultiUpdateExpectedKLDivergence` reward function is created.
+# This reward function generates multiple synthetic detections to decided on how rewarding
+# candidate actions may be. This is not essential but for STE when sensing can be
+# unreliable, it helps to improve robustness in reward estimation, preventing potentially
+# rewarding actions from being overlooked. A separate :class:`~.ParticleUpdater` is
+# used for the reward function as there will be no resampling or regularisation when
+# evaluating candidate actions.
+#
+# The next step is to create the sensor manager which in this case will be the
+# :class:`~.BruteForceSensorManager` as this is a myopic implementation.
+
+from stonesoup.sensormanager.reward import MultiUpdateExpectedKLDivergence
+from stonesoup.sensormanager import BruteForceSensorManager
+
+reward_updater = ParticleUpdater(measurement_model=None)
+reward_func = MultiUpdateExpectedKLDivergence(updater=reward_updater, updates_per_track=4)
+sensormanager = BruteForceSensorManager(sensors={gas_sensor},
+                                        platforms={sensor_platform},
+                                        reward_function=reward_func)
+
+# %%
+# Create prior distribution
+# ^^^^^^^^^^^^^^^^^^^^^^^^^
+#
+# The particle filter is initialised with a broad distribution of particles. Each position
+# component receives a uniform distribution across the entire simulation environment. The
+# release rate receives a Gamma distribution and the wind speed, direction and diffusivity
+# parameters all receive uniform distributions about their respective ground truth values.
+# It would be expected in an STE scenario that wind speed, direction and properties of
+# the agent would all be known or estimated by a separate system and are therefore not
+# the main focus, but their inclusion helps to improve robustness of the plume model.
+# Notice that in this particle filter 10000 particles are used to capture the distribution.
+# This is because of the large state dimension which requires large numbers of particles
+# to get good coverage and effective estimation.
+
+from stonesoup.types.state import StateVectors, ParticleState
+
+n_parts = 10000
+prior = ParticleState(StateVectors([np.random.uniform(0, 50, n_parts),
+                                    np.random.uniform(0, 50, n_parts),
+                                    np.random.uniform(0, 5, n_parts),
+                                    np.random.gamma(2, 5, n_parts),
+                                    np.random.uniform(0, 6, n_parts),
+                                    np.random.uniform(np.radians(0), np.radians(180), n_parts),
+                                    np.random.uniform(0, 2, n_parts),
+                                    np.random.uniform(6, 10, n_parts)]),
+                      weight=np.array([1 / n_parts] * n_parts),
+                      timestamp=start_time)
+
+prior.parent = prior
+
+# %%
+# Run the filter and sensor manager
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+#
+# Now that all components have been created, the particle filter and sensor managers
+# can be run. Here 50 iterations are carried out but this process is usually dependent
+# on the estimated distribution covariance.
+#
+# Storing the sensor :math:`xy` positions is not required to run the algorithms,
+# but aids plotting later on.
+
+from stonesoup.types.track import Track
+from stonesoup.types.hypothesis import SingleHypothesis
+
+n_iter = 50
+track = Track(prior)
+sensor_x = [sensor_platform.position[0]]
+sensor_y = [sensor_platform.position[1]]
+for n in range(n_iter):
+    time = (start_time + timedelta(seconds=n + 1))
+    if n > 0:
+        chosen_actions = sensormanager.choose_actions({track}, time, n_steps=2, step_size=2,
+                                                      action_mapping=(0, 1))
+        for sensor, actions in chosen_actions[0].items():
+            sensor.add_actions(actions)
+            sensor.act(time)
+
+    prediction = predictor.predict(prior, timestamp=time)
+    theta.timestamp = time
+    detection = (gas_sensor.measure({theta}, noise=True).pop())
+    hypothesis = SingleHypothesis(prediction, detection)
+    update = updater.update(hypothesis)
+    track.append(update)
+    prior = track[-1]
+    sensor_x.append(sensor_platform.position[0])
+    sensor_y.append(sensor_platform.position[1])
+
+# %%
+# Plot the result
+# ^^^^^^^^^^^^^^^
+#
+# To illustrate the result of the simulation, the sensor trajectory created by the management
+# algorithm is plotted over the plume resulting from the source term. Concentration
+# measurements are also illustrated along the trajectory by the markers along the path
+# at the location that the detection was made. The size of the marker is proportional to
+# the concentration received. The :math:`xy` position from the particle distribution is
+# also shown to illustrate the estimation accuracy.
+
+from matplotlib import animation
+import matplotlib
+matplotlib.rcParams['animation.html'] = 'jshtml'
+
+# Plot ground truth plume
+plotter = Plotter()
+plotter.ax.set_xlim(left=0, right=50)
+plotter.ax.set_ylim(bottom=0, top=50)
+plotter.ax.set_box_aspect(1)
+gas_distribution = plotter.ax.pcolor(pos_x, pos_y, intensity.T)
+plotter.fig.colorbar(gas_distribution, label='Concentration')
+
+# Plot platform start location
+plotter.ax.plot(sensor_platform.movement_controller.states[0].state_vector[0],
+                sensor_platform.movement_controller.states[0].state_vector[1],
+                'go',
+               label='Start Location')
+
+# Plot initial particles and store line object for setting later
+parts, = plotter.ax.plot(track[0].state_vector[0],
+                         track[0].state_vector[1],
+                         'g.',
+                         markersize=0.5,
+                         linewidth=0,
+                         label='Particles')
+
+# Plot scatter of detection locations, intially with large marker for the legend
+detections = plotter.ax.scatter(sensor_x,
+                                sensor_y,
+                                s=np.array([10]*len(sensor_x)),
+                                c='r',
+                                linewidth=0,
+                                label='Detections')
+
+# Plot first sensor position for constructing trajectory, storing the line object for setting later
+trajectory, = plotter.ax.plot(sensor_platform.movement_controller.states[0].state_vector[0],
+                              sensor_platform.movement_controller.states[0].state_vector[0],
+                              'r-',
+                              label='Sensor Path')
+
+plotter.ax.legend(loc='center left', bbox_to_anchor=(-0.5, 0.5))
+
+# Reset the marker sizes after creating legend
+detections.set_sizes(np.array([0]*len(sensor_x)))
+
+def anim_func(i):
+    # Update particle line object according to latest track
+    parts.set_data(track[i].state_vector[0], track[i].state_vector[1])
+
+    states = np.array([[sensor_x[0]], [sensor_y[0]], [0]])
+    detection_marker_sizes = np.zeros(51)
+    for n in range(i):
+        # Collect states upto timestep i
+        states = np.append(states, np.array([[sensor_x[n+1]], [sensor_y[n+1]], [0]]), axis=1)
+
+        # Collect detections upto timestep i
+        if hasattr(track[n+1], 'hypothesis'):
+            detection_marker_sizes[n+1] = track[n+1].hypothesis.measurement.state_vector[0][0]*3000
+
+    # Update trajectory data and detection scatter marker sizes
+    trajectory.set_data(states[0], states[1])
+    detections.set_sizes(detection_marker_sizes)
+
+animation.FuncAnimation(plotter.fig, anim_func, interval=500, frames=len(track))
+
+# sphinx_gallery_thumbnail_number = 2
+
+# %%
+# References
+# ----------
+#
+# .. [#] Hutchinson, Michael & Liu, Cunjia & Chen, Wen-Hua, "Source term estimation of
+#        a hazardous airborne release using an unmanned aerial vehicle", Journal of Field
+#        Robotics, Vol. 36, 797-917, 2019
+# .. [#] Hutchinson, Michael & Liu, Cunjia & Chen, Wen-Hua, "Information-based search
+#        for an atmospheric release using a mobile robot: algorithms and experiements",
+#        IEEE Transactions on Control Systems Technology, Vol. 27, No. 6, 2388-2402, 2019
+#

--- a/docs/examples/sensormanagement/Monte_Carlo_Tree_Search_for_Autonomous_Source_Term_Estimation.py
+++ b/docs/examples/sensormanagement/Monte_Carlo_Tree_Search_for_Autonomous_Source_Term_Estimation.py
@@ -76,7 +76,6 @@ from datetime import datetime, timedelta
 import random
 
 np.random.seed(1991)
-random.seed(1991)
 
 # %%
 # Generate ground truth
@@ -242,7 +241,9 @@ updater = ParticleUpdater(measurement_model,
 # with increasing future depth, :attr:`rollout_depth` controls the
 # rollout horizon and :attr:`best_child_policy` determines how to select
 # the best child at the end of the MCTS process. Choices include maximum
-# action value, average action value per visit and maximum number of visits.
+# action value (``'max_cumulative_reward'``), average action value per
+# visit (``'max_average_reward'``) and maximum number of visits
+# (``'max_visits'``).
 
 
 from stonesoup.sensormanager.reward import ExpectedKLDivergence
@@ -266,7 +267,7 @@ sensormanagerB = MCTSRolloutSensorManager(sensors={gas_sensorB},
                                           exploration_factor=0.05,
                                           discount_factor=0.9, 
                                           rollout_depth=5,
-                                          best_child_policy=0)
+                                          best_child_policy='max_cumulative_reward')
 
 # %%
 # Create prior distribution

--- a/docs/examples/sensormanagement/Monte_Carlo_Tree_Search_for_Autonomous_Source_Term_Estimation.py
+++ b/docs/examples/sensormanagement/Monte_Carlo_Tree_Search_for_Autonomous_Source_Term_Estimation.py
@@ -67,7 +67,7 @@ Monte Carlo Tree Search for Autonomous Source Term Estimation
 # Setup
 # ^^^^^
 # First, some general packages used throughout the example are imported and
-# random number generation is seeded for repeatabiltiy.
+# random number generation is seeded for repeatability.
 #
 
 # General imports and environment setup
@@ -190,7 +190,7 @@ sensor_platformB = FixedPlatform(
 # 
 # Now the :class:`~.ParticlePredictor` and :class:`~.ParticleUpdater` are
 # constructed. The particle predictor will be created with a :class:`~.RandomWalk`
-# motion model with 0 magnitude, meaning that the perdictor will not change
+# motion model with 0 magnitude, meaning that the predictor will not change
 # the estimated source term.
 # 
 # The :class:`~.ParticleUpdater` is created with an effective sample size
@@ -546,7 +546,7 @@ animation.FuncAnimation(plotterB.fig, anim_funcB, interval=250, frames=len(track
 # the MCTS algorithm was able to converge to a better source term
 # estimate and did so in less iterations than the myopic benchmark. Considering
 # non-myopic actions in this scenario allows for more robust handling of
-# unreliable measurements, a common problem is STE that is caused by low
+# unreliable measurements, a common problem in STE that is caused by low
 # quality sensors or turbulent environment conditions.
 
 # %%

--- a/docs/examples/sensormanagement/Monte_Carlo_Tree_Search_for_Autonomous_Source_Term_Estimation.py
+++ b/docs/examples/sensormanagement/Monte_Carlo_Tree_Search_for_Autonomous_Source_Term_Estimation.py
@@ -1,0 +1,562 @@
+#!/usr/bin/env python
+
+"""
+Monte Carlo Tree Search for Autonomous Source Term Estimation
+=============================================================
+"""
+
+# %%
+# This example demonstrates how to set up and run a Monte Carlo tree search (MCTS)
+# sensor management algorithm for autonomous source term estimation (STE). More details
+# about the problem of autonomous STE can be found in the Autonomous Source Term Estimation
+# example, so this will not be replicated here. Instead, the focus is on MCTS and how to
+# implement it this for the problem.
+# 
+# MCTS is a technique for solving MDP and POMDP problems by simultaneously constructing
+# and evaluating a search tree. The process consists of 4 stages that are iterated
+# until we reach some predefined computational budget. These processes are: Selection,
+# Expansion, Simulation and Backpropagation. The purpose of the algorithm is to
+# arrive at the optimal action policy by sequentially estimating the action value
+# function, :math:`Q`, and returning the maximal argument to this at the end of
+# the process.
+# 
+# The process is described as follows. Starting from the root node (current
+# state or estimated state) the best child node is selected. The most common
+# way, and the way implemented here, is to select this node according to the
+# upper confidence bound (UCB) for trees. This is given by
+# 
+# .. math::
+#     \text{argmax}_{a} \frac{Q(h, a)}{N(h, a)}+c\sqrt{\frac{\log N(h)}{N(h,a)}},
+# 
+# where :math:`a` is the action, :math:`h` is the history (for POMDP problems a
+# history or belief is commonly used but in MDP problems this would be replaced with a
+# state), :math:`Q(h, a)` is the current cumulative action value estimate,
+# :math:`N(h, a)` is the number of visits or simulations of this node, :math:`N(h)`
+# is the number of visits to the parent node and :math:`c` is the exploration factor,
+# defined with :attr:`exploration_factor`. The purpose of the UCB is to trade off
+# between exploitation of the most rewarding nodes in the tree and exploration of
+# those that have been visited as frequently.
+# 
+# Once the best child node has been selected, this becomes a parent node and a
+# new child node added according to the available set of unvisited actions. This
+# selection happens at random. This node is then simulated by predicting the
+# current state estimate in the parent node and updating this estimate with a
+# generated detection after applying the candidate action. This provides a
+# predicted future state which is used to calculate the action value of this
+# node. This is done by providing a :attr:`reward_function`. Finally, this
+# reward is added to the current action value estimated in each node on the
+# search tree branch that was descended during selection. This creates a
+# tradeoff between future and immediate rewards during the next iteration
+# of the search process. Once a predefined computational budget has been
+# reached, which in this implementation is the :attr:`niterations` attribute,
+# the best child to the root node in the tree is determined and returned from
+# the :meth:`choose_actions`. The user can select which criteria used to
+# select this best action by defining the :attr:`best_child_policy`.
+# Further detail on MCTS can be found in the literature, including
+# variations and alternative POMDP approaches [#]_.
+# 
+# This example and MCTS implementation is based on the work by Glover et al [#]_.
+# The simulation shown here is similar to that work, with some modification
+# to reduce execution time. The reward implemented for this problem is the
+# Kullback-Leibler divegence (KLD) using :class:`~.ExpectedKLDivergence`
+# and this will be used with the :class:`~.MCTSRolloutSensorManager` and
+# benchmarked against a myopic alternative with :class:`~.BruteForceSensorManager`.
+#
+
+# %%
+# Setup
+# ^^^^^
+# First, some general packages used throughout the example are imported and
+# random number generation is seeded for repeatabiltiy.
+#
+
+# General imports and environment setup
+import numpy as np
+from datetime import datetime, timedelta
+import random
+
+np.random.seed(1991)
+random.seed(1991)
+
+# %%
+# Generate ground truth
+# ^^^^^^^^^^^^^^^^^^^^^
+# 
+# Here we generate the source term ground truth and import the
+# :class:`~.IsotropicPlume` measurement model to plot the resulting plume
+# from the ground truth.
+
+from stonesoup.types.groundtruth import GroundTruthState
+from stonesoup.models.measurement.gas import IsotropicPlume
+
+start_time = datetime.now()
+theta = GroundTruthState([30, # x
+                          40, # y
+                          1, # z
+                          5, # Q
+                          4, # u
+                          np.radians(90), # phi 
+                          1, # ci
+                          8], # cii
+                         timestamp=start_time)
+
+measurement_model = IsotropicPlume()
+
+# %%
+# Plot the resulting plume from the ground truth source term. This uses
+# the :class:`~.Plotter` class from Stone Soup.
+
+from stonesoup.plotter import Plotter
+from stonesoup.types.state import StateVector
+
+plotter = Plotter()
+
+z = 0
+n_values = 200
+intensity = np.zeros([n_values, n_values])
+pos_x = np.zeros([n_values])
+pos_y = np.zeros([n_values])
+for n_x, x in enumerate(np.linspace(0, 50, n_values)):
+    pos_x[n_x] = x
+    for n_y, y in enumerate(np.linspace(0, 50, n_values)):
+        pos_y[n_y] = y
+        pos = StateVector([x, y, z])
+        measurement_model.translation_offset = pos
+        intensity[n_x, n_y] = measurement_model.function(theta)
+
+plotter.ax.set_xlim(left=0, right=50)
+plotter.ax.set_ylim(bottom=0, top=50)
+plotter.ax.set_box_aspect(1)
+gas_distribution = plotter.ax.pcolor(pos_x, pos_y, intensity.T)
+plotter.fig.colorbar(gas_distribution, label='Concentration')
+
+
+# %%
+# Create sensors and platforms
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+# 
+# The sensor used here is a :class:`~.GasIntensitySensor` that provides
+# point concentration measurements. The documentation for the sensor provides
+# insight into the various noise parameters used here.
+# 
+# The sensor alone is not controllable and therefore will be mounted onto an
+# actionable platform with the :class:`~.NStepDirectionalGridMovable` movement
+# controller, that allows movement in the :math:`xy` plane in fixed step sizes. The
+# resulting trajectory from a controller of this type can be seen later in the
+# results.
+# 
+# The `gas_sensorA` and `sensor_platformA` is to be used with the benchmark
+# algorithm and `gas_sensorB` and `sensor_platformB` is to be used with the
+# MCTS sensor manager.
+
+from stonesoup.types.state import State
+from stonesoup.platform import FixedPlatform
+from stonesoup.movable.grid import NStepDirectionalGridMovable
+from stonesoup.sensor.gas import GasIntensitySensor
+
+gas_sensorA = GasIntensitySensor(min_noise=1e-4,
+                                 missed_detection_probability=0.3,
+                                 sensing_threshold=5e-4)
+
+sensor_platformA = FixedPlatform(
+    movement_controller=NStepDirectionalGridMovable(states=[State([[5], [15], [0.]],
+                                                                  timestamp=start_time)],
+                                                    position_mapping=(0, 1, 2),
+                                                    resolution=2,
+                                                    n_steps=1,
+                                                    step_size=1,
+                                                    action_mapping=(0, 1),
+                                                    action_space=np.array([[0, 50], [0, 50]])),
+    sensors=[gas_sensorA])
+
+gas_sensorB = GasIntensitySensor(min_noise=1e-4,
+                                 missed_detection_probability=0.3,
+                                 sensing_threshold=5e-4)
+
+sensor_platformB = FixedPlatform(
+    movement_controller=NStepDirectionalGridMovable(states=[State([[5], [15], [0.]],
+                                                                  timestamp=start_time)],
+                                                    position_mapping=(0, 1, 2),
+                                                    resolution=2,
+                                                    n_steps=1,
+                                                    step_size=1,
+                                                    action_mapping=(0, 1),
+                                                    action_space=np.array([[0, 50], [0, 50]])),
+    sensors=[gas_sensorB])
+
+
+# %%
+# Create particle predictor and updater
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+# 
+# Now the :class:`~.ParticlePredictor` and :class:`~.ParticleUpdater` are
+# constructed. The particle predictor will be created with a :class:`~.RandomWalk`
+# motion model with 0 magnitude, meaning that the perdictor will not change
+# the estimated source term.
+# 
+# The :class:`~.ParticleUpdater` is created with an effective sample size
+# resampling technique (:class:`~.ESSResampler`) and Markov Chain Monte Carlo
+# regularisation (:class:`~.MCMCRegulariser`). A constraint function is also
+# provided to the :class:`~.ParticleUpdater` and :class:`~.MCMCRegulariser`
+# to prevent invalid states from being generated.
+
+
+from stonesoup.resampler.particle import ESSResampler
+from stonesoup.regulariser.particle import MCMCRegulariser
+from stonesoup.predictor.particle import ParticlePredictor
+from stonesoup.updater.particle import ParticleUpdater
+from stonesoup.models.transition.linear import RandomWalk, CombinedGaussianTransitionModel
+
+def constraint_function(particle_state):
+    logical_indx = ((particle_state.state_vector[3, :]<0) |
+        (particle_state.state_vector[4, :]<0) |
+        (particle_state.state_vector[6, :]<0) |
+        (particle_state.state_vector[7, :]<0))
+    return logical_indx
+
+resampler = ESSResampler()
+regulariser = MCMCRegulariser(constraint_func=constraint_function)
+predictor = ParticlePredictor(CombinedGaussianTransitionModel([RandomWalk(0.0)]*8))
+updater = ParticleUpdater(measurement_model,
+                          resampler=resampler,
+                          regulariser=regulariser,
+                          constraint_func=constraint_function)
+
+# %%
+# Create reward functions and sensor managers
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+# 
+# Both the myopic benchmark and MCTS algorithms will be using the KLD
+# reward function (:class:`~.ExpectedKLDivergence`) but two separate
+# instances are created as the MCTS version will be required to return
+# tracks to store states in the search tree as it is constructed. Both
+# are created with a separate :class:`~.ParticleUpdater` that does
+# not perform resampling or regularisation.
+# 
+# The :class:`~.BruteForceSensorManager` is defined in the usual way,
+# but :class:`~.MCTSRolloutSensorManager` requires some more arguments.
+# :attr:`niterations` defines the computational budget for MCTS,
+# :attr:`exploration_factor` controls how exploratory the tree search
+# behaviour will be, :attr:`discount_factor` discounts future rewards
+# calculated in the rollout to reflect increasing uncertainty of rewards
+# with increasing future depth, :attr:`rollout_depth` controls the
+# rollout horizon and :attr:`best_child_policy` determines how to select
+# the best child at the end of the MCTS process. Choices include maximum
+# action value, average action value per visit and maximum number of visits.
+
+
+from stonesoup.sensormanager.reward import ExpectedKLDivergence
+from stonesoup.sensormanager import BruteForceSensorManager
+from stonesoup.sensormanager.tree_search import MCTSRolloutSensorManager
+
+reward_updater = ParticleUpdater(measurement_model=None)
+
+# Myopic benchmark approach
+reward_funcA = ExpectedKLDivergence(updater=reward_updater)
+sensormanagerA = BruteForceSensorManager(sensors={gas_sensorA}, 
+                                         platforms={sensor_platformA}, 
+                                         reward_function=reward_funcA)
+
+# MCTS with rollout approach
+reward_funcB = ExpectedKLDivergence(updater=reward_updater, return_tracks=True)
+sensormanagerB = MCTSRolloutSensorManager(sensors={gas_sensorB}, 
+                                          platforms={sensor_platformB}, 
+                                          reward_function=reward_funcB, 
+                                          niterations=100,
+                                          exploration_factor=0.05,
+                                          discount_factor=0.9, 
+                                          rollout_depth=5,
+                                          best_child_policy=0)
+
+# %%
+# Create prior distribution
+# ^^^^^^^^^^^^^^^^^^^^^^^^^
+# 
+# Each component of the source term will receive its own distribution.
+# Source location received a uniform distribution across the environment,
+# release rate received a Gamma distribution and the wind speed,
+# direction and diffusivity parameters all receive normal distributions.
+# The prior for both myopic and MCTS algorithms will be identical.
+
+
+from stonesoup.types.state import StateVectors, ParticleState
+from stonesoup.types.track import Track
+import copy 
+
+n_parts = 10000
+priorA = ParticleState(StateVectors([np.random.uniform(0, 50, n_parts),
+                                    np.random.uniform(0, 50, n_parts),
+                                    np.random.uniform(0, 5, n_parts),
+                                    np.random.gamma(2, 5, n_parts),
+                                    np.random.normal(theta.state_vector[4],
+                                                     2,
+                                                     n_parts),
+                                    np.random.normal(theta.state_vector[5],
+                                                     np.radians(10),
+                                                     n_parts),
+                                    np.random.normal(theta.state_vector[6],
+                                                     0.1,
+                                                     n_parts),
+                                    np.random.normal(theta.state_vector[7],
+                                                     1,
+                                                     n_parts)]),
+                      weight=np.array([1/n_parts]*n_parts),
+                      timestamp=start_time)
+
+priorA.parent = priorA
+priorB = copy.copy(priorA)
+
+# %%
+# Run the myopic sensor manager
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+# 
+# First the myopic sensor manager and associated filter is run
+# over 100 iterations, or until it reaches a stopping criteria
+# defined as the square root of the covariance trace being below a
+# threshold value. It is important to note that this has no bearing
+# on the performance of the estimation, just the convergence of
+# the particle distribution.
+
+from stonesoup.types.hypothesis import SingleHypothesis
+
+n_iter = 100
+stopping_criteria = 3
+
+trackA = Track(priorA)
+sensorA_x = [sensor_platformA.position[0]]
+sensorA_y = [sensor_platformA.position[1]]
+for n in range(n_iter):
+    time = (start_time + timedelta(seconds=n+1))
+    if n > 0:
+        chosen_actions = sensormanagerA.choose_actions({trackA}, time, n_steps=2, step_size=2,
+                                                      action_mapping=(0, 1))
+        for sensor, actions in chosen_actions[0].items():
+            sensor.add_actions(actions)
+            sensor.act(time)
+    
+    prediction = predictor.predict(priorA, timestamp=time)
+    theta.timestamp=time
+    detection = (gas_sensorA.measure({theta}, noise=True).pop())
+    hypothesis = SingleHypothesis(prediction, detection)
+    update = updater.update(hypothesis)
+    trackA.append(update)
+    priorA = trackA[-1]
+    sensorA_x.append(sensor_platformA.position[0])
+    sensorA_y.append(sensor_platformA.position[1])
+
+    if np.sqrt(np.trace(trackA.state.covar)) < stopping_criteria:
+        print('Converged in {} iterations'.format(n))
+        break
+
+
+# %%
+# Plot the myopic result
+# ^^^^^^^^^^^^^^^^^^^^^^
+# 
+# The performance of the myopic benchmark approach is illustrated
+# with an animation showing the sensor platform trajectory,
+# detections along this trajectory and the resulting source estimate
+# with the particle distributions.
+
+from matplotlib import animation
+import matplotlib
+matplotlib.rcParams['animation.html'] = 'jshtml'
+matplotlib.rcParams['animation.embed_limit'] = 40000000
+
+# Plot ground truth plume
+plotterA = Plotter()
+plotterA.ax.set_xlim(left=0, right=50)
+plotterA.ax.set_ylim(bottom=0, top=50)
+plotterA.ax.set_box_aspect(1)
+gas_distributionA = plotterA.ax.pcolor(pos_x, pos_y, intensity.T)
+plotterA.fig.colorbar(gas_distributionA, label='Concentration')
+plotterA.ax.set_title('Myopic KLD Sensor Management Result')
+
+# Plot platform start location
+plotterA.ax.plot(sensor_platformA.movement_controller.states[0].state_vector[0],
+                sensor_platformA.movement_controller.states[0].state_vector[1],
+                'go',
+               label='Start Location')
+
+# Plot initial particles and store line object for setting later
+partsA, = plotterA.ax.plot(trackA[0].state_vector[0],
+                           trackA[0].state_vector[1],
+                           'g.',
+                           markersize=0.5,
+                           linewidth=0,
+                           label='Particles')
+
+# Plot scatter of detection locations, intially with large marker for the legend
+detectionsA = plotterA.ax.scatter(sensorA_x,
+                                  sensorA_y,
+                                  s=np.array([10]*len(sensorA_x)),
+                                  c='r',
+                                  linewidth=0,
+                                  label='Detections')
+
+# Plot first sensor position for constructing trajectory, storing the line object for setting later
+trajectoryA, = plotterA.ax.plot(sensor_platformA.movement_controller.states[0].state_vector[0],
+                                sensor_platformA.movement_controller.states[0].state_vector[0],
+                                'r-',
+                                label='Sensor Path')
+
+plotterA.ax.legend(loc='center left', bbox_to_anchor=(-0.5, 0.5))
+
+# Reset the marker sizes after creating legend
+detectionsA.set_sizes(np.array([0]*len(sensorA_x)))
+
+def anim_funcA(i):
+    # Update particle line object according to latest track
+    partsA.set_data(trackA[i].state_vector[0], trackA[i].state_vector[1])
+
+    states = np.array([[sensorA_x[0]], [sensorA_y[0]], [0]])
+    detection_marker_sizes = np.zeros(len(trackA))
+    for n in range(i):
+        # Collect states upto timestep i
+        states = np.append(states, np.array([[sensorA_x[n+1]], [sensorA_y[n+1]], [0]]), axis=1)
+
+        # Collect detections upto timestep i
+        if hasattr(trackA[n+1], 'hypothesis'):
+            detection_marker_sizes[n+1] = (
+                    trackA[n+1].hypothesis.measurement.state_vector[0][0]*3000)
+
+    # Update trajectory data and detection scatter marker sizes
+    trajectoryA.set_data(states[0], states[1])
+    detectionsA.set_sizes(detection_marker_sizes)
+
+animation.FuncAnimation(plotterA.fig, anim_funcA, interval=100, frames=len(trackA))
+
+# %%
+# Run the MCTS sensor manager
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+# 
+# The MCTS sensor manager and associated filters are run in the same
+# way as regular sensor manager in Stone Soup. Again, the process is
+# limited to 100 iterations or meeting a stopping criteria, whichever
+# comes first.
+
+n_iter = 100
+stopping_criteria = 3
+
+trackB = Track(priorB)
+sensorB_x = [sensor_platformB.position[0]]
+sensorB_y = [sensor_platformB.position[1]]
+for n in range(n_iter):
+    time = (start_time + timedelta(seconds=n+1))
+    if n > 0:
+        chosen_actions = sensormanagerB.choose_actions({trackB}, time, n_steps=2, step_size=2,
+                                                      action_mapping=(0, 1))
+        for sensor, actions in chosen_actions[0].items():
+            sensor.add_actions(actions)
+            sensor.act(time)
+    
+    prediction = predictor.predict(priorB, timestamp=time)
+    theta.timestamp=time
+    detection = (gas_sensorB.measure({theta}, noise=True).pop())
+    hypothesis = SingleHypothesis(prediction, detection)
+    update = updater.update(hypothesis)
+    trackB.append(update)
+    priorB = trackB[-1]
+    sensorB_x.append(sensor_platformB.position[0])
+    sensorB_y.append(sensor_platformB.position[1])
+
+    if np.sqrt(np.trace(trackB.state.covar)) < stopping_criteria:
+        print('Converged in {} iterations'.format(n))
+        break
+
+
+# %%
+# Plot the MCTS result
+# ^^^^^^^^^^^^^^^^^^^^
+# 
+# The same animation is generated for the MCTS algorithm. Notice
+# that the algorithm converged before reaching the iteration limit
+# suggesting that it converged faster than the myopic approach in
+# this case.
+
+
+# Plot ground truth plume
+plotterB = Plotter()
+plotterB.ax.set_xlim(left=0, right=50)
+plotterB.ax.set_ylim(bottom=0, top=50)
+plotterB.ax.set_box_aspect(1)
+gas_distributionB = plotterB.ax.pcolor(pos_x, pos_y, intensity.T)
+plotterB.fig.colorbar(gas_distributionB, label='Concentration')
+plotterB.ax.set_title('MCTS KLD Sensor Management Result')
+
+# Plot platform start location
+plotterB.ax.plot(sensor_platformB.movement_controller.states[0].state_vector[0],
+                sensor_platformB.movement_controller.states[0].state_vector[1],
+                'go',
+               label='Start Location')
+
+# Plot initial particles and store line object for setting later
+partsB, = plotterB.ax.plot(trackB[0].state_vector[0],
+                           trackB[0].state_vector[1],
+                           'g.',
+                           markersize=0.5,
+                           linewidth=0,
+                           label='Particles')
+
+# Plot scatter of detection locations, intially with large marker for the legend
+detectionsB = plotterB.ax.scatter(sensorB_x,
+                                  sensorB_y,
+                                  s=np.array([10]*len(sensorB_x)),
+                                  c='r',
+                                  linewidth=0,
+                                  label='Detections')
+
+# Plot first sensor position for constructing trajectory, storing the line object for setting later
+trajectoryB, = plotterB.ax.plot(sensor_platformB.movement_controller.states[0].state_vector[0],
+                                sensor_platformB.movement_controller.states[0].state_vector[0],
+                                'r-',
+                                label='Sensor Path')
+
+plotterB.ax.legend(loc='center left', bbox_to_anchor=(-0.5, 0.5))
+
+# Reset the marker sizes after creating legend
+detectionsB.set_sizes(np.array([0]*len(sensorB_x)))
+
+def anim_funcB(i):
+    # Update particle line object according to latest track
+    partsB.set_data(trackB[i].state_vector[0], trackB[i].state_vector[1])
+
+    states = np.array([[sensorB_x[0]], [sensorB_y[0]], [0]])
+    detection_marker_sizes = np.zeros(len(trackB))
+    for n in range(i):
+        # Collect states upto timestep i
+        states = np.append(states, np.array([[sensorB_x[n+1]], [sensorB_y[n+1]], [0]]), axis=1)
+
+        # Collect detections upto timestep i
+        if hasattr(trackB[n+1], 'hypothesis'):
+            detection_marker_sizes[n+1] = (
+                    trackB[n+1].hypothesis.measurement.state_vector[0][0]*3000)
+
+    # Update trajectory data and detection scatter marker sizes
+    trajectoryB.set_data(states[0], states[1])
+    detectionsB.set_sizes(detection_marker_sizes)
+
+animation.FuncAnimation(plotterB.fig, anim_funcB, interval=250, frames=len(trackB))
+
+# sphinx_gallery_thumbnail_number = 3
+
+# %%
+# Comparing the performance of both approaches here, it is clear that
+# the MCTS algorithm was able to converge to a better source term
+# estimate and did so in less iterations than the myopic benchmark. Considering
+# non-myopic actions in this scenario allows for more robust handling of
+# unreliable measurements, a common problem is STE that is caused by low
+# quality sensors or turbulent environment conditions.
+
+# %%
+# References
+# ----------
+#
+# .. [#] Kochenderfer, Mykel J. & Wheeler, Tim A. & Wray, Kyle H. "Algorithms for
+#        decision making", MIT Press, 2022 (https://algorithmsbook.com/)
+# .. [#] Glover, Timothy & Nanavati, Rohit V. & Coombes, Matthew & Liu, Cunjia &
+#        Chen, Wen-Hua & Perree, Nicola & Hiscocks, Steven. "A Monte Carlo Tree Search
+#        Framework for Autonomous Source Term Estimation in Stone Soup, 2024 27th
+#        International Conference on Information Fusion (FUSION), 1-8, 2024. Accepted,
+#        awaiting publication
+#

--- a/docs/source/stonesoup.sensormanager.rst
+++ b/docs/source/stonesoup.sensormanager.rst
@@ -12,6 +12,14 @@ Sensor Managers
     :inherited-members:
 
 
+Tree Search Managers
+--------------------
+
+.. automodule:: stonesoup.sensormanager.tree_search
+    :show-inheritance:
+    :inherited-members:
+
+
 Reward Functions
 ----------------
 .. automodule:: stonesoup.sensormanager.reward

--- a/stonesoup/models/measurement/gas.py
+++ b/stonesoup/models/measurement/gas.py
@@ -1,7 +1,7 @@
 from typing import Sequence, Union
 
-from math import sqrt
 import numpy as np
+from scipy.stats import norm
 from scipy.special import erf
 
 from ...base import Property
@@ -199,7 +199,7 @@ class IsotropicPlume(GaussianModel, MeasurementModel):
         pred_meas = self.function(state2, **kwargs)
         if state1.state_vector[0] <= self.sensing_threshold:
             pdf = p_m + ((1-p_m) * 1/2 * (1+erf((self.sensing_threshold - pred_meas)
-                                                / (nd_sigma * sqrt(2)))))
+                                                / (nd_sigma * np.sqrt(2)))))
             likelihood = np.atleast_1d(np.log(pdf)).view(np.ndarray)
 
         else:
@@ -291,10 +291,10 @@ class IsotropicPlume(GaussianModel, MeasurementModel):
 
         random_state = random_state if random_state is not None else self.random_state
 
-        generator = np.random.RandomState(random_state)
-        noise = generator.normal(np.zeros(self.ndim_meas),
-                                 np.ravel(state*self.standard_deviation_percentage),
-                                 num_samples)
+        noise = norm.rvs(loc=np.zeros(self.ndim_meas),
+                         scale=np.ravel(state*self.standard_deviation_percentage),
+                         size=num_samples,
+                         random_state=random_state)
 
         noise = np.atleast_2d(noise)
 

--- a/stonesoup/sensormanager/reward.py
+++ b/stonesoup/sensormanager/reward.py
@@ -233,9 +233,8 @@ class ExpectedKLDivergence(RewardFunction):
         # Create dictionary of predictions for the tracks in the configuration
         predicted_tracks = set()
         for track in tracks:
-            predicted_track = Track()
+            predicted_track = copy.copy(track)
             if self.predictor:
-                predicted_track = copy.copy(track)
                 predicted_track.append(self.predictor.predict(track[-1],
                                                               timestamp=metric_time))
             else:

--- a/stonesoup/sensormanager/reward.py
+++ b/stonesoup/sensormanager/reward.py
@@ -207,6 +207,10 @@ class ExpectedKLDivergence(RewardFunction):
         : float
             Kullback-Leibler divergence for given configuration
 
+        : Set[Track] (if defined)
+            Set of tracks that have been predicted and updated in reward
+            calculation if :attr:`return_tracks` is `True`
+
         """
 
         # Reward value

--- a/stonesoup/sensormanager/reward.py
+++ b/stonesoup/sensormanager/reward.py
@@ -278,7 +278,6 @@ class ExpectedKLDivergence(RewardFunction):
     def _generate_detections(self, predicted_tracks, sensors, timestamp=None):
 
         all_detections = {}
-        detection_set = set()
 
         for sensor in sensors:
             detections = {}
@@ -286,16 +285,16 @@ class ExpectedKLDivergence(RewardFunction):
                 tmp_detection = sensor.measure({State(predicted_track.mean,
                                                       timestamp=predicted_track.timestamp)},
                                                noise=True)
-                detection_set |= tmp_detection
-                if self.data_associator:
-                    tmp_hypotheses = self.data_associator.associate(predicted_tracks,
-                                                                    tmp_detection,
-                                                                    timestamp)
-                    detections.update({predicted_track: {hypothesis.measurement}
-                                      for predicted_track, hypothesis in tmp_hypotheses.items() if
-                                      hypothesis})
-                else:
-                    detections.update({predicted_track: tmp_detection})
+                detections.update({predicted_track: tmp_detection})
+
+            if self.data_associator:
+                tmp_hypotheses = self.data_associator.associate(
+                    predicted_tracks,
+                    {det for dets in detections.values() for det in dets},
+                    timestamp)
+                detections = {predicted_track: {hypothesis.measurement}
+                              for predicted_track, hypothesis in tmp_hypotheses.items()
+                              if hypothesis}
 
             all_detections.update({sensor: detections})
 

--- a/stonesoup/sensormanager/tests/test_sensormanager.py
+++ b/stonesoup/sensormanager/tests/test_sensormanager.py
@@ -14,7 +14,7 @@ from ...sensor.radar import RadarRotatingBearingRange
 from ...sensor.action.dwell_action import ChangeDwellAction
 from ...sensormanager import RandomSensorManager, BruteForceSensorManager, GreedySensorManager
 from stonesoup.sensormanager.tree_search import (MonteCarloTreeSearchSensorManager,
-                                                 MCTSRolloutSensorManager)
+                                                 MCTSRolloutSensorManager, MCTSBestChildPolicyEnum)
 from ...sensormanager.reward import UncertaintyRewardFunction, ExpectedKLDivergence, \
     MultiUpdateExpectedKLDivergence
 from ...sensormanager.action import Actionable
@@ -590,7 +590,7 @@ def test_sensor_manager_with_platform(params):
                 cov=np.diag([1.5, 0.25, 1.5, 0.25]),
                 size=100).T),
                           weight=np.array([1/100]*100)),  # track2_state2
-            0,  # best_child_policy
+            'max_cumulative_reward',  # best_child_policy
         ), (
             ParticlePredictor,  # predictor_obj
             ParticleUpdater,  # updater_obj
@@ -617,7 +617,7 @@ def test_sensor_manager_with_platform(params):
                 cov=np.diag([1.5, 0.25, 1.5, 0.25]),
                 size=100).T),
                           weight=np.array([1/100]*100)),  # track2_state2
-            0,  # best_child_policy
+            'max_cumulative_reward',  # best_child_policy
         ), (
             KalmanPredictor,  # predictor_obj
             ExtendedKalmanUpdater,  # updater_obj
@@ -636,7 +636,7 @@ def test_sensor_manager_with_platform(params):
             GaussianState([[2], [1.5], [2], [1.5]],
                           np.diag([1.5, 0.25, 1.5, 0.25]
                                   + np.random.normal(0, 5e-4, 4))),  # track2_state2
-            0,  # best_child_policy
+            'max_cumulative_reward',  # best_child_policy
         ), (
             KalmanPredictor,  # predictor_obj
             ExtendedKalmanUpdater,  # updater_obj
@@ -655,7 +655,7 @@ def test_sensor_manager_with_platform(params):
             GaussianState([[2], [1.5], [2], [1.5]],
                           np.diag([1.5, 0.25, 1.5, 0.25]
                                   + np.random.normal(0, 5e-4, 4))),  # track2_state2
-            1,  # best_child_policy
+            'max_average_reward',  # best_child_policy
         ), (
             KalmanPredictor,  # predictor_obj
             ExtendedKalmanUpdater,  # updater_obj
@@ -674,7 +674,7 @@ def test_sensor_manager_with_platform(params):
             GaussianState([[2], [1.5], [2], [1.5]],
                           np.diag([1.5, 0.25, 1.5, 0.25]
                                   + np.random.normal(0, 5e-4, 4))),  # track2_state2
-            2,  # best_child_policy
+            'max_cumulative_reward',  # best_child_policy
         ), (
             KalmanPredictor,  # predictor_obj
             ExtendedKalmanUpdater,  # updater_obj
@@ -693,12 +693,12 @@ def test_sensor_manager_with_platform(params):
             GaussianState([[2], [1.5], [2], [1.5]],
                           np.diag([1.5, 0.25, 1.5, 0.25]
                                   + np.random.normal(0, 5e-4, 4))),  # track2_state2
-            3,  # best_child_policy
+            MCTSBestChildPolicyEnum.MAXCREWARD,  # best_child_policy
         )
     ],
     ids=['KLDivergenceMCTSNoAssociation', 'KLDivergenceMCTSAssociation',
          'KLDivergenceMCTSGaussianTest', 'KLDMCTSGaussianPolicy1', 'KLDMCTSGaussianPolicy2',
-         'KLDMCTSGaussianPolicyError']
+         'KLDMCTSGaussianEnum']
 )
 def test_mcts_sensor_managers(predictor_obj, updater_obj, hypothesiser_obj, associator_obj,
                               reward_function_obj, track1_state1, track1_state2, track2_state1,
@@ -783,12 +783,12 @@ def test_mcts_sensor_managers(predictor_obj, updater_obj, hypothesiser_obj, asso
     for sensor_manager in sensor_managers:
         dwell_centres_over_time = []
         for time in timesteps:
-            if best_child_policy == 3:
-                with pytest.raises(NotImplementedError) as e:
-                    chosen_action_configs = sensor_manager.choose_actions(tracks, time)
-                assert 'Selected best child policy is not a valid option' in \
-                    str(e.value)
-                return
+            # if best_child_policy == 3:
+            #     with pytest.raises(NotImplementedError) as e:
+            #         chosen_action_configs = sensor_manager.choose_actions(tracks, time)
+            #     assert 'Selected best child policy is not a valid option' in \
+            #         str(e.value)
+            #     return
 
             chosen_action_configs = sensor_manager.choose_actions(tracks, time)
 

--- a/stonesoup/sensormanager/tests/test_sensormanager.py
+++ b/stonesoup/sensormanager/tests/test_sensormanager.py
@@ -617,7 +617,7 @@ def test_sensor_manager_with_platform(params):
                 cov=np.diag([1.5, 0.25, 1.5, 0.25]),
                 size=100).T),
                           weight=np.array([1/100]*100)),  # track2_state2
-            'max_cumulative_reward',  # best_child_policy
+            'max_visits',  # best_child_policy
         ), (
             KalmanPredictor,  # predictor_obj
             ExtendedKalmanUpdater,  # updater_obj

--- a/stonesoup/sensormanager/tree_search.py
+++ b/stonesoup/sensormanager/tree_search.py
@@ -160,7 +160,7 @@ class MonteCarloTreeSearchSensorManager(SensorManager):
                 nodes[node_indx]['configs'] = configs
 
             # select one of the unsimulated configs
-            config_indx = random.randint(0, len(nodes[node_indx]['configs'])-1)
+            config_indx = np.random.randint(0, len(nodes[node_indx]['configs']))
             nodes[node_indx]['Child_IDs'].append(len(nodes))
             selected_branch.insert(0, len(nodes))
             nodes.append({'Child_IDs': [],

--- a/stonesoup/sensormanager/tree_search.py
+++ b/stonesoup/sensormanager/tree_search.py
@@ -11,10 +11,10 @@ from ..types.track import Track
 
 
 class MonteCarloTreeSearchSensorManager(SensorManager):
-    r"""A Monte Carlo Tree Search based sensor management algorithm implementing
-    a simple value estimation.
+    r"""A Monte Carlo tree search based sensor management algorithm implementing
+    simple value estimation.
 
-    Monte Carlo Tree Search works by simultaneously constructing and evaluating a
+    Monte Carlo tree search works by simultaneously constructing and evaluating a
     search tree of states and actions through an iterative process. The process
     consists of 4 stages: Selection, Expansion, Simulation and Backpropagation.
     The purpose of the algorithm is to arrive at the optimal action policy by
@@ -23,11 +23,11 @@ class MonteCarloTreeSearchSensorManager(SensorManager):
 
     Starting from the root node (current state or estimated state) the best child
     node is selected. The most common way, and the way implemented here, is to
-    select this node is according to the upper confidence bound (UCB) for trees.
+    select this node according to the upper confidence bound (UCB) for trees.
     This is given by
 
     .. math::
-        \text{argmath}_{a} \frac{Q(h, a)}{N(h, a)}+c\sqrt{\frac{\log N(h)}{N(h,a)}},
+        \text{argmax}_{a} \frac{Q(h, a)}{N(h, a)}+c\sqrt{\frac{\log N(h)}{N(h,a)}},
 
     where :math:`a` is the action, :math:`h` is the history (for POMDP problems a
     history or belief is commonly used but in MDP problems h would be replaced
@@ -35,9 +35,10 @@ class MonteCarloTreeSearchSensorManager(SensorManager):
     :math:`N(h, a)` is the number of visits or simulations of this node, :math:`N(h)`
     is the number of visits to the parent node and :math:`c` is the exploration factor,
     defined with :attr:`exploration_factor`. The purpose of the UCB is to trade off
-    between exploitation of the most rewarding nodes in the tree and those that have
-    been visited fewer times, as the second term in the above expression will
-    accumulate as the ratio of number of parent visits and child visits increases.
+    between exploitation of the most rewarding nodes in the tree and exploration of
+    those that have been visited fewer times, as the second term in the above
+    expression will accumulate as the ratio of number of parent visits and child
+    visits increases.
 
     Once the best child node has been selected, this becomes a parent node and a
     new child node added according to the available set of unvisited actions. This
@@ -54,15 +55,17 @@ class MonteCarloTreeSearchSensorManager(SensorManager):
     is the :attr:`niterations` attribute, the best child to the root node in the tree
     is determined and returned from the :meth:`choose_actions`. The user can select which
     criteria used to select this best action by defining the :attr:`best_child_policy`.
-    Further detail on this particular implementation can be seen in work by Glover
-    et al [1]_. Further detail on MCTS and its variations can also be seen in [2]_.
+    Further detail on this particular implementation, including the rollout process in
+    :class:`~.MCTSRolloutSensorManager` can be seen in work by Glover et al [1]_.
+    Further detail on MCTS and its variations can also be seen in [2]_.
 
     References
     ----------
     .. [1] Glover, Timothy & Nanavati, Rohit V. & Coombes, Matthew & Liu, Cunjia &
            Chen, Wen-Hua & Perree, Nicola & Hiscocks, Steven. "A Monte Carlo Tree Search
            Framework for Autonomous Source Term Estimation in Stone Soup, 2024 27th
-           International Conference on Information Fusion (FUSION), 1-8, 2024"
+           International Conference on Information Fusion (FUSION), 1-8, 2024. Accepted,
+           awaiting publication"
     .. [2] Kochenderfer, Mykel J. & Wheeler, Tim A. & Wray, Kyle H. "Algorithms for
            decision making", MIT Press, 2022 (https://algorithmsbook.com/)
     """

--- a/stonesoup/sensormanager/tree_search.py
+++ b/stonesoup/sensormanager/tree_search.py
@@ -1,0 +1,247 @@
+from typing import Callable
+import random
+import numpy as np
+import itertools as it
+from datetime import timedelta
+import copy
+
+from ..base import Property
+from .base import SensorManager
+from ..types.track import Track
+
+
+class MonteCarloTreeSearchSensorManager(SensorManager):
+    r"""A Monte Carlo Tree Search bases sensor management algorithm implementing
+    a simple value estimation."""
+
+    reward_function: Callable = Property(
+        default=None, doc="A function or class designed to work out the reward associated with an "
+                          "action or set of actions. This will be implemented to evaluate each "
+                          "action within the rollout with the discounted sum being stored at "
+                          "the node representing the first action.")
+
+    niterations: int = Property(
+        default=100, doc="The number of iterations of the tree search process to be carried out.")
+
+    time_step: timedelta = Property(
+        default=timedelta(seconds=1), doc="The sample time between steps in the horizon.")
+
+    exploration_factor: float = Property(
+        default=1.0, doc="The exploration factor used in the upper confidence bound for trees.")
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def choose_actions(self, tracks, timestamp, nchoose=1, **kwargs):
+        """Returns a list of actions that reflect the most visited child nodes to the
+        root node in the tree. randomly chosen [list of] action(s) from the action
+        set for each sensor.
+
+        Parameters
+        ----------
+        tracks: set of :class:`~Track`
+            Set of tracks at given time. Used in reward function.
+        timestamp: :class:`datetime.datetime`
+            Time at which the actions are carried out until
+        nchoose : int
+            Number of actions from the set to choose (default is 1)
+
+        Returns
+        -------
+        : dict
+            The pairs of :class:`~.Sensor`: [:class:`~.Action`] selected
+        """
+
+        nodes = [{'Child_IDs': [],
+                  'sensors': self.sensors,
+                  'config': dict(),  # the config that has resulted in this node
+                  'configs': [],  # the configs that have not been simulated
+                  'action_count': 0,
+                  'visits': 0,
+                  'reward': 0,
+                  'tracks': {Track([track.state]) for track in tracks},
+                  'timestamp': timestamp,
+                  'level': 0}]
+
+        loop_count = 0
+        while loop_count <= self.niterations:
+            loop_count += 1
+            # select best child node
+            node_indx = 0
+            selected_branch = [0]
+            while (len(nodes[node_indx]['Child_IDs']) > 0 and
+                   len(nodes[node_indx]['Child_IDs']) == nodes[node_indx]['action_count']):
+                node_indx = self.tree_policy(nodes, node_indx)
+                selected_branch.insert(0, node_indx)
+
+            next_timestamp = nodes[node_indx]['timestamp'] + self.time_step
+            if not nodes[node_indx]['Child_IDs']:
+                action_count = 0
+                all_action_choices = dict()
+
+                for sensor in nodes[node_indx]['sensors']:
+                    # get action 'generator(s)'
+                    action_generators = sensor.actions(next_timestamp)
+                    # list possible action combinations for the sensor
+                    action_choices = list(it.product(*action_generators))
+                    if not len(action_choices) == 1 and not len(action_choices[0]) == 0:
+                        action_count += len(action_choices)
+                    # dictionary of sensors: list(action combinations)
+                    all_action_choices[sensor] = action_choices
+
+                nodes[node_indx]['action_count'] = action_count
+                configs = [{sensor: action
+                            for sensor, action in zip(all_action_choices.keys(), actionconfig)}
+                           for actionconfig in it.product(*all_action_choices.values())]
+
+                nodes[node_indx]['configs'] = configs
+
+            # select one of the unsimulated configs
+            config_indx = random.randint(0, len(nodes[node_indx]['configs'])-1)
+            nodes[node_indx]['Child_IDs'].append(len(nodes))
+            selected_branch.insert(0, len(nodes))
+            nodes.append({'Child_IDs': [],
+                          'sensors': set(),
+                          'config': nodes[node_indx]['configs'][config_indx],
+                          'configs': [],
+                          'action_count': 0,
+                          'visits': 0,
+                          'reward': 0,
+                          'timestamp': next_timestamp,
+                          'tracks': set(),
+                          'level': 0})
+
+            selected_config = copy.deepcopy(nodes[node_indx]['configs'].pop(config_indx))
+
+            reward, updates = self.simulate_action(nodes[-1], nodes[node_indx])
+
+            for n, track in enumerate(nodes[node_indx]['tracks']):
+                for update in updates[n]:
+                    nodes[-1]['tracks'].add(Track([update]))
+
+            for sensor, actions in selected_config.items():
+                sensor.add_actions(actions)
+                sensor.act(nodes[-1]['timestamp'])
+                nodes[-1]['sensors'].add(sensor)
+
+            for node_id in selected_branch:
+                nodes[node_id]['visits'] += 1
+                nodes[node_id]['reward'] += reward
+
+        best_children = self.select_best_child(nodes)
+        selected_configs = []
+        for best_child in best_children:
+            selected_configs.append(nodes[best_child]['config'])
+
+        return selected_configs
+
+    def tree_policy(self, nodes, node_indx):
+        """Implements the upper confidence bound for trees, which balances exploitation
+        of highly rewarding actiond and exploring actions that have been visited a fewer times"""
+
+        uct = []
+        for Child_ID in nodes[node_indx]['Child_IDs']:
+            uct.append(nodes[Child_ID]['reward']/nodes[Child_ID]['visits'] +
+                       self.exploration_factor*np.sqrt(np.log(nodes[node_indx]['visits'])
+                                                       /nodes[Child_ID]['visits']))
+
+        max_uct_indx = np.argmax(uct)
+        return nodes[node_indx]['Child_IDs'][max_uct_indx]
+
+    @staticmethod
+    def select_best_child(nodes):
+        """Selects the best child node to the root node in the tree according to
+        maximum number of visits."""
+
+        visit_list = []
+        for Child_ID in nodes[0]['Child_IDs']:
+            visit_list.append(nodes[Child_ID]['visits'])
+
+        max_visit_indx = np.argmax(visit_list)
+        return [nodes[0]['Child_IDs'][max_visit_indx]]
+
+    def simulate_action(self, node, parent_node):
+        """Simulates the expected reward that would be received by executing
+        the candidate action."""
+
+        reward, updates = self.reward_function(node['config'],
+                                               parent_node['tracks'],
+                                               node['timestamp'])
+
+        return reward, updates
+
+
+class MCTSRolloutSensorManager(MonteCarloTreeSearchSensorManager):
+    r"""A Monte Carlo Tree Search bases sensor management algorithm implementing
+    a Monte Carlo rollout policy for action value estimation."""
+
+    rollout_depth: int = Property(
+        default=1, doc="The depth of rollout to conduct for each node.")
+
+    discount_factor: float = Property(
+        default=0.9, doc="The discount factor is applied to each action evaluated in the "
+                         "tree to assign an incrementally lower multiplier to future actions "
+                         "in the tree.")
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def simulate_action(self, node, parent_node):
+        """Simulates the expected reward that would be received by executing
+        the candidate action."""
+
+        reward_list = []
+        # calculate reward of new node
+        reward, updates = self.reward_function(node['config'],
+                                               parent_node['tracks'],
+                                               node['timestamp'])
+        reward_list.append(reward)
+        # tmp_tracks = copy.deepcopy(parent_node['tracks'])
+        tmp_tracks = {Track([track.state]) for track in parent_node['tracks']}
+        for n, track in enumerate(tmp_tracks):
+            for update in updates[n]:
+                track.append(update)
+
+        tmp_sensors = set()
+        for sensor, actions in copy.deepcopy(node['config']).items():
+            sensor.add_actions(actions)
+            sensor.act(node['timestamp'])
+            tmp_sensors.add(sensor)
+
+        # execute Monte Carlo Rollout from the new node
+        for d in range(self.rollout_depth):
+            all_action_choices = dict()
+            timestamp = node['timestamp'] + ((d + 1) * self.time_step)
+
+            action_count = 0
+            for sensor in tmp_sensors:
+                # get action 'generator(s)'
+                action_generators = sensor.actions(timestamp)
+                # list possible action combinations for the sensor
+                action_choices = list(it.product(*action_generators))
+                if not len(action_choices) == 1 and not len(action_choices[0]) == 0:
+                    action_count += len(action_choices)
+                # dictionary of sensors: list(action combinations)
+                all_action_choices[sensor] = action_choices
+
+            configs = [{sensor: action
+                        for sensor, action in zip(all_action_choices.keys(), actionconfig)}
+                       for actionconfig in it.product(*all_action_choices.values())]
+
+            random_config_indx = random.randint(0, action_count-1)
+            random_config = configs[random_config_indx]
+
+            reward, updates_ = self.reward_function(random_config, tmp_tracks, timestamp)
+
+            reward *= self.discount_factor**(d+1)
+            reward_list.append(reward)
+            for n, track in enumerate(tmp_tracks):
+                for update in updates_[n]:
+                    track.append(update)
+
+            for sensor, actions in random_config.items():
+                sensor.add_actions(actions)
+                sensor.act(timestamp)
+
+        final_reward = sum(reward_list)
+        return final_reward, updates

--- a/stonesoup/sensormanager/tree_search.py
+++ b/stonesoup/sensormanager/tree_search.py
@@ -8,7 +8,6 @@ import numpy as np
 
 from .base import SensorManager
 from ..base import Property
-from ..types.track import Track
 
 
 class MCTSBestChildPolicyEnum(Enum):
@@ -133,7 +132,7 @@ class MonteCarloTreeSearchSensorManager(SensorManager):
                   'action_count': 0,
                   'visits': 0,
                   'reward': 0,
-                  'tracks': {copy.copy(track) for track in tracks},
+                  'tracks': copy.deepcopy(tracks),
                   'timestamp': timestamp-self.time_step,
                   'level': 0}]
 
@@ -191,8 +190,7 @@ class MonteCarloTreeSearchSensorManager(SensorManager):
 
             reward, updates = self.simulate_action(nodes[-1], nodes[node_indx])
 
-            for track in updates:
-                nodes[-1]['tracks'].add(Track(track[-1]))
+            nodes[-1]['tracks'] = updates
 
             for sensor, actions in selected_config.items():
                 sensor.add_actions(actions)

--- a/stonesoup/sensormanager/tree_search.py
+++ b/stonesoup/sensormanager/tree_search.py
@@ -120,7 +120,7 @@ class MonteCarloTreeSearchSensorManager(SensorManager):
                   'action_count': 0,
                   'visits': 0,
                   'reward': 0,
-                  'tracks': {Track([track.state]) for track in tracks},
+                  'tracks': {copy.copy(track) for track in tracks},
                   'timestamp': timestamp-self.time_step,
                   'level': 0}]
 

--- a/stonesoup/sensormanager/tree_search.py
+++ b/stonesoup/sensormanager/tree_search.py
@@ -154,11 +154,17 @@ class MonteCarloTreeSearchSensorManager(SensorManager):
         maximum number of visits."""
 
         visit_list = []
+        reward_list = []
         for Child_ID in nodes[0]['Child_IDs']:
             visit_list.append(nodes[Child_ID]['visits'])
+            reward_list.append(nodes[Child_ID]['reward'])
 
         max_visit_indx = np.argmax(visit_list)
-        return [nodes[0]['Child_IDs'][max_visit_indx]]
+        max_reward_indx = np.argmax(reward_list)
+        max_creward_indx = np.argmax(np.asarray(reward_list)/np.asarray(visit_list))
+        return [nodes[0]['Child_IDs'][max_reward_indx]]
+        # return [nodes[0]['Child_IDs'][max_creward_indx]]
+        # return [nodes[0]['Child_IDs'][max_visit_indx]]
 
     def simulate_action(self, node, parent_node):
         """Simulates the expected reward that would be received by executing

--- a/stonesoup/sensormanager/tree_search.py
+++ b/stonesoup/sensormanager/tree_search.py
@@ -1,12 +1,12 @@
-from typing import Callable
-import random
-import numpy as np
+import copy
 import itertools as it
 from datetime import timedelta
-import copy
+from typing import Callable
 
-from ..base import Property
+import numpy as np
+
 from .base import SensorManager
+from ..base import Property
 from ..types.track import Track
 
 
@@ -90,9 +90,6 @@ class MonteCarloTreeSearchSensorManager(SensorManager):
                        "child at the end of the MCTS process. The choices are 0: maximum reward, "
                        "1: maximum reward per visit or 2: maximum visit count"
     )
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
 
     def choose_actions(self, tracks, timestamp, nchoose=1, **kwargs):
         """Returns a list of actions that reflect the best child nodes to the
@@ -256,9 +253,6 @@ class MCTSRolloutSensorManager(MonteCarloTreeSearchSensorManager):
                          "tree to assign an incrementally lower multiplier to future actions "
                          "in the tree.")
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
     def simulate_action(self, node, parent_node):
         """Simulates the expected reward that would be received by executing
         the candidate action."""
@@ -288,7 +282,7 @@ class MCTSRolloutSensorManager(MonteCarloTreeSearchSensorManager):
                 action_generators = sensor.actions(timestamp)
                 # list possible action combinations for the sensor
                 action_choices = list(it.product(*action_generators))
-                if not len(action_choices) == 1 and not len(action_choices[0]) == 0:
+                if len(action_choices) != 1 and len(action_choices[0]) != 0:
                     action_count += len(action_choices)
                 # dictionary of sensors: list(action combinations)
                 all_action_choices[sensor] = action_choices
@@ -297,7 +291,7 @@ class MCTSRolloutSensorManager(MonteCarloTreeSearchSensorManager):
                         for sensor, action in zip(all_action_choices.keys(), actionconfig)}
                        for actionconfig in it.product(*all_action_choices.values())]
 
-            random_config_indx = random.randint(0, action_count-1)
+            random_config_indx = np.random.randint(0, action_count)
             random_config = configs[random_config_indx]
 
             reward, updates_ = self.reward_function(random_config, updates_, timestamp)

--- a/stonesoup/sensormanager/tree_search.py
+++ b/stonesoup/sensormanager/tree_search.py
@@ -11,8 +11,61 @@ from ..types.track import Track
 
 
 class MonteCarloTreeSearchSensorManager(SensorManager):
-    r"""A Monte Carlo Tree Search bases sensor management algorithm implementing
-    a simple value estimation."""
+    r"""A Monte Carlo Tree Search based sensor management algorithm implementing
+    a simple value estimation.
+
+    Monte Carlo Tree Search works by simultaneously constructing and evaluating a
+    search tree of states and actions through an iterative process. The process
+    consists of 4 stages: Selection, Expansion, Simulation and Backpropagation.
+    The purpose of the algorithm is to arrive at the optimal action policy by
+    sequentially estimating the action value function, :math:`Q`, and returning
+    the maximum argument to this at the end of the process.
+
+    Starting from the root node (current state or estimated state) the best child
+    node is selected. The most common way, and the way implemented here, is to
+    select this node is according to the upper confidence bound (UCB) for trees.
+    This is given by
+
+    .. math::
+        \text{argmath}_{a} \frac{Q(h, a)}{N(h, a)}+c\sqrt{\frac{\log N(h)}{N(h,a)}},
+
+    where :math:`a` is the action, :math:`h` is the history (for POMDP problems a
+    history or belief is commonly used but in MDP problems h would be replaced
+    with a state), :math:`Q(h, a)` is the current cumulative action value estimate,
+    :math:`N(h, a)` is the number of visits or simulations of this node, :math:`N(h)`
+    is the number of visits to the parent node and :math:`c` is the exploration factor,
+    defined with :attr:`exploration_factor`. The purpose of the UCB is to trade off
+    between exploitation of the most rewarding nodes in the tree and those that have
+    been visited fewer times, as the second term in the above expression will
+    accumulate as the ratio of number of parent visits and child visits increases.
+
+    Once the best child node has been selected, this becomes a parent node and a
+    new child node added according to the available set of unvisited actions. This
+    selection happens at random. This node is then simulated by predicting the
+    current state estimate in the parent node and updating this estimate with a
+    generated detection after applying the candidate action. This provides a
+    predicted future state which is used to calculate the action value of this node.
+    This is done by providing a :attr:`reward_function`. Finally, this reward is
+    added to the current action value estimated in each node on the search tree
+    branch that was descended during selection. This creates a tradeoff between future
+    and immediate rewards during the next iteration of the search process.
+
+    Once a predefined computational budget has been reached, which in this implementation
+    is the :attr:`niterations` attribute, the best child to the root node in the tree
+    is determined and returned from the :meth:`choose_actions`. The user can select which
+    criteria used to select this best action by defining the :attr:`best_child_policy`.
+    Further detail on this particular implementation can be seen in work by Glover
+    et al [1]_. Further detail on MCTS and its variations can also be seen in [2]_.
+
+    References
+    ----------
+    .. [1] Glover, Timothy & Nanavati, Rohit V. & Coombes, Matthew & Liu, Cunjia &
+           Chen, Wen-Hua & Perree, Nicola & Hiscocks, Steven. "A Monte Carlo Tree Search
+           Framework for Autonomous Source Term Estimation in Stone Soup, 2024 27th
+           International Conference on Information Fusion (FUSION), 1-8, 2024"
+    .. [2] Kochenderfer, Mykel J. & Wheeler, Tim A. & Wray, Kyle H. "Algorithms for
+           decision making", MIT Press, 2022 (https://algorithmsbook.com/)
+    """
 
     reward_function: Callable = Property(
         default=None, doc="A function or class designed to work out the reward associated with an "
@@ -29,13 +82,18 @@ class MonteCarloTreeSearchSensorManager(SensorManager):
     exploration_factor: float = Property(
         default=1.0, doc="The exploration factor used in the upper confidence bound for trees.")
 
+    best_child_policy: int = Property(
+        default=0, doc="An integer controlling which policy to use when determining the best "
+                       "child at the end of the MCTS process. The choices are 0: maximum reward, "
+                       "1: maximum reward per visit or 2: maximum visit count"
+    )
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
     def choose_actions(self, tracks, timestamp, nchoose=1, **kwargs):
-        """Returns a list of actions that reflect the most visited child nodes to the
-        root node in the tree. randomly chosen [list of] action(s) from the action
-        set for each sensor.
+        """Returns a list of actions that reflect the best child nodes to the
+        root node in the tree.
 
         Parameters
         ----------
@@ -53,14 +111,14 @@ class MonteCarloTreeSearchSensorManager(SensorManager):
         """
 
         nodes = [{'Child_IDs': [],
-                  'sensors': self.sensors,
+                  'sensors': self.actionables,
                   'config': dict(),  # the config that has resulted in this node
                   'configs': [],  # the configs that have not been simulated
                   'action_count': 0,
                   'visits': 0,
                   'reward': 0,
                   'tracks': {Track([track.state]) for track in tracks},
-                  'timestamp': timestamp,
+                  'timestamp': timestamp-self.time_step,
                   'level': 0}]
 
         loop_count = 0
@@ -69,14 +127,16 @@ class MonteCarloTreeSearchSensorManager(SensorManager):
             # select best child node
             node_indx = 0
             selected_branch = [0]
+            level = 1
             while (len(nodes[node_indx]['Child_IDs']) > 0 and
                    len(nodes[node_indx]['Child_IDs']) == nodes[node_indx]['action_count']):
                 node_indx = self.tree_policy(nodes, node_indx)
                 selected_branch.insert(0, node_indx)
+                level += 1
 
             next_timestamp = nodes[node_indx]['timestamp'] + self.time_step
             if not nodes[node_indx]['Child_IDs']:
-                action_count = 0
+                action_count = 1
                 all_action_choices = dict()
 
                 for sensor in nodes[node_indx]['sensors']:
@@ -85,7 +145,7 @@ class MonteCarloTreeSearchSensorManager(SensorManager):
                     # list possible action combinations for the sensor
                     action_choices = list(it.product(*action_generators))
                     if not len(action_choices) == 1 and not len(action_choices[0]) == 0:
-                        action_count += len(action_choices)
+                        action_count *= len(action_choices)
                     # dictionary of sensors: list(action combinations)
                     all_action_choices[sensor] = action_choices
 
@@ -109,15 +169,14 @@ class MonteCarloTreeSearchSensorManager(SensorManager):
                           'reward': 0,
                           'timestamp': next_timestamp,
                           'tracks': set(),
-                          'level': 0})
+                          'level': level})
 
             selected_config = copy.deepcopy(nodes[node_indx]['configs'].pop(config_indx))
 
             reward, updates = self.simulate_action(nodes[-1], nodes[node_indx])
 
-            for n, track in enumerate(nodes[node_indx]['tracks']):
-                for update in updates[n]:
-                    nodes[-1]['tracks'].add(Track([update]))
+            for track in updates:
+                nodes[-1]['tracks'].add(Track(track[-1]))
 
             for sensor, actions in selected_config.items():
                 sensor.add_actions(actions)
@@ -137,19 +196,18 @@ class MonteCarloTreeSearchSensorManager(SensorManager):
 
     def tree_policy(self, nodes, node_indx):
         """Implements the upper confidence bound for trees, which balances exploitation
-        of highly rewarding actiond and exploring actions that have been visited a fewer times"""
+        of highly rewarding actioned and exploring actions that have been visited a fewer times"""
 
         uct = []
         for Child_ID in nodes[node_indx]['Child_IDs']:
             uct.append(nodes[Child_ID]['reward']/nodes[Child_ID]['visits'] +
                        self.exploration_factor*np.sqrt(np.log(nodes[node_indx]['visits'])
-                                                       /nodes[Child_ID]['visits']))
+                                                       / nodes[Child_ID]['visits']))
 
         max_uct_indx = np.argmax(uct)
         return nodes[node_indx]['Child_IDs'][max_uct_indx]
 
-    @staticmethod
-    def select_best_child(nodes):
+    def select_best_child(self, nodes):
         """Selects the best child node to the root node in the tree according to
         maximum number of visits."""
 
@@ -159,12 +217,17 @@ class MonteCarloTreeSearchSensorManager(SensorManager):
             visit_list.append(nodes[Child_ID]['visits'])
             reward_list.append(nodes[Child_ID]['reward'])
 
-        max_visit_indx = np.argmax(visit_list)
-        max_reward_indx = np.argmax(reward_list)
-        max_creward_indx = np.argmax(np.asarray(reward_list)/np.asarray(visit_list))
-        return [nodes[0]['Child_IDs'][max_reward_indx]]
-        # return [nodes[0]['Child_IDs'][max_creward_indx]]
-        # return [nodes[0]['Child_IDs'][max_visit_indx]]
+        if self.best_child_policy == 0:
+            max_reward_indx = np.argmax(reward_list)
+            return [nodes[0]['Child_IDs'][max_reward_indx]]
+        elif self.best_child_policy == 1:
+            max_creward_indx = np.argmax(np.asarray(reward_list) / np.asarray(visit_list))
+            return [nodes[0]['Child_IDs'][max_creward_indx]]
+        elif self.best_child_policy == 2:
+            max_visit_indx = np.argmax(visit_list)
+            return [nodes[0]['Child_IDs'][max_visit_indx]]
+        else:
+            raise NotImplementedError('Selected best child policy is not a valid option')
 
     def simulate_action(self, node, parent_node):
         """Simulates the expected reward that would be received by executing
@@ -178,8 +241,9 @@ class MonteCarloTreeSearchSensorManager(SensorManager):
 
 
 class MCTSRolloutSensorManager(MonteCarloTreeSearchSensorManager):
-    r"""A Monte Carlo Tree Search bases sensor management algorithm implementing
-    a Monte Carlo rollout policy for action value estimation."""
+    r"""A Monte Carlo Tree Search bases sensor management algorithm that implements Monte
+    Carlo rollout for more robust action simulation. All other details are consistent
+    with :class:`~.MonteCarloTreeSearchSensorManager`"""
 
     rollout_depth: int = Property(
         default=1, doc="The depth of rollout to conduct for each node.")
@@ -202,11 +266,7 @@ class MCTSRolloutSensorManager(MonteCarloTreeSearchSensorManager):
                                                parent_node['tracks'],
                                                node['timestamp'])
         reward_list.append(reward)
-        # tmp_tracks = copy.deepcopy(parent_node['tracks'])
-        tmp_tracks = {Track([track.state]) for track in parent_node['tracks']}
-        for n, track in enumerate(tmp_tracks):
-            for update in updates[n]:
-                track.append(update)
+        updates_ = updates
 
         tmp_sensors = set()
         for sensor, actions in copy.deepcopy(node['config']).items():
@@ -237,13 +297,10 @@ class MCTSRolloutSensorManager(MonteCarloTreeSearchSensorManager):
             random_config_indx = random.randint(0, action_count-1)
             random_config = configs[random_config_indx]
 
-            reward, updates_ = self.reward_function(random_config, tmp_tracks, timestamp)
+            reward, updates_ = self.reward_function(random_config, updates_, timestamp)
 
             reward *= self.discount_factor**(d+1)
             reward_list.append(reward)
-            for n, track in enumerate(tmp_tracks):
-                for update in updates_[n]:
-                    track.append(update)
 
             for sensor, actions in random_config.items():
                 sensor.add_actions(actions)

--- a/stonesoup/sensormanager/tree_search.py
+++ b/stonesoup/sensormanager/tree_search.py
@@ -147,7 +147,7 @@ class MonteCarloTreeSearchSensorManager(SensorManager):
                     action_generators = sensor.actions(next_timestamp)
                     # list possible action combinations for the sensor
                     action_choices = list(it.product(*action_generators))
-                    if not len(action_choices) == 1 and not len(action_choices[0]) == 0:
+                    if len(action_choices) != 1 and len(action_choices[0]) != 0:
                         action_count *= len(action_choices)
                     # dictionary of sensors: list(action combinations)
                     all_action_choices[sensor] = action_choices

--- a/stonesoup/sensormanager/tree_search.py
+++ b/stonesoup/sensormanager/tree_search.py
@@ -252,7 +252,7 @@ class MonteCarloTreeSearchSensorManager(SensorManager):
 
 
 class MCTSRolloutSensorManager(MonteCarloTreeSearchSensorManager):
-    r"""A Monte Carlo Tree Search bases sensor management algorithm that implements Monte
+    r"""A Monte Carlo Tree Search based sensor management algorithm that implements Monte
     Carlo rollout for more robust action simulation. All other details are consistent
     with :class:`~.MonteCarloTreeSearchSensorManager`"""
 


### PR DESCRIPTION
This pull request introduces two new sensor management techniques to Stone Soup: `MonteCarloTreeSearchSensorManager` and `MCTSRolloutSensorManager`. These two managers are implementations of Monte Carlo tree search (MCTS) that construct a search tree based on actions and estimated future target states and estimate the action value resulting from this. Introducing these managers has also required a modification to reward functions that are to be compatible with MCTS. The `ExpectedKLDivergence` has been modified to include an extra property called `return_tracks` that allows the predicted tracks that have been used to calculate the KLD value to be returned to the invoking sensor manager so that it can be stored, in the case of MCTS, in the search tree. `ExpectedKLDivergence` is currently the only modified reward function. Another modification to `ExpectedKLDivergence` has also been introduced to allow data association to be performed when predicting tracks that have received multiple detections if sequential state updates are not the desired process. Tests for each of these new features and modifications have also been included in the PR.

Two examples have also been added to the documentation. The first covers the work done for the Loughborough University Stone Soup Kitchen for autonomous STE. This example covers particle filter setup for STE and actionable platform sensor management using `BruteForceSensorManager` and `MultiUpdateExpectedKLDivergence`. 

The second example is includes an MCTS approach to STE and compares it with a Myopic alternative. The example focusses on more on how to implement a MCTS sensor manager rather than the STE problem that is better covered by the first. 

@hpritchett-dstl @nperree-dstl @sdhiscocks 