### PR TITLE
Fix GaussianMixtureInitiator to use a MultiMeasurementInitiator

### DIFF
--- a/stonesoup/initiator/simple.py
+++ b/stonesoup/initiator/simple.py
@@ -378,7 +378,7 @@ class GaussianMixtureInitiator(GaussianInitiator):
                         timestamp=state.timestamp,
                         tag=[])]
                 track[n] = GaussianMixtureUpdate(
-                    hypothesis=track.hypothesis,
+                    hypothesis=getattr(state, 'hypothesis', None),
                     components=mixture)
 
         return tracks

--- a/stonesoup/initiator/simple.py
+++ b/stonesoup/initiator/simple.py
@@ -369,16 +369,17 @@ class GaussianMixtureInitiator(GaussianInitiator):
         tracks = self.initiator.initiate(detections, timestamp, **kwargs)
 
         for track in tracks:
-            mixture = [
-                TaggedWeightedGaussianState(
-                    state_vector=track.state_vector,
-                    covar=track.covar,
-                    weight=Probability(1),
-                    timestamp=track.timestamp,
-                    tag=[])]
-            track[-1] = GaussianMixtureUpdate(
-                hypothesis=track.hypothesis,
-                components=mixture)
+            for n, state in enumerate(track):
+                mixture = [
+                    TaggedWeightedGaussianState(
+                        state_vector=state.state_vector,
+                        covar=state.covar,
+                        weight=Probability(1),
+                        timestamp=state.timestamp,
+                        tag=[])]
+                track[n] = GaussianMixtureUpdate(
+                    hypothesis=track.hypothesis,
+                    components=mixture)
 
         return tracks
 


### PR DESCRIPTION
This PR adds the ability to use the `MultiMeasurementInitiator` with the `GaussianMixtureInitiator`. Previously, the `GaussianMixtureInitiator` would only modify the last state of a `Track` so when a track with more than one state (from the `MultiMeasurementInitiator`) is presented, the result is a `Track` with a mixed set of states (`GaussianState` and `GaussianMixture`).