### PR TITLE
Minor deprecation fixes

### DIFF
--- a/docs/examples/readers/Custom_Pandas_Dataloader.py
+++ b/docs/examples/readers/Custom_Pandas_Dataloader.py
@@ -42,7 +42,7 @@ from stonesoup.types.groundtruth import GroundTruthPath, GroundTruthState
 
 from typing import Sequence, Collection
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from dateutil.parser import parse
 
 
@@ -84,7 +84,8 @@ class _DataFrameReader(Reader):
             time_field_value = datetime.strptime(row[self.time_field], self.time_field_format)
         elif self.timestamp:
             fractional, timestamp = modf(float(row[self.time_field]))
-            time_field_value = datetime.utcfromtimestamp(int(timestamp))
+            time_field_value = datetime.fromtimestamp(
+                int(timestamp), timezone.utc).replace(tzinfo=None)
             time_field_value += timedelta(microseconds=fractional * 1E6)
         else:
             time_field_value = row[self.time_field]

--- a/stonesoup/measures/state.py
+++ b/stonesoup/measures/state.py
@@ -485,10 +485,10 @@ class KLDivergence(Measure):
                 inv_state2_covar = np.linalg.inv(state2.covar)
                 trace_term = np.trace(inv_state2_covar@state1.covar)
 
-                delta = state2.state_vector - state1.state_vector
-                mahalanobis_term = delta.T @ inv_state2_covar @ delta
+                delta = (state2.state_vector - state1.state_vector).ravel()
+                mahalanobis_term = np.dot(np.dot(delta, inv_state2_covar), delta)
 
-                kld = float(0.5*(log_term - n_dims + trace_term + mahalanobis_term))
+                kld = 0.5*(log_term - n_dims + trace_term + mahalanobis_term)
 
             else:
                 raise ValueError(f'The state dimensions are not compatible '

--- a/stonesoup/movable/movable.py
+++ b/stonesoup/movable/movable.py
@@ -488,8 +488,8 @@ def _get_angle(vec: StateVector, axis: np.ndarray) -> float:
     Angle : float
         Angle, in radians, between the two vectors
     """
-    vel_norm = vec / np.linalg.norm(vec)
-    axis_norm = axis / np.linalg.norm(axis)
+    vel_norm = (vec / np.linalg.norm(vec)).ravel()
+    axis_norm = (axis / np.linalg.norm(axis)).ravel()
 
     return np.arccos(np.clip(np.dot(axis_norm, vel_norm), -1.0, 1.0))
 

--- a/stonesoup/reader/aishub.py
+++ b/stonesoup/reader/aishub.py
@@ -1,5 +1,5 @@
 import json
-from datetime import datetime
+from datetime import datetime, timezone
 
 import numpy as np
 
@@ -59,8 +59,8 @@ class JSON_AISDetectionReader(DetectionReader, TextFileReader):
                 lon_value = float(record['LONGITUDE'])/600000
 
                 # extract timestamp values from JSON record
-                time_value = datetime.utcfromtimestamp(float(
-                        record['TIME']))
+                time_value = datetime.fromtimestamp(float(
+                        record['TIME']), timezone.utc).replace(tzinfo=None)
 
                 # delete lat, lon, timestamp from JSON record;
                 # the rest is metadata

--- a/stonesoup/reader/generic.py
+++ b/stonesoup/reader/generic.py
@@ -5,7 +5,7 @@ of data that is in common formats.
 """
 
 import csv
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Sequence, Collection, Mapping
 
 from math import modf
@@ -52,7 +52,8 @@ class _CSVReader(TextFileReader):
             time_field_value = datetime.strptime(row[self.time_field], self.time_field_format)
         elif self.timestamp is True:
             fractional, timestamp = modf(float(row[self.time_field]))
-            time_field_value = datetime.utcfromtimestamp(int(timestamp))
+            time_field_value = datetime.fromtimestamp(
+                int(timestamp), timezone.utc).replace(tzinfo=None)
             time_field_value += timedelta(microseconds=fractional * 1E6)
         else:
             time_field_value = parse(row[self.time_field], ignoretz=True)

--- a/stonesoup/reader/hdf5.py
+++ b/stonesoup/reader/hdf5.py
@@ -5,7 +5,7 @@ of data that is in `HDF5 <https://hdfgroup.org/>`_ format, using the `h5py
 <https://docs.h5py.org/>`_ library.
 """
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Collection, Sequence
 
 try:
@@ -122,7 +122,8 @@ class _HDF5Reader(BinaryFileReader):
         if self.time_field_format is not None:
             time_field_value = datetime.strptime(raw_time_val, self.time_field_format)
         elif self.timestamp is True:
-            time_field_value = datetime.utcfromtimestamp(raw_time_val)
+            time_field_value = datetime.fromtimestamp(
+                raw_time_val, timezone.utc).replace(tzinfo=None)
         else:
             time_field_value = parse(raw_time_val, ignoretz=True)
 

--- a/stonesoup/reader/kafka.py
+++ b/stonesoup/reader/kafka.py
@@ -1,6 +1,6 @@
 import json
 import sys
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from math import modf
 from queue import Empty, Queue
 from threading import Thread
@@ -83,7 +83,8 @@ class _KafkaReader(Reader):
             )
         elif self.timestamp is True:
             fractional, timestamp = modf(float(data[self.time_field]))
-            time_field_value = datetime.utcfromtimestamp(int(timestamp))
+            time_field_value = datetime.fromtimestamp(
+                int(timestamp), timezone.utc).replace(tzinfo=None)
             time_field_value += timedelta(microseconds=fractional * 1e6)
         else:
             time_field_value = parse(data[self.time_field], ignoretz=True)

--- a/stonesoup/reader/opensky.py
+++ b/stonesoup/reader/opensky.py
@@ -105,7 +105,8 @@ class _OpenSkyNetworkReader(Reader):
                     data['time'], datetime.timezone.utc).replace(tzinfo=None)
                 yield time, states_and_metadata
 
-                while time + self.timestep > datetime.datetime.utcnow():
+                while time + self.timestep > datetime.datetime.now(
+                        datetime.timezone.utc).replace(tzinfo=None):
                     sleep(0.1)
 
 

--- a/stonesoup/reader/opensky.py
+++ b/stonesoup/reader/opensky.py
@@ -83,7 +83,8 @@ class _OpenSkyNetworkReader(Reader):
                     # Must have position (lon, lat, geo-alt)
                     if not all(state[index] for index in (5, 6, 13)):
                         continue
-                    timestamp = datetime.datetime.utcfromtimestamp(state[3])
+                    timestamp = datetime.datetime.fromtimestamp(
+                        state[3], datetime.timezone.utc).replace(tzinfo=None)
                     # Skip old detections
                     if time is not None and timestamp <= time:
                         continue
@@ -100,7 +101,8 @@ class _OpenSkyNetworkReader(Reader):
                             'source': self.sources[state[16]],
                         }
                     ))
-                time = datetime.datetime.utcfromtimestamp(data['time'])
+                time = datetime.datetime.fromtimestamp(
+                    data['time'], datetime.timezone.utc).replace(tzinfo=None)
                 yield time, states_and_metadata
 
                 while time + self.timestep > datetime.datetime.utcnow():

--- a/stonesoup/reader/pandas_reader.py
+++ b/stonesoup/reader/pandas_reader.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from dateutil.parser import parse
 from math import modf
 from typing import Sequence, Collection
@@ -47,7 +47,8 @@ class _DataFrameReader(Reader):
             time_field_value = datetime.strptime(row[self.time_field], self.time_field_format)
         elif self.timestamp:
             fractional, timestamp = modf(float(row[self.time_field]))
-            time_field_value = datetime.utcfromtimestamp(int(timestamp))
+            time_field_value = datetime.fromtimestamp(
+                int(timestamp), timezone.utc).replace(tzinfo=None)
             time_field_value += timedelta(microseconds=fractional * 1E6)
         else:
             time_field_value = row[self.time_field]

--- a/stonesoup/tests/test_stitcher.py
+++ b/stonesoup/tests/test_stitcher.py
@@ -64,8 +64,8 @@ def params():
                     np.random.uniform(-2, 2, 1)]*n_spacial_dimensions
 
     for i in range(number_of_targets):
-        number_of_segments = int(np.random.choice(range(1, max_segments), 1))
-        truthlet0_length = np.random.choice(range(max_track_start), 1)
+        number_of_segments = np.random.choice(range(1, max_segments))
+        truthlet0_length = np.random.choice(range(max_track_start))
         truthlet_lengths = np.random.choice(range(min_segment_length, max_segment_length),
                                             number_of_segments)
         disjoint_lengths = np.random.choice(range(min_disjoint_length, max_disjoint_length),

--- a/stonesoup/types/array.py
+++ b/stonesoup/types/array.py
@@ -14,8 +14,8 @@ class Matrix(np.ndarray):
         array = np.asarray(*args, **kwargs)
         return array.view(cls)
 
-    def __array_wrap__(self, array):
-        return self._cast(array)
+    def __array_wrap__(self, array, context=None, return_scalar=False):
+        return array[()] if return_scalar else self._cast(array)
 
     @classmethod
     def _cast(cls, val):


### PR DESCRIPTION
 - [Fix deprecated array wrap method without context/return_scalar](https://github.com/dstl/Stone-Soup/commit/84fb7ad645b8aa62273d3593d36b6bbffcc2ea40)
 - [Fix deprecated utcfromtimestamp](https://github.com/dstl/Stone-Soup/commit/f5045a1f2369bfe3c24083512410f17f31dfe873)
 - [Fix deprecation warnings for ndim > 0 arrays becoming scalar](https://github.com/dstl/Stone-Soup/commit/608446f1516caf4013ba487bb9c65e54bcda4474)
 - [Fix deprecated utcnow](https://github.com/dstl/Stone-Soup/pull/1045/commits/c6503fef0258e4d135983e08dafc7ef4de6ebe50)