### PR TITLE
GOSPAMetric: Avoid unnecessary copies and inefficient masking

### DIFF
--- a/stonesoup/metricgenerator/ospametric.py
+++ b/stonesoup/metricgenerator/ospametric.py
@@ -189,17 +189,17 @@ class GOSPAMetric(MetricGenerator):
         gospa_metrics = []
 
         while next_truth is not None or next_meas is not None:
-            timestamp = min(next_truth[0], next_meas[0])
+            timestamp = min(group[0] for group in [next_truth, next_meas] if group is not None)
 
             truth_idxs = []
 
-            if timestamp == next_truth[0]:
+            if next_truth is not None and timestamp == next_truth[0]:
                 truth_idxs = np.fromiter(next_truth[1], dtype=int)
                 next_truth = next(truth_iter, None)
 
             meas_idxs = []
 
-            if timestamp == next_meas[0]:
+            if next_meas is not None and timestamp == next_meas[0]:
                 meas_idxs = np.fromiter(next_meas[1], dtype=int)
                 next_meas = next(meas_iter, None)
 
@@ -350,6 +350,8 @@ class GOSPAMetric(MetricGenerator):
         if num_truth_states == 0:
             # When truth states are empty all measured states are false
             opt_cost = -1.0 * num_measured_states * dummy_cost
+            if self.alpha == 2:
+                gospa_metric['false'] = opt_cost
         elif num_measured_states == 0:
             # When measured states are empty all truth
             # states are missed

--- a/stonesoup/metricgenerator/ospametric.py
+++ b/stonesoup/metricgenerator/ospametric.py
@@ -182,8 +182,8 @@ class GOSPAMetric(MetricGenerator):
         truth_iter = iter(groupby(range(len(all_truth_ids)), all_truth_timestamps.__getitem__))
         meas_iter = iter(groupby(range(len(all_meas_ids)), all_meas_timestamps.__getitem__))
 
-        next_truth = next(truth_iter)
-        next_meas = next(meas_iter)
+        next_truth = next(truth_iter, None)
+        next_meas = next(meas_iter, None)
 
         switching_metric = _SwitchingLoss(self.switching_penalty, self.p)
         gospa_metrics = []
@@ -228,13 +228,13 @@ class GOSPAMetric(MetricGenerator):
         if len(gospa_metrics) == 1:
             return gospa_metrics[0]
         else:
+            start_time = np.concatenate((all_truth_timestamps[:1], all_meas_timestamps[:1])).min()
+            end_time = np.concatenate((all_truth_timestamps[-1:], all_meas_timestamps[-1:])).max()
+
             return TimeRangeMetric(
                 title='GOSPA Metrics',
                 value=gospa_metrics,
-                time_range=TimeRange(
-                    start=min(all_truth_timestamps[0], all_meas_timestamps[0]),
-                    end=max(all_truth_timestamps[-1], all_meas_timestamps[-1])
-                ),
+                time_range=TimeRange(start=start_time, end=end_time),
                 generator=self)
 
     def compute_assignments(self, cost_matrix):

--- a/stonesoup/metricgenerator/ospametric.py
+++ b/stonesoup/metricgenerator/ospametric.py
@@ -161,21 +161,23 @@ class GOSPAMetric(MetricGenerator):
         exist for in the parameters. metric.value contains a list of metrics
         for the GOSPA metric at each timestamp
         """
-        all_meas_points = np.array(measured_states)
-        all_meas_ids = np.array(measured_state_ids)
-        all_meas_timestamps = np.fromiter((state.timestamp for state in measured_states), dtype='datetime64[us]')
+        all_meas_timestamps = np.fromiter(
+            (state.timestamp for state in measured_states),
+            dtype='datetime64[us]'
+        )
         meas_order = np.argsort(all_meas_timestamps)
-        all_meas_points = all_meas_points[meas_order]
-        all_meas_ids = all_meas_ids[meas_order]
         all_meas_timestamps = all_meas_timestamps[meas_order]
+        all_meas_points = np.array(measured_states)[meas_order]
+        all_meas_ids = np.array(measured_state_ids)[meas_order]
 
-        all_truth_points = np.array(truth_states)
-        all_truth_ids = np.array(truth_state_ids)
-        all_truth_timestamps = np.fromiter((state.timestamp for state in truth_states), dtype='datetime64[us]')
+        all_truth_timestamps = np.fromiter(
+            (state.timestamp for state in truth_states),
+            dtype='datetime64[us]'
+        )
         truth_order = np.argsort(all_truth_timestamps)
-        all_truth_points = all_truth_points[truth_order]
-        all_truth_ids = all_truth_ids[truth_order]
         all_truth_timestamps = all_truth_timestamps[truth_order]
+        all_truth_points = np.array(truth_states)[truth_order]
+        all_truth_ids = np.array(truth_state_ids)[truth_order]
 
         truth_iter = iter(groupby(range(len(all_truth_ids)), all_truth_timestamps.__getitem__))
         meas_iter = iter(groupby(range(len(all_meas_ids)), all_meas_timestamps.__getitem__))
@@ -207,7 +209,10 @@ class GOSPAMetric(MetricGenerator):
             truth_points = all_truth_points[truth_idxs]
             truth_ids = all_truth_ids[truth_idxs]
 
-            metric, truth_to_measured_assignment = self.compute_gospa_metric(meas_points, truth_points)
+            metric, truth_to_measured_assignment = self.compute_gospa_metric(
+                meas_points,
+                truth_points
+            )
             truth_mapping = {
                 truth_id: meas_ids[meas_id] if meas_id != -1 else None
                 for truth_id, meas_id in zip(truth_ids, truth_to_measured_assignment)}
@@ -218,7 +223,6 @@ class GOSPAMetric(MetricGenerator):
                                                 metric.value['switching']**self.alpha,
                                                 1.0/self.alpha)
             gospa_metrics.append(metric)
-            tmax = timestamp
 
         # If only one timestamp is present then return a SingleTimeMetric
         if len(gospa_metrics) == 1:
@@ -227,7 +231,10 @@ class GOSPAMetric(MetricGenerator):
             return TimeRangeMetric(
                 title='GOSPA Metrics',
                 value=gospa_metrics,
-                time_range=TimeRange(min(all_truth_timestamps[0], all_meas_timestamps[0]), max(all_truth_timestamps[-1], all_meas_timestamps[-1])),
+                time_range=TimeRange(
+                    start=min(all_truth_timestamps[0], all_meas_timestamps[0]),
+                    end=max(all_truth_timestamps[-1], all_meas_timestamps[-1])
+                ),
                 generator=self)
 
     def compute_assignments(self, cost_matrix):

--- a/stonesoup/metricgenerator/tests/test_ospametric.py
+++ b/stonesoup/metricgenerator/tests/test_ospametric.py
@@ -367,6 +367,46 @@ def test_switching_gospametric_computemetric():
     assert third_association.generator == generator
 
 
+def test_gospametric_single_timestep():
+    """Test GOSPA on dataset with only a single time step."""
+    max_penalty = 2
+    switching_penalty = 3
+    p = 2
+    generator = GOSPAMetric(
+        c=max_penalty,
+        p=p,
+        switching_penalty=switching_penalty
+    )
+
+    time = datetime.datetime.now()
+    times = [time.now()]
+    tracks = {Track(states=[State(state_vector=[[i]], timestamp=time) for i, time
+                            in zip([1, 2, 2], times)]),
+              Track(states=[State(state_vector=[[i]], timestamp=time) for i, time
+                            in zip([2, 1, 1], times)]),
+              Track(states=[State(state_vector=[[i]], timestamp=time) for i, time
+                            in zip([3, 100, 3], times)])}
+
+    truths = {GroundTruthPath(states=[State(state_vector=[[i]], timestamp=time)
+                                      for i, time in zip([1, 1, 1], times)]),
+              GroundTruthPath(states=[State(state_vector=[[i]], timestamp=time)
+                                      for i, time in zip([2, 2, 2], times)]),
+              GroundTruthPath(states=[State(state_vector=[[i]], timestamp=time)
+                                      for i, time in zip([3, 3, 3], times)])}
+
+    manager = MultiManager([generator])
+    manager.add_data({'groundtruth_paths': truths, 'tracks': tracks})
+    main_metric = generator.compute_metric(manager)
+
+    assert main_metric.value['distance'] == 0
+    assert main_metric.value['localisation'] == 0
+    assert main_metric.value['missed'] == 0
+    assert main_metric.value['false'] == 0
+    assert main_metric.value['switching'] == 0
+    assert main_metric.timestamp == times[0]
+    assert main_metric.generator == generator
+
+
 def test_gospametric_speed():
     """Test GOSPA compute speed."""
     generator = GOSPAMetric(

--- a/stonesoup/metricgenerator/tests/test_ospametric.py
+++ b/stonesoup/metricgenerator/tests/test_ospametric.py
@@ -401,10 +401,11 @@ def test_gospametric_speed():
 
     track_states = np.vstack(
         (
-            gt_states[:num_true_positives] + np.random.normal(0, track_position_sigma, (num_true_positives, num_timesteps, 2)),
-            5*gt_states[:num_false_positives] + np.random.normal(0, track_position_sigma, (num_false_positives, num_timesteps, 2))
+            gt_states[:num_true_positives],
+            5*gt_states[:num_false_positives]
         )
     )
+    track_states += np.random.normal(0, track_position_sigma, track_states.shape)
 
     time = datetime.datetime.now()
     # Multiple tracks and truths present at two timesteps
@@ -420,13 +421,13 @@ def test_gospametric_speed():
     }
     truths = {
         GroundTruthPath(
-        states=[
-            State(
-                state_vector=gt_states[gt_idx, state_idx],
-                timestamp=time + datetime.timedelta(ts[state_idx])
-            )
-            for state_idx in range(gt_states.shape[1])
-        ])
+            states=[
+                State(
+                    state_vector=gt_states[gt_idx, state_idx],
+                    timestamp=time + datetime.timedelta(ts[state_idx])
+                )
+                for state_idx in range(gt_states.shape[1])
+            ])
         for gt_idx in range(gt_states.shape[0])
     }
 

--- a/stonesoup/metricgenerator/tests/test_ospametric.py
+++ b/stonesoup/metricgenerator/tests/test_ospametric.py
@@ -458,6 +458,61 @@ def test_gospametric_no_tracks():
     assert ((gospa_num_false//dummy_cost) == 0).all()
 
 
+def test_gospametric_no_gts():
+    """Test GOSPA of no ground truths."""
+    generator = GOSPAMetric(
+        c=10,
+        p=1
+    )
+    dummy_cost = (generator.c ** generator.p) / generator.alpha
+
+    np.random.seed(42)
+
+    num_gt = 10
+    num_timesteps = int(1e2)
+
+    gt_distance = 30
+    gt_speed = 10
+    track_position_sigma = 1
+
+    r = gt_distance*num_gt/(2*np.pi)
+    w = gt_speed/(2*np.pi*r)
+
+    ts = np.arange(num_timesteps, dtype=float)
+    gt_offsets = 2*np.pi*np.linspace(0, 1, num_gt + 1)[:-1]
+    gt_states = r*np.stack(
+        (
+            np.cos(w*ts[:, None] + gt_offsets[None, :]),
+            np.sin(w*ts[:, None] + gt_offsets[None, :])
+        )
+    ).T
+
+    track_states = gt_states + np.random.normal(0, track_position_sigma, gt_states.shape)
+
+    time = datetime.datetime.now()
+    tracks = {
+        Track(states=[
+            State(
+                state_vector=track_states[track_idx, state_idx],
+                timestamp=time + datetime.timedelta(ts[state_idx])
+            )
+            for state_idx in range(track_states.shape[1])
+        ])
+        for track_idx in range(track_states.shape[0])
+    }
+    truths = {}
+
+    manager = MultiManager([generator])
+    manager.add_data({'groundtruth_paths': truths, 'tracks': tracks})
+    main_metric = generator.compute_metric(manager)
+
+    gospa_num_missed = np.fromiter((i.value['missed'] for i in main_metric.value), dtype=float)
+    gospa_num_false = np.fromiter((i.value['false'] for i in main_metric.value), dtype=float)
+
+    assert ((gospa_num_missed//dummy_cost) == 0).all()
+    assert ((gospa_num_false//dummy_cost) == num_gt).all()
+
+
 def test_gospametric_occasional_no_tracks():
     """Test GOSPA for instances where some timesteps observe no tracks."""
     generator = GOSPAMetric(

--- a/stonesoup/metricgenerator/tests/test_ospametric.py
+++ b/stonesoup/metricgenerator/tests/test_ospametric.py
@@ -407,6 +407,57 @@ def test_gospametric_single_timestep():
     assert main_metric.generator == generator
 
 
+def test_gospametric_no_tracks():
+    """Test GOSPA in the case of no tracks."""
+    generator = GOSPAMetric(
+        c=10,
+        p=1
+    )
+    dummy_cost = (generator.c ** generator.p) / generator.alpha
+
+    num_gt = 10
+    num_timesteps = int(1e2)
+
+    gt_distance = 30
+    gt_speed = 10
+
+    r = gt_distance*num_gt/(2*np.pi)
+    w = gt_speed/(2*np.pi*r)
+
+    ts = np.arange(num_timesteps, dtype=float)
+    gt_offsets = 2*np.pi*np.linspace(0, 1, num_gt + 1)[:-1]
+    gt_states = r*np.stack(
+        (
+            np.cos(w*ts[:, None] + gt_offsets[None, :]),
+            np.sin(w*ts[:, None] + gt_offsets[None, :])
+        )
+    ).T
+
+    time = datetime.datetime.now()
+    tracks = {}
+    truths = {
+        GroundTruthPath(
+            states=[
+                State(
+                    state_vector=gt_states[gt_idx, state_idx],
+                    timestamp=time + datetime.timedelta(ts[state_idx])
+                )
+                for state_idx in range(gt_states.shape[1])
+            ])
+        for gt_idx in range(gt_states.shape[0])
+    }
+
+    manager = MultiManager([generator])
+    manager.add_data({'groundtruth_paths': truths, 'tracks': tracks})
+    main_metric = generator.compute_metric(manager)
+
+    gospa_num_missed = np.fromiter((i.value['missed'] for i in main_metric.value), dtype=float)
+    gospa_num_false = np.fromiter((i.value['false'] for i in main_metric.value), dtype=float)
+
+    assert ((gospa_num_missed//dummy_cost) == num_gt).all()
+    assert ((gospa_num_false//dummy_cost) == 0).all()
+
+
 def test_gospametric_occasional_no_tracks():
     """Test GOSPA for instances where some timesteps observe no tracks."""
     generator = GOSPAMetric(


### PR DESCRIPTION
`GOSPAMetric.compute_over_time()` was taking a complete copy of _all_ measurements and ground truth states for every timestep in the sequence. Additionally, it used multiple full linear masks for every iteration on the sorted timestamps. These steps cause the metric to have $` \mathcal{O}(n^2) `$ running time in the number of timesteps, resulting in slow compute on long datasets.

This PR performs the copying once and uses `itertools.groupby()` to avoid the linear masking in each iteration. As a result, `GOSPAMetric` now uses slightly less memory (we perform the same copy, but save the masking) and, in practice, runs linearly in the number of timesteps. The PR also includes a test which demonstrates 30-40x speedup on a 1k timestep long sequence. Offline I'm seeing 150x speedup (going from 20 min to 8 sec) on a real-world dataset with 50k timesteps.

This patch is also likely to help in the case of #1032.