### PR TITLE
Update UncertaintyRewardFunction to return tracks and minor modifications

### DIFF
--- a/docs/examples/sensormanagement/Monte_Carlo_Tree_Search_for_Autonomous_Source_Term_Estimation.py
+++ b/docs/examples/sensormanagement/Monte_Carlo_Tree_Search_for_Autonomous_Source_Term_Estimation.py
@@ -73,7 +73,6 @@ Monte Carlo Tree Search for Autonomous Source Term Estimation
 # General imports and environment setup
 import numpy as np
 from datetime import datetime, timedelta
-import random
 
 np.random.seed(1991)
 
@@ -253,13 +252,15 @@ from stonesoup.sensormanager.tree_search import MCTSRolloutSensorManager
 reward_updater = ParticleUpdater(measurement_model=None)
 
 # Myopic benchmark approach
-reward_funcA = ExpectedKLDivergence(updater=reward_updater)
+reward_funcA = ExpectedKLDivergence(updater=reward_updater, measurement_noise=True)
 sensormanagerA = BruteForceSensorManager(sensors={gas_sensorA}, 
                                          platforms={sensor_platformA}, 
                                          reward_function=reward_funcA)
 
 # MCTS with rollout approach
-reward_funcB = ExpectedKLDivergence(updater=reward_updater, return_tracks=True)
+reward_funcB = ExpectedKLDivergence(updater=reward_updater,
+                                    measurement_noise=True,
+                                    return_tracks=True)
 sensormanagerB = MCTSRolloutSensorManager(sensors={gas_sensorB}, 
                                           platforms={sensor_platformB}, 
                                           reward_function=reward_funcB, 

--- a/stonesoup/sensormanager/tests/test_sensormanager.py
+++ b/stonesoup/sensormanager/tests/test_sensormanager.py
@@ -694,11 +694,38 @@ def test_sensor_manager_with_platform(params):
                           np.diag([1.5, 0.25, 1.5, 0.25]
                                   + np.random.normal(0, 5e-4, 4))),  # track2_state2
             MCTSBestChildPolicyEnum.MAXCREWARD,  # best_child_policy
+        ), (
+            ParticlePredictor,  # predictor_obj
+            ParticleUpdater,  # updater_obj
+            None,  # hypothesiser
+            None,  # associator
+            UncertaintyRewardFunction,  # reward_function_obj
+            ParticleState(state_vector=StateVectors(np.random.multivariate_normal(
+                mean=np.array([1, 1, 1, 1]),
+                cov=np.diag([1.5, 0.25, 1.5, 0.25]),
+                size=100).T),
+                          weight=np.array([1/100]*100)),  # track1_state1
+            ParticleState(state_vector=StateVectors(np.random.multivariate_normal(
+                mean=np.array([2, 1.5, 2, 1.5]),
+                cov=np.diag([3, 0.5, 3, 0.5]),
+                size=100).T),
+                          weight=np.array([1/100]*100)),  # track1_state2
+            ParticleState(state_vector=StateVectors(np.random.multivariate_normal(
+                mean=np.array([-1, 1, -1, 1]),
+                cov=np.diag([3, 0.5, 3, 0.5]),
+                size=100).T),
+                          weight=np.array([1/100]*100)),  # track2_state1
+            ParticleState(state_vector=StateVectors(np.random.multivariate_normal(
+                mean=np.array([2, 1.5, 2, 1.5]),
+                cov=np.diag([1.5, 0.25, 1.5, 0.25]),
+                size=100).T),
+                          weight=np.array([1/100]*100)),  # track2_state2
+            'max_cumulative_reward',  # best_child_policy
         )
     ],
     ids=['KLDivergenceMCTSNoAssociation', 'KLDivergenceMCTSAssociation',
          'KLDivergenceMCTSGaussianTest', 'KLDMCTSGaussianPolicy1', 'KLDMCTSGaussianPolicy2',
-         'KLDMCTSGaussianEnum']
+         'KLDMCTSGaussianEnum', 'UncertaintyMCTSTest']
 )
 def test_mcts_sensor_managers(predictor_obj, updater_obj, hypothesiser_obj, associator_obj,
                               reward_function_obj, track1_state1, track1_state2, track2_state1,


### PR DESCRIPTION
This PR introduces several minor updates, mainly to the `UncertaintyRewardFunction`. The first change is to add `return_tracks` as a property to the `UncertaintyRewardFunction`  allowing it to be used with the MCTS type sensor managers and any other sensor management algorithm that requires storage and reuse of states estimated during reward calculation. A test has also been added to verify this functionality with MCTS.

The second change to `UncertaintyRewardFunction` is in generating detections from predicted future target states. As the `measure` method of a sensor is not designed to operate on particle states, it will return a measurement for every `state_vector` in `state_vectors` of the `ParticleState` which is not handled by a `ParticleUpdater` under usual circumstances. To prevent this problem, the mean of `predicted_track` objects are used to construct a `GroundTruthState` which is passed into the `measure` method. This generates a single measurement from the `ParticleState` objects and has no effect when dealing with `GaussianState` types. `GroundTruthState` also allows for track metadata to be stored in the object. 

The third chance is to add a property to the `UncertaintyRewardFunction` has also been added, `measurement_noise`, which allows the user to decide whether noise should be added when generating predicted future measurements. This defaults to `False`, as it was before this change. 

For `ExpectedKLDivergence` and `MultiUpdateKLDivergence`, as these classes were constructing a `State` object when generating measurements, this has been updated to the `GroundTruthState` inline with the `UncertaintyRewardFunction` to allow for metadata passing. The `measurement_noise` property has also been added to these classes. 