### PR TITLE
Added id property to Platform & property to create a GroundTruthPath from a Platform

### DIFF
--- a/stonesoup/platform/base.py
+++ b/stonesoup/platform/base.py
@@ -1,7 +1,7 @@
 import uuid
 from typing import MutableSequence
 
-from stonesoup.base import Property, Base, cached_property
+from stonesoup.base import Property, Base
 from stonesoup.movable import Movable, FixedMovable, MovingMovable, MultiTransitionMovable
 from stonesoup.sensor.sensor import Sensor
 from stonesoup.types.groundtruth import GroundTruthPath
@@ -42,7 +42,7 @@ class Platform(Base):
 
     id: str = Property(
         default=None,
-        doc="The unique path ID. Default `None` where random UUID is generated.")
+        doc="The unique platform ID. Default `None` where random UUID is generated.")
 
     _default_movable_class = None  # Will be overridden by subclasses
 
@@ -160,10 +160,24 @@ class Platform(Base):
 
     @property
     def ground_truth_path(self) -> GroundTruthPath:
-        """
-        The `states` property for the platform and `ground_truth_path` are dynamically linked
-        `self.ground_truth_path.states` == self.states`. So after `platform.move()` the
-        `ground_truth_path` will contain the new state.
+        """ Produce a :class:`.GroundTruthPath` with the same `id` and `states` as the platform.
+
+        The `states` property for the platform and `ground_truth_path` are dynamically linked:
+        >>> self.ground_truth_path.states is self.states
+        True
+
+        So after `platform.move()` the `ground_truth_path` will contain the new state. However,
+        replacing the `id`, `states` or `movement_controller` variables in either the platform or
+        ground truth path will not be reflected in the other object.
+        >>> platform_gtp = self.ground_truth_path
+        >>> platform_gtp.states = []
+        >>> self.states is not platform_gtp.states
+        True
+
+        `Platform.ground_truth_path` produces a new :class:`.GroundTruthPath` on every instance.
+        It is not an object that is updated
+        >>> self.ground_truth_path.states is not self.ground_truth_path.states
+        True
         """
         return GroundTruthPath(id=self.id, states=self.movement_controller.states)
 

--- a/stonesoup/platform/base.py
+++ b/stonesoup/platform/base.py
@@ -163,21 +163,18 @@ class Platform(Base):
         """ Produce a :class:`.GroundTruthPath` with the same `id` and `states` as the platform.
 
         The `states` property for the platform and `ground_truth_path` are dynamically linked:
-        >>> self.ground_truth_path.states is self.states
-        True
+        ``self.ground_truth_path.states is self.states``
 
         So after `platform.move()` the `ground_truth_path` will contain the new state. However,
         replacing the `id`, `states` or `movement_controller` variables in either the platform or
         ground truth path will not be reflected in the other object.
-        >>> platform_gtp = self.ground_truth_path
-        >>> platform_gtp.states = []
-        >>> self.states is not platform_gtp.states
-        True
+        ``platform_gtp = self.ground_truth_path``
+        ``platform_gtp.states = []``
+        ``self.states is not platform_gtp.states``
 
         `Platform.ground_truth_path` produces a new :class:`.GroundTruthPath` on every instance.
         It is not an object that is updated
-        >>> self.ground_truth_path.states is not self.ground_truth_path.states
-        True
+        ``self.ground_truth_path.states is not self.ground_truth_path.states``
         """
         return GroundTruthPath(id=self.id, states=self.movement_controller.states)
 

--- a/stonesoup/platform/base.py
+++ b/stonesoup/platform/base.py
@@ -1,8 +1,9 @@
 from typing import MutableSequence
 
-from stonesoup.base import Property, Base
+from stonesoup.base import Property, Base, clearable_cached_property
 from stonesoup.movable import Movable, FixedMovable, MovingMovable, MultiTransitionMovable
 from stonesoup.sensor.sensor import Sensor
+from stonesoup.types.groundtruth import GroundTruthPath
 
 
 class Platform(Base):
@@ -37,6 +38,10 @@ class Platform(Base):
     sensors: MutableSequence[Sensor] = Property(
         default=None, readonly=True,
         doc="A list of N mounted sensors. Defaults to an empty list.")
+
+    # id: str = Property(
+    #     default=None,
+    #     doc="The unique path ID. Default `None` where random UUID is generated.")
 
     _default_movable_class = None  # Will be overridden by subclasses
 
@@ -149,6 +154,18 @@ class Platform(Base):
 
     def __getitem__(self, item):
         return self.movement_controller.__getitem__(item)
+
+    @clearable_cached_property('movement_controller')
+    def ground_truth_path(self) -> GroundTruthPath:
+        return GroundTruthPath(states=self.movement_controller.states)
+
+    @property
+    def id(self):
+        return self.ground_truth_path.id
+
+    @id.setter
+    def id(self, value):
+        self.ground_truth_path.id = value
 
 
 class FixedPlatform(Platform):

--- a/stonesoup/platform/tests/test_platform_base.py
+++ b/stonesoup/platform/tests/test_platform_base.py
@@ -755,29 +755,6 @@ def test_platform_initialised_with_id():
     assert platform.id == test_id_str
 
 
-# @pytest.mark.xfail(reason="Changing the id of a platform resets the `ground_truth_path` property. "
-#                           "Changing the id of a platform does not change its ground truth path. "
-#                           "The id of the platform and ground truth path aren't dynamically linked."
-#                    )
-# def test_platform_id_matches_ground_truth():
-#
-#     fixed_state = State(np.array([[2], [2], [0]]), datetime.datetime.now())
-#     platform = FixedPlatform(states=fixed_state, position_mapping=(0, 1, 2))
-#
-#     platform_gtp_before = platform.ground_truth_path
-#     assert platform_gtp_before.id == platform.id
-#
-#     platform.id = test_id_str
-#
-#     assert platform.ground_truth_path.id == platform.id
-#
-#     # These currently fails
-#     assert platform_gtp_before.id == platform.id
-#     assert platform_gtp_before is platform.ground_truth_path
-#
-#     new_platform_gtp = platform.ground_truth_path
-
-
 def test_ground_truth_path_story():
     # Set Up
     timestamp = datetime.datetime.now()
@@ -845,5 +822,3 @@ def test_setting_movement_controller_sensors():
     platform.movement_controller = moving
 
     assert platform.movement_controller is sensor.movement_controller
-
-


### PR DESCRIPTION
Added `Platform.id` property.
Added `Platform.ground_truth_path` that creates a GroundTruthPath from the Platform.
Added tests for the new functionality.