### PR TITLE
Set weakref to particle parent parent, rather than None

### DIFF
--- a/stonesoup/types/particle.py
+++ b/stonesoup/types/particle.py
@@ -1,3 +1,4 @@
+import weakref
 from typing import Sequence
 
 from ..base import Property
@@ -17,14 +18,21 @@ class Particle(Type):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        if self.parent:
-            self.parent.parent = None
+        if self.parent and self.parent.parent:
+            self.parent.parent = weakref.ref(self.parent.parent)
         if self.state_vector is not None and not isinstance(self.state_vector, StateVector):
             self.state_vector = StateVector(self.state_vector)
 
     @property
     def ndim(self):
         return self.state_vector.shape[0]
+
+    @parent.getter
+    def parent(self):
+        if isinstance(self._property_parent, weakref.ReferenceType):
+            return self._property_parent()
+        else:
+            return self._property_parent
 
 
 class MultiModelParticle(Particle):

--- a/stonesoup/types/state.py
+++ b/stonesoup/types/state.py
@@ -797,7 +797,9 @@ class MultiModelParticleState(ParticleState):
 
     def __getitem__(self, item):
         if self.parent is not None:
-            parent = self.parent[item]
+            parent = copy.copy(self.parent)
+            parent.parent = None  # Don't slice parent parent
+            parent = parent[item]
         else:
             parent = None
 
@@ -843,7 +845,9 @@ class RaoBlackwellisedParticleState(ParticleState):
 
     def __getitem__(self, item):
         if self.parent is not None:
-            parent = self.parent[item]
+            parent = copy.copy(self.parent)
+            parent.parent = None  # Don't slice parent parent
+            parent = parent[item]
         else:
             parent = None
 
@@ -898,7 +902,9 @@ class BernoulliParticleState(ParticleState):
 
     def __getitem__(self, item):
         if self.parent is not None:
-            parent = self.parent[item]
+            parent = copy.copy(self.parent)
+            parent.parent = None  # Don't slice parent parent
+            parent = parent[item]
         else:
             parent = None
 

--- a/stonesoup/types/tests/test_particle.py
+++ b/stonesoup/types/tests/test_particle.py
@@ -15,5 +15,7 @@ def test_particle():
 
     particle3 = Particle(np.array([[0]]), weight=0.1, parent=particle2)
 
+    del particle1  # Weakref in particle3.parent.parent should now be None
+
     assert particle3.parent is particle2
     assert particle3.parent.parent is None

--- a/stonesoup/types/tests/test_state.py
+++ b/stonesoup/types/tests/test_state.py
@@ -348,6 +348,24 @@ def test_particlestate_cache():
     assert np.allclose(state.covar, CovarianceMatrix([[2]]))
 
 
+@pytest.mark.parametrize(
+    'particle_class', [ParticleState, MultiModelParticleState, RaoBlackwellisedParticleState,
+                       BernoulliParticleState])
+def test_particle_parent_parent(particle_class):
+    state1 = ParticleState([[1, 2, 3]], weight=np.full((3, ), 1/3))
+    state2 = ParticleState([[2, 3, 1]], weight=np.full((3, ), 1/3), parent=state1)
+    state3 = ParticleState([[3, 1, 2]], weight=np.full((3, ), 1/3), parent=state2)
+
+    assert state2.parent is state1
+    assert state3.parent is state2
+    assert state3.parent.parent is state1
+
+    del state1  # All remaining references should be weak
+
+    assert state3.parent is state2
+    assert state3.parent.parent is None
+
+
 def test_ensemblestate():
 
     # 1D


### PR DESCRIPTION
This allows references to be kept where parent parent remains in memory elsewhere, like track history.

This covers additional cases from changes in #1023