### PR TITLE
Fix Inverse Function in CartesianToElevationBearingRangeRate

### DIFF
--- a/stonesoup/models/measurement/nonlinear.py
+++ b/stonesoup/models/measurement/nonlinear.py
@@ -942,9 +942,7 @@ class CartesianToElevationBearingRangeRate(NonLinearGaussianMeasurement, Reversi
         x, y, z = sphere2cart(rho, phi, theta)
         # because only rho_rate is known, only the components in
         # x,y and z of the range rate can be found.
-        x_rate = np.cos(theta) * np.cos(phi) * rho_rate
-        y_rate = np.cos(theta) * np.sin(phi) * rho_rate
-        z_rate = np.sin(theta) * rho_rate
+        x_rate, y_rate, z_rate = sphere2cart(rho_rate, phi, theta)
 
         inv_rotation_matrix = inv(self.rotation_matrix)
 

--- a/stonesoup/models/measurement/nonlinear.py
+++ b/stonesoup/models/measurement/nonlinear.py
@@ -942,9 +942,9 @@ class CartesianToElevationBearingRangeRate(NonLinearGaussianMeasurement, Reversi
         x, y, z = sphere2cart(rho, phi, theta)
         # because only rho_rate is known, only the components in
         # x,y and z of the range rate can be found.
-        x_rate = np.cos(phi) * np.cos(theta) * rho_rate
-        y_rate = np.cos(phi) * np.sin(theta) * rho_rate
-        z_rate = np.sin(phi) * rho_rate
+        x_rate = np.cos(theta) * np.cos(phi) * rho_rate
+        y_rate = np.cos(theta) * np.sin(phi) * rho_rate
+        z_rate = np.sin(theta) * rho_rate
 
         inv_rotation_matrix = inv(self.rotation_matrix)
 

--- a/stonesoup/models/measurement/tests/test_models.py
+++ b/stonesoup/models/measurement/tests/test_models.py
@@ -558,7 +558,7 @@ def h3d_rr(state_vector, pos_map, vel_map, translation_offset, rotation_offset, 
     "h, modelclass, state_vec, ndim_state, pos_mapping, vel_mapping,\
     noise_covar, position, orientation",
     [
-        (   # 3D meas, 6D state
+        (   # rrRB_1. 3D meas, 6D state
             h2d_rr,  # h
             CartesianToBearingRangeRate,  # ModelClass
             StateVector([[200.], [10.], [0.], [0.], [0.], [0.]]),  # state_vec
@@ -571,7 +571,7 @@ def h3d_rr(state_vector, pos_map, vel_map, translation_offset, rotation_offset, 
             StateVector([[1], [-1], [0]]),  # position (translation offset)
             StateVector([[0], [0], [1]])  # orientation (rotation offset)
         ),
-        (   # 3D meas, 6D state
+        (   # rrRB_2. 3D meas, 6D state
             h2d_rr,  # h
             CartesianToBearingRangeRate,  # ModelClass
             StateVector([[200.], [10.], [0.], [0.], [0.], [0.]]),  # state_vec
@@ -584,7 +584,7 @@ def h3d_rr(state_vector, pos_map, vel_map, translation_offset, rotation_offset, 
             None,  # position (translation offset)
             None  # orientation (rotation offset)
         ),
-        (   # 4D meas, 6D state
+        (   # rrRBE_1, 4D meas, 6D state
             h3d_rr,  # h
             CartesianToElevationBearingRangeRate,  # ModelClass
             StateVector([[200.], [10.], [0.], [0.], [0.], [0.]]),  # state_vec
@@ -598,7 +598,7 @@ def h3d_rr(state_vector, pos_map, vel_map, translation_offset, rotation_offset, 
             StateVector([[100], [0], [0]]),  # position (translation offset)
             StateVector([[0], [0], [0]])  # orientation (rotation offset)
         ),
-        (   # 4D meas, 6D state
+        (   # rrRBE_2. 4D meas, 6D state
             h3d_rr,  # h
             CartesianToElevationBearingRangeRate,  # ModelClass
             StateVector([[200.], [10.], [0.], [0.], [0.], [0.]]),  # state_vec
@@ -611,9 +611,37 @@ def h3d_rr(state_vector, pos_map, vel_map, translation_offset, rotation_offset, 
                               [0, 0, 0, 10]]),  # noise_covar
             None,  # position (translation offset)
             None  # orientation (rotation offset)
+        ),
+        (   # rrRBE_3. 4D meas, 6D state. Changed orientation compared to rrRBE_2.
+            h3d_rr,  # h
+            CartesianToElevationBearingRangeRate,  # ModelClass
+            StateVector([[200.], [10.], [0.], [0.], [0.], [0.]]),  # state_vec
+            6,  # ndim_state
+            np.array([0, 2, 4]),  # pos_mapping
+            np.array([1, 3, 5]),  # vel_mapping
+            CovarianceMatrix([[0.05, 0, 0, 0],
+                              [0, 0.05, 0, 0],
+                              [0, 0, 0.015, 0],
+                              [0, 0, 0, 10]]),  # noise_covar
+            None,  # position (translation offset)
+            StateVector([[0], [0], [np.pi / 2]])  # orientation (rotation offset)
+        ),
+        (   # rrRBE_4. 4D meas, 6D state. Range rate not alligned with any axis
+            h3d_rr,  # h
+            CartesianToElevationBearingRangeRate,  # ModelClass
+            StateVector([[300.], [30.], [200.], [20.], [10.], [1.]]),  # state_vec
+            6,  # ndim_state
+            np.array([0, 2, 4]),  # pos_mapping
+            np.array([1, 3, 5]),  # vel_mapping
+            CovarianceMatrix([[0.05, 0, 0, 0],
+                              [0, 0.05, 0, 0],
+                              [0, 0, 0.015, 0],
+                              [0, 0, 0, 10]]),  # noise_covar
+            StateVector([[0], [0], [0]]),  # position (translation offset)
+            StateVector([[0], [0], [np.pi / 2]])  # orientation (rotation offset), Facing North
         )
     ],
-    ids=["rrRB_1", "rrRB_2", "rrRBE_1", "rrRBE_2"]
+    ids=["rrRB_1", "rrRB_2", "rrRBE_1", "rrRBE_2", "rrRBE_3", "rrRBE_4"]
 )
 def test_rangeratemodels(h, modelclass, state_vec, ndim_state, pos_mapping, vel_mapping,
                          noise_covar, position, orientation):


### PR DESCRIPTION
Fix `CartesianToElevationBearingRangeRate.inverse_function`. 
Current tests didn't find the problem as the state to measure was on the x-axis (`phi == theta == 0`).
New tests have been added which will fail on the old implementation.