### PR TITLE
Update docs link action to new name

### DIFF
--- a/.github/workflows/docs-link.yml
+++ b/.github/workflows/docs-link.yml
@@ -13,7 +13,7 @@ jobs:
     name: Run CircleCI artifacts redirector
     steps:
       - name: GitHub Action step
-        uses: larsoner/circleci-artifacts-redirector-action@v1
+        uses: scientific-python/circleci-artifacts-redirector-action@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           api-token: ${{ secrets.CIRCLECI_DOCS_LINK }}


### PR DESCRIPTION
Skip CI for now, as won't run until merged.