### PR TITLE
Don't set global random seed in tests

### DIFF
--- a/stonesoup/functions/__init__.py
+++ b/stonesoup/functions/__init__.py
@@ -561,7 +561,7 @@ def rotz(theta):
                      [zero, zero, one]])
 
 
-def gm_sample(means, covars, size, weights=None):
+def gm_sample(means, covars, size, weights=None, random_state=None):
     """Sample from a mixture of multi-variate Gaussians
 
     Parameters
@@ -595,8 +595,10 @@ def gm_sample(means, covars, size, weights=None):
     elif weights is None:
         weights = np.array([1 / len(means)] * len(means))
 
-    n_samples = np.random.multinomial(size, weights)
-    samples = np.vstack([np.random.multivariate_normal(mean.ravel(), covar, sample)
+    rng = random_state if random_state is not None else np.random
+
+    n_samples = rng.multinomial(size, weights)
+    samples = np.vstack([rng.multivariate_normal(mean.ravel(), covar, sample)
                          for (mean, covar, sample) in zip(means, covars, n_samples)]).T
 
     return StateVectors(samples)

--- a/stonesoup/metricgenerator/tests/test_ospametric.py
+++ b/stonesoup/metricgenerator/tests/test_ospametric.py
@@ -466,7 +466,7 @@ def test_gospametric_no_gts():
     )
     dummy_cost = (generator.c ** generator.p) / generator.alpha
 
-    np.random.seed(42)
+    rng = np.random.RandomState(42)
 
     num_gt = 10
     num_timesteps = int(1e2)
@@ -487,7 +487,7 @@ def test_gospametric_no_gts():
         )
     ).T
 
-    track_states = gt_states + np.random.normal(0, track_position_sigma, gt_states.shape)
+    track_states = gt_states + rng.normal(0, track_position_sigma, gt_states.shape)
 
     time = datetime.datetime.now()
     tracks = {
@@ -521,7 +521,7 @@ def test_gospametric_occasional_no_tracks():
     )
     dummy_cost = (generator.c ** generator.p) / generator.alpha
 
-    np.random.seed(42)
+    rng = np.random.RandomState(42)
 
     num_gt = 10
     num_timesteps = int(1e2)
@@ -542,7 +542,7 @@ def test_gospametric_occasional_no_tracks():
         )
     ).T
 
-    track_states = gt_states + np.random.normal(0, track_position_sigma, gt_states.shape)
+    track_states = gt_states + rng.normal(0, track_position_sigma, gt_states.shape)
 
     time = datetime.datetime.now()
     tracks = {
@@ -587,7 +587,7 @@ def test_gospametric_occasional_no_gts():
     )
     dummy_cost = (generator.c ** generator.p) / generator.alpha
 
-    np.random.seed(42)
+    rng = np.random.RandomState(42)
 
     num_gt = 10
     num_timesteps = int(1e2)
@@ -608,7 +608,7 @@ def test_gospametric_occasional_no_gts():
         )
     ).T
 
-    track_states = gt_states + np.random.normal(0, track_position_sigma, gt_states.shape)
+    track_states = gt_states + rng.normal(0, track_position_sigma, gt_states.shape)
 
     time = datetime.datetime.now()
     tracks = {
@@ -654,7 +654,7 @@ def test_gospametric_speed():
     )
     dummy_cost = (generator.c ** generator.p) / generator.alpha
 
-    np.random.seed(42)
+    rng = np.random.RandomState(42)
 
     num_gt = 10
     num_missed = 3
@@ -684,7 +684,7 @@ def test_gospametric_speed():
             5*gt_states[:num_false_positives]
         )
     )
-    track_states += np.random.normal(0, track_position_sigma, track_states.shape)
+    track_states += rng.normal(0, track_position_sigma, track_states.shape)
 
     time = datetime.datetime.now()
     tracks = {

--- a/stonesoup/models/measurement/gas.py
+++ b/stonesoup/models/measurement/gas.py
@@ -123,8 +123,8 @@ class IsotropicPlume(GaussianModel, MeasurementModel):
     def ndim_meas(self) -> int:
         return 1
 
-    def function(self, state: State, noise: Union[bool, np.ndarray] = False, **kwargs) -> Union[
-                 StateVector, StateVectors]:
+    def function(self, state: State, noise: Union[bool, np.ndarray] = False, random_state=None,
+                 **kwargs) -> Union[StateVector, StateVectors]:
         r"""Model function :math:`h(\vec{x}_t,\vec{v}_t)`
 
         Parameters
@@ -164,11 +164,13 @@ class IsotropicPlume(GaussianModel, MeasurementModel):
         if noise:
             C += self.rvs(state=C.view(StateVectors),
                           num_samples=state.state_vector.shape[1],
+                          random_state=random_state,
                           **kwargs)
             # measurement thresholding
             C[C < self.sensing_threshold] = 0
             # missed detections
-            flag = np.random.uniform(size=state.state_vector.shape[1]) \
+            rng = random_state or self.random_state or np.random
+            flag = rng.uniform(size=state.state_vector.shape[1]) \
                 > (1 - self.missed_detection_probability)
             C[:, flag] = 0
 

--- a/stonesoup/models/measurement/tests/test_gas.py
+++ b/stonesoup/models/measurement/tests/test_gas.py
@@ -116,8 +116,9 @@ def test_isotropic_plume(state, mapping, translation_offset):
     actual_conc = isoplume_h(unmapped_state, translation_offset)
     assert np.all(np.isclose(expected_conc, actual_conc))
 
+    rng = np.random.RandomState(1990)
     # Test noise
-    expected_conc = model.function(state, noise=True, random_state=1990)
+    expected_conc = model.function(state, noise=True, random_state=rng)
 
     rng = np.random.RandomState(1990)
     actual_conc += actual_conc * standard_deviation_percentage * rng.normal(size=nparts)

--- a/stonesoup/predictor/particle.py
+++ b/stonesoup/predictor/particle.py
@@ -305,7 +305,7 @@ class BernoulliParticlePredictor(ParticlePredictor):
 
         # Sample from birth distribution
         detections = self.get_detections(prior)
-        birth_state = self.birth_sampler.sample(detections)
+        birth_state = self.birth_sampler.sample(detections, **kwargs)
 
         birth_part = birth_state.state_vector
         nbirth_particles = len(birth_state)
@@ -455,7 +455,7 @@ class SMCPHDPredictor(Predictor):
         self.birth_scheme = SMCPHDBirthSchemeEnum(self.birth_scheme)
 
     @predict_lru_cache()
-    def predict(self, prior, timestamp=None, **kwargs):
+    def predict(self, prior, timestamp=None, random_state=None, **kwargs):
         """ SMC-PHD prediction step
 
         Parameters
@@ -477,7 +477,9 @@ class SMCPHDPredictor(Predictor):
         # Predict surviving particles forward
         pred_particles_sv = self.transition_model.function(prior,
                                                            time_interval=time_interval,
-                                                           noise=True)
+                                                           noise=True,
+                                                           random_state=random_state,
+                                                           **kwargs)
 
         # Calculate probability of survival
         log_prob_survive = -float(self.death_probability) * time_interval.total_seconds()
@@ -490,7 +492,10 @@ class SMCPHDPredictor(Predictor):
 
             # Sample birth particles
             birth_particles = self.birth_sampler.sample(
-                params={self.birth_func_num_samples_field: num_birth}, timestamp=timestamp)
+                params={self.birth_func_num_samples_field: num_birth},
+                timestamp=timestamp,
+                random_state=random_state,
+                **kwargs)
             # Ensure birth weights are uniform and scaled by birth rate
             birth_particles.log_weight = np.full((num_birth,), np.log(self.birth_rate / num_birth))
 
@@ -502,17 +507,22 @@ class SMCPHDPredictor(Predictor):
                 np.concatenate((pred_particles_sv, birth_particles.state_vector), axis=1))
             log_pred_weights = np.concatenate((log_pred_weights, birth_particles.log_weight))
         else:
+            rng = random_state if random_state is not None else np.random
             # Flip a coin for each particle to decide if it gets replaced by a birth particle
             birth_inds = np.flatnonzero(
-                np.random.binomial(1, float(self.birth_probability), num_samples)
+                rng.binomial(1, float(self.birth_probability), num_samples)
             )
 
             # Sample birth particles and replace in original state vector matrix
             num_birth = len(birth_inds)
-            birth_particles = self.birth_sampler.sample(
-                params={self.birth_func_num_samples_field: num_birth}, timestamp=timestamp)
-            # Replace particles in the state vector matrix
-            pred_particles_sv[:, birth_inds] = birth_particles.state_vector
+            if num_birth > 0:
+                birth_particles = self.birth_sampler.sample(
+                    params={self.birth_func_num_samples_field: num_birth},
+                    timestamp=timestamp,
+                    random_state=random_state,
+                    **kwargs)
+                # Replace particles in the state vector matrix
+                pred_particles_sv[:, birth_inds] = birth_particles.state_vector
 
             # Process weights
             prob_survive = np.exp(log_prob_survive)

--- a/stonesoup/sampler/detection.py
+++ b/stonesoup/sampler/detection.py
@@ -43,7 +43,7 @@ class GaussianDetectionParticleSampler(DetectionSampler):
         default=1,
         doc="Number of samples to return")
 
-    def sample(self, detections):
+    def sample(self, detections, random_state=None, **kwargs):
         """Samples from a Gaussian mixture around detections
 
         Parameters
@@ -68,8 +68,7 @@ class GaussianDetectionParticleSampler(DetectionSampler):
                     mapping = detection.measurement_model.mapping
                     mapping_matrix = np.zeros((ndim_state, ndim_meas))
                     mapping_index = np.linspace(0, len(mapping)-1, ndim_meas, dtype=int)
-                    mapping_matrix[mapping, mapping_index] \
-                        = 1
+                    mapping_matrix[mapping, mapping_index] = 1
                     dist_mean.append(mapping_matrix @ detection.state_vector)
                     dist_covar.append(mapping_matrix @
                                       detection.measurement_model.noise_covar @
@@ -89,7 +88,8 @@ class GaussianDetectionParticleSampler(DetectionSampler):
         samples = gm_sample(means=dist_mean,
                             covars=dist_covar,
                             weights=weights,
-                            size=self.nsamples)
+                            size=self.nsamples,
+                            random_state=random_state)
 
         particles = ParticleState(state_vector=StateVectors(samples),
                                   weight=np.array([1 / self.nsamples] * self.nsamples),
@@ -119,7 +119,7 @@ class SwitchingDetectionSampler(DetectionSampler):
     backup_sampler: Sampler = Property(
         doc="Sampler for generating samples in the absence of detections")
 
-    def sample(self, detections, timestamp=None):
+    def sample(self, detections, timestamp=None, **kwargs):
         """Produces samples based on the detections provided.
 
         Parameters
@@ -136,9 +136,9 @@ class SwitchingDetectionSampler(DetectionSampler):
         """
 
         if detections:
-            sample = self.detection_sampler.sample(detections)
+            sample = self.detection_sampler.sample(detections, **kwargs)
 
         else:
-            sample = self.backup_sampler.sample(timestamp=timestamp)
+            sample = self.backup_sampler.sample(timestamp=timestamp, **kwargs)
 
         return sample

--- a/stonesoup/sampler/particle.py
+++ b/stonesoup/sampler/particle.py
@@ -23,7 +23,7 @@ class ParticleSampler(Sampler):
     ndim_state: int = Property(
         doc="Number of dimensions in each sample.")
 
-    def sample(self, params=None, timestamp=None):
+    def sample(self, params=None, timestamp=None, **kwargs):
         """Samples from the desired distribution and returns as a :class:`~.ParticleState`
 
         Parameters

--- a/stonesoup/tests/test_kernel.py
+++ b/stonesoup/tests/test_kernel.py
@@ -8,16 +8,18 @@ from ..types.state import KernelParticleState
 from ..kernel import Kernel, QuadraticKernel, QuarticKernel, GaussianKernel
 
 number_particles = 4
-np.random.seed(50)
+rng = np.random.RandomState(50)
 samples = multivariate_normal.rvs([0, 0, 0, 0],
                                   np.diag([0.01, 0.005, 0.1, 0.5])**2,
-                                  size=number_particles)
+                                  size=number_particles,
+                                  random_state=rng)
 prior = KernelParticleState(state_vector=StateVectors(samples.T),
                             weight=np.array([1/number_particles]*number_particles),
                             )
 samples = multivariate_normal.rvs([0, 0, 0, 0],
                                   np.diag([0.01, 0.005, 0.1, 0.5])**2,
-                                  size=number_particles)
+                                  size=number_particles,
+                                  random_state=rng)
 proposal = KernelParticleState(state_vector=StateVectors(samples.T),
                                weight=np.array([1/number_particles]*number_particles),
                                )

--- a/stonesoup/tests/test_stitcher.py
+++ b/stonesoup/tests/test_stitcher.py
@@ -25,7 +25,6 @@ from stonesoup.tracker.simple import MultiTargetTracker
 @pytest.fixture
 def params():
     start_time = datetime(2023, 4, 6, 16, 17)
-    np.random.seed(100)  # Set seed for numpy random arrays
 
     number_of_targets = 3
     range_value = 10000

--- a/stonesoup/types/tests/test_prediction.py
+++ b/stonesoup/types/tests/test_prediction.py
@@ -253,10 +253,11 @@ def test_asdgaussianmeasurementprediction():
 
 def test_kernel_particle_state_prediction():
     number_particles = 4
-    np.random.seed(50)
+    rng = np.random.RandomState(50)
     samples = multivariate_normal.rvs([0, 0, 0, 0],
                                       np.diag([0.01, 0.005, 0.1, 0.5]) ** 2,
-                                      size=number_particles)
+                                      size=number_particles,
+                                      random_state=rng)
 
     state_vector = StateVectors(samples.T)
     weights = np.array([1 / number_particles] * number_particles)

--- a/stonesoup/types/tests/test_update.py
+++ b/stonesoup/types/tests/test_update.py
@@ -223,7 +223,6 @@ def test_from_state_sequence():
 
 def test_kernel_particle_state_update():
     number_particles = 4
-    np.random.seed(50)
     samples = multivariate_normal.rvs([0, 0, 0, 0],
                                       np.diag([0.01, 0.005, 0.1, 0.5]) ** 2,
                                       size=number_particles)


### PR DESCRIPTION
This removes all cases where the NumPy global seed is set in tests, such that setting of seed in one test doesn't impact others.

This also makes some minor changes in samplers to optionally use a provided seed, and fallback to global if not provided (similar to models).