### PR TITLE
Add Joseph form of covariance calculation to Kalman Updater

### DIFF
--- a/stonesoup/updater/kalman.py
+++ b/stonesoup/updater/kalman.py
@@ -215,8 +215,6 @@ class KalmanUpdater(Updater):
             post_cov = I_KH @ prior_covar @ I_KH.T \
                 + kalman_gain @ meas_covar @ kalman_gain.T
 
-            return post_cov.view(CovarianceMatrix), kalman_gain
-
         else:
             kalman_gain = hypothesis.measurement_prediction.cross_covar @ \
                 np.linalg.inv(hypothesis.measurement_prediction.covar)
@@ -224,7 +222,7 @@ class KalmanUpdater(Updater):
             post_cov = hypothesis.prediction.covar - kalman_gain @ \
                 hypothesis.measurement_prediction.covar @ kalman_gain.T
 
-            return post_cov.view(CovarianceMatrix), kalman_gain
+        return post_cov.view(CovarianceMatrix), kalman_gain
 
     @lru_cache()
     def predict_measurement(self, predicted_state, measurement_model=None, measurement_noise=True,

--- a/stonesoup/updater/kalman.py
+++ b/stonesoup/updater/kalman.py
@@ -70,6 +70,10 @@ class KalmanUpdater(Updater):
         default=False,
         doc="A flag to force the output covariance matrix to be symmetric by way of a simple "
             "geometric combination of the matrix and transpose. Default is False.")
+    use_joseph_cov: bool = Property(
+        default=False,
+        doc="Bool dictating the method of covariance calculation. If use_joseph_cov is True then "
+            "the Joseph form of the covariance equation is used.")
 
     def _measurement_matrix(self, predicted_state=None, measurement_model=None,
                             **kwargs):
@@ -185,13 +189,42 @@ class KalmanUpdater(Updater):
             The Kalman gain, :math:`K = P_{k|k-1} H_k^T S^{-1}`
 
         """
-        kalman_gain = hypothesis.measurement_prediction.cross_covar @ \
-            np.linalg.inv(hypothesis.measurement_prediction.covar)
+        if self.use_joseph_cov:
+            # Identity matrix
+            id_matrix = np.identity(hypothesis.prediction.ndim)
 
-        post_cov = hypothesis.prediction.covar - kalman_gain @ \
-            hypothesis.measurement_prediction.covar @ kalman_gain.T
+            # Calculate Kalman gain
+            kalman_gain = hypothesis.measurement_prediction.cross_covar @ \
+                np.linalg.inv(hypothesis.measurement_prediction.covar)
 
-        return post_cov.view(CovarianceMatrix), kalman_gain
+            measurement_model = self._check_measurement_model(
+                hypothesis.measurement.measurement_model)
+
+            # Calculate measurement matrix/jacobian matrix
+            meas_matrix = self._measurement_matrix(hypothesis.prediction,
+                                                   measurement_model)
+
+            # Calculate Prior covariance
+            prior_covar = hypothesis.prediction.covar
+
+            # Calculate measurement covariance
+            meas_covar = measurement_model.covar()
+
+            # Compute posterior covariance matrix
+            I_KH = id_matrix - kalman_gain @ meas_matrix
+            post_cov = I_KH @ prior_covar @ I_KH.T \
+                + kalman_gain @ meas_covar @ kalman_gain.T
+
+            return post_cov.view(CovarianceMatrix), kalman_gain
+
+        else:
+            kalman_gain = hypothesis.measurement_prediction.cross_covar @ \
+                np.linalg.inv(hypothesis.measurement_prediction.covar)
+
+            post_cov = hypothesis.prediction.covar - kalman_gain @ \
+                hypothesis.measurement_prediction.covar @ kalman_gain.T
+
+            return post_cov.view(CovarianceMatrix), kalman_gain
 
     @lru_cache()
     def predict_measurement(self, predicted_state, measurement_model=None, measurement_noise=True,

--- a/stonesoup/updater/recursive.py
+++ b/stonesoup/updater/recursive.py
@@ -98,8 +98,6 @@ class BayesianRecursiveUpdater(ExtendedKalmanUpdater):
             post_cov = I_KH @ prior_covar @ I_KH.T \
                 + kalman_gain @ (scale_factor * meas_covar) @ kalman_gain.T
 
-            return post_cov.view(CovarianceMatrix), kalman_gain
-
         else:
             kalman_gain = hypothesis.measurement_prediction.cross_covar @ \
                 np.linalg.inv(hypothesis.measurement_prediction.covar)
@@ -107,7 +105,7 @@ class BayesianRecursiveUpdater(ExtendedKalmanUpdater):
             post_cov = hypothesis.prediction.covar - kalman_gain @ \
                 hypothesis.measurement_prediction.covar @ kalman_gain.T
 
-            return post_cov.view(CovarianceMatrix), kalman_gain
+        return post_cov.view(CovarianceMatrix), kalman_gain
 
     def update(self, hypothesis, **kwargs):
         r"""The Kalman update method. Given a hypothesised association between

--- a/stonesoup/updater/recursive.py
+++ b/stonesoup/updater/recursive.py
@@ -19,10 +19,6 @@ class BayesianRecursiveUpdater(ExtendedKalmanUpdater):
     """
     number_steps: int = Property(doc="Number of recursive steps",
                                  default=1)
-    use_joseph_cov: bool = Property(doc="Bool dictating the method of covariance calculation. If "
-                                        "use_joseph_cov is True then the Joseph form of the "
-                                        "covariance equation is used.",
-                                    default=False)
 
     @classmethod
     def _get_meas_cov_scale_factor(cls, n=1, step_no=None):
@@ -84,14 +80,18 @@ class BayesianRecursiveUpdater(ExtendedKalmanUpdater):
             kalman_gain = hypothesis.measurement_prediction.cross_covar @ \
                 np.linalg.inv(hypothesis.measurement_prediction.covar)
 
+            measurement_model = self._check_measurement_model(
+                hypothesis.measurement.measurement_model)
+
             # Calculate measurement matrix/jacobian matrix
-            meas_matrix = self._measurement_matrix(hypothesis.prediction)
+            meas_matrix = self._measurement_matrix(hypothesis.prediction,
+                                                   measurement_model)
 
             # Calculate Prior covariance
             prior_covar = hypothesis.prediction.covar
 
             # Calculate measurement covariance
-            meas_covar = hypothesis.measurement.measurement_model.covar()
+            meas_covar = measurement_model.covar()
 
             # Compute posterior covariance matrix
             I_KH = id_matrix - kalman_gain @ meas_matrix
@@ -387,10 +387,6 @@ class VariableStepBayesianRecursiveUpdater(BayesianRecursiveUpdater):
     """
     number_steps: int = Property(doc="Number of recursive steps",
                                  default=1)
-    use_joseph_cov: bool = Property(doc="Bool dictating the method of covariance calculation. If "
-                                        "use_joseph_cov is True then the Joseph form of the "
-                                        "covariance equation is used.",
-                                    default=False)
 
     @classmethod
     def _get_meas_cov_scale_factor(cls, n=1, step_no=None):


### PR DESCRIPTION
Add the implementation of Joseph form of covariance to the Kalman Updater (as implemented in the Bayesian Recursive Updater).
Fix error arising when using Joseph form of covariance in BRUF with no measurement model.
Add tests.