### PR TITLE
Particle filter proposal implementation

### DIFF
--- a/stonesoup/hypothesiser/distance.py
+++ b/stonesoup/hypothesiser/distance.py
@@ -69,7 +69,7 @@ class DistanceHypothesiser(Hypothesiser):
 
             # Re-evaluate prediction
             prediction = self.predictor.predict(
-                track, timestamp=detection.timestamp, **kwargs)
+                track, timestamp=detection.timestamp, measurement=detection, **kwargs)
 
             # Compute measurement prediction and distance measure
             measurement_prediction = self.updater.predict_measurement(

--- a/stonesoup/proposal/base.py
+++ b/stonesoup/proposal/base.py
@@ -1,0 +1,16 @@
+from abc import abstractmethod
+from stonesoup.base import Base
+
+
+class Proposal(Base):
+
+    @abstractmethod
+    def rvs(self, *args, **kwargs):
+        r"""Proposal noise/sample generation function
+        Generates samples from the proposal.
+        Parameters
+        ----------
+        state: :class:`~.State`
+            The state to generate samples from.
+        """
+        raise NotImplementedError

--- a/stonesoup/proposal/simple.py
+++ b/stonesoup/proposal/simple.py
@@ -1,7 +1,6 @@
 from typing import Union
 
 import numpy as np
-from enum import Enum
 from scipy.stats import multivariate_normal as mvn
 
 from stonesoup.base import Property
@@ -55,7 +54,6 @@ class PriorAsProposal(Proposal):
                                      prior=prior)
 
 
-
 class KFasProposal(Proposal):
     """This proposal uses the kalman filter prediction and update steps to
     generate new set of particles and weights
@@ -84,9 +82,6 @@ class KFasProposal(Proposal):
         : :class:`~.ParticlePrediction`
         """
 
-        # get the number of particles
-        number_particles = prior.state_vector.shape[1]
-
         if measurement is not None:
             timestamp = measurement.timestamp
             time_interval = measurement.timestamp - prior.timestamp
@@ -105,7 +100,7 @@ class KFasProposal(Proposal):
         if isinstance(self.predictor, SqrtKalmanPredictor):
             prior_cls = SqrtGaussianState
 
-        # Null covariance
+        # Null covariance for the particles
         null_covar = np.zeros_like(prior.covar)
 
         predictions = [

--- a/stonesoup/proposal/simple.py
+++ b/stonesoup/proposal/simple.py
@@ -1,0 +1,146 @@
+from typing import Union
+
+import numpy as np
+from enum import Enum
+from scipy.stats import multivariate_normal as mvn
+
+from stonesoup.base import Property
+from stonesoup.models.transition import TransitionModel
+from stonesoup.proposal.base import Proposal
+from stonesoup.types.array import StateVector, StateVectors
+from stonesoup.types.detection import Detection
+from stonesoup.types.state import State, GaussianState, SqrtGaussianState
+from stonesoup.types.prediction import Prediction
+from stonesoup.updater.base import Updater
+from stonesoup.predictor.base import Predictor
+from stonesoup.predictor.kalman import SqrtKalmanPredictor
+from stonesoup.types.hypothesis import SingleHypothesis
+
+
+class PriorAsProposal(Proposal):
+    """Proposal that uses the dynamics model as the importance density.
+    This proposal uses the dynamics model to predict the next state, and then
+    uses the predicted state as the prior for the measurement model.
+    """
+    transition_model: TransitionModel = Property(
+        doc="The transition model used to make the prediction")
+
+    def rvs(self, prior: State, measurement=None, time_interval=None,
+            **kwargs) -> Union[StateVector, StateVectors]:
+        """Generate samples from the proposal.
+        Parameters
+        ----------
+        state: :class:`~.State`
+            The state to generate samples from.
+        Returns
+        -------
+        : :class:`~.ParticlePrediction` with samples drawn from the updated proposal
+
+        """
+
+        if measurement is not None:
+            timestamp = measurement.timestamp
+            time_interval = measurement.timestamp - prior.timestamp
+        else:
+            timestamp = prior.timestamp + time_interval
+
+        new_state_vector = self.transition_model.function(prior,
+                                                          time_interval=time_interval,
+                                                          **kwargs)
+        return Prediction.from_state(prior,
+                                     parent=prior,
+                                     state_vector=new_state_vector,
+                                     timestamp=timestamp,
+                                     transition_model=self.transition_model,
+                                     prior=prior)
+
+
+
+class KFasProposal(Proposal):
+    """This proposal uses the kalman filter prediction and update steps to
+    generate new set of particles and weights
+    """
+    predictor: Predictor = Property(
+        doc="predictor to use the various values")
+    updater: Updater = Property(
+        doc="Updater used for update the values")
+
+    def rvs(self, prior: State, measurement: Detection = None, time_interval=None,
+            **kwargs):
+        """Generate samples from the proposal.
+            Use the kalman filter predictor and updater to create a new distribution
+        Parameters
+        ----------
+        state: :class:`~.State`
+            The state to generate samples from.
+        measurement: :class:`~.Detection`
+            the measurement that is used in the update step of the kalman prediction,
+            (the default is `None`)
+        time_interval: :class:`datetime.time_delta`
+            time interval of the prediction is needed to propagate the states
+
+        Returns
+        -------
+        : :class:`~.ParticlePrediction`
+        """
+
+        # get the number of particles
+        number_particles = prior.state_vector.shape[1]
+
+        if measurement is not None:
+            timestamp = measurement.timestamp
+            time_interval = measurement.timestamp - prior.timestamp
+        else:
+            timestamp = prior.timestamp + time_interval
+
+        if time_interval.total_seconds() == 0:
+            return Prediction.from_state(prior,
+                                         parent=prior,
+                                         state_vector=prior.state_vector,
+                                         timestamp=prior.timestamp,
+                                         transition_model=self.predictor.transition_model,
+                                         prior=prior)
+
+        prior_cls = GaussianState  # Default
+        if isinstance(self.predictor, SqrtKalmanPredictor):
+            prior_cls = SqrtGaussianState
+
+        # Null covariance
+        null_covar = np.zeros_like(prior.covar)
+
+        predictions = [
+            self.predictor.predict(
+                prior_cls(particle_sv, null_covar, prior.timestamp),
+                timestamp=timestamp)
+            for particle_sv in prior.state_vector]
+
+        if measurement is not None:
+            updates = [self.updater.update(SingleHypothesis(prediction, measurement))
+                       for prediction in predictions]
+        else:
+            updates = predictions  # keep the prediction
+
+        # Draw the samples
+        samples = np.array([state.state_vector.reshape(-1) +
+                            mvn.rvs(cov=state.covar).T
+                            for state in updates])
+
+        # Compute the log of q(x_k|x_{k-1}, y_k)
+        post_log_weights = np.array([mvn.logpdf(sample,
+                                                np.array(update.mean).reshape(-1),
+                                                update.covar)
+                                     for sample, update in zip(samples, updates)])
+
+        pred_state = Prediction.from_state(prior,
+                                           parent=prior,
+                                           state_vector=StateVectors(samples.T),
+                                           timestamp=timestamp,
+                                           transition_model=self.predictor.transition_model,
+                                           prior=prior)
+
+        prior_log_weights = self.predictor.transition_model.logpdf(pred_state, prior,
+                                                                   time_interval=time_interval)
+
+        pred_state.log_weight = (pred_state.log_weight + prior_log_weights - post_log_weights)
+
+        return pred_state

--- a/stonesoup/proposal/tests/test_simple.py
+++ b/stonesoup/proposal/tests/test_simple.py
@@ -1,0 +1,147 @@
+import itertools
+
+import datetime
+import numpy as np
+import pytest
+
+# Import the proposals
+from stonesoup.proposal.simple import PriorAsProposal, KFasProposal
+from stonesoup.models.transition.linear import ConstantVelocity
+from stonesoup.types.particle import Particle
+from stonesoup.types.prediction import ParticleStatePrediction
+from stonesoup.predictor.kalman import KalmanPredictor
+from stonesoup.updater.kalman import KalmanUpdater
+from stonesoup.updater.particle import ParticleUpdater
+from stonesoup.types.state import ParticleState, GaussianState
+from stonesoup.predictor.particle import ParticlePredictor
+from stonesoup.types.detection import Detection
+from stonesoup.models.measurement.linear import LinearGaussian
+from stonesoup.types.hypothesis import SingleHypothesis
+
+
+def test_prior_proposal():
+    # test that the proposal as prior and basic PF implementation
+    # yield same results, since they are driven by the transition model
+    np.random.seed(16549)
+
+    # Initialise a transition model
+    cv = ConstantVelocity(noise_diff_coeff=0)
+
+    # Define time related variables
+    timestamp = datetime.datetime.now()
+    timediff = 2  # 2sec
+    new_timestamp = timestamp + datetime.timedelta(seconds=timediff)
+    time_interval = new_timestamp - timestamp
+
+    num_particles = 9  # Number of particles
+
+    # Define prior state
+    prior_particles = [Particle(np.array([[i], [j]]), 1/num_particles)
+                       for i, j in itertools.product([10, 20, 30], [10, 20, 30])]
+    prior = ParticleState(None, particle_list=prior_particles, timestamp=timestamp)
+
+    # predictors prior and standard stone soup
+    predictor_prior = ParticlePredictor(cv,
+                                        proposal=PriorAsProposal(cv))
+
+    # Check that the predictor without prior specified works with the prior as
+    # proposal
+    predictor_base = ParticlePredictor(cv)
+
+    # basic transition model evaluations
+    eval_particles = [Particle(cv.matrix(timestamp=new_timestamp,
+                                         time_interval=time_interval)
+                               @ particle.state_vector,
+                               1 / 9)
+                      for particle in prior_particles]
+    eval_mean = np.mean(np.hstack([i.state_vector for i in eval_particles]),
+                        axis=1).reshape(2, 1)
+
+    # construct the evaluation prediction
+    eval_prediction = ParticleStatePrediction(None, new_timestamp, particle_list=eval_particles)
+
+    prediction_base = predictor_base.predict(prior, timestamp=new_timestamp)
+    prediction_prior = predictor_prior.predict(prior, timestamp=new_timestamp)
+
+    assert np.all([eval_prediction.state_vector[:, i] ==
+                   prediction_base.state_vector[:, i] for i in range(9)])
+    assert np.all([prediction_base.weight[i] == 1 / 9 for i in range(9)])
+
+    assert np.allclose(prediction_prior.mean, eval_mean)
+    assert prediction_prior.timestamp == new_timestamp
+    assert np.all([eval_prediction.state_vector[:, i] ==
+                   prediction_prior.state_vector[:, i] for i in range(9)])
+    assert np.all([prediction_prior.weight[i] == 1 / 9 for i in range(9)])
+
+
+def test_kf_proposal():
+
+    np.random.seed(16549)
+
+    # Initialise a transition model
+    cv = ConstantVelocity(noise_diff_coeff=1)
+
+    # initialise the measurement model
+    lg = LinearGaussian(ndim_state=2,
+                        mapping=[0],
+                        noise_covar=np.diag([1]))
+
+    # Define time related variables
+    timestamp = datetime.datetime.now()
+    timediff = 2  # 2sec
+    new_timestamp = timestamp + datetime.timedelta(seconds=timediff)
+    time_interval = new_timestamp - timestamp
+
+    num_particles = 9  # Number of particles
+
+    # Define prior state
+    prior_particles = [Particle(np.array([[i], [j]]), 1/num_particles)
+                       for i, j in itertools.product([1, 2, 3], [1, 2, 3])]
+
+    prior = ParticleState(None, particle_list=prior_particles, timestamp=timestamp)
+
+    prior_kf = GaussianState(prior.mean, prior.covar, prior.timestamp)
+    kf_predictor = KalmanPredictor(cv)
+    kf_updater = KalmanUpdater(lg)
+
+    # perform the kalman filter update
+    prediction = kf_predictor.predict(prior_kf, timestamp=new_timestamp)
+
+    new_state = GaussianState(state_vector=cv.function(prior_kf, noise=True,
+                                                       time_interval=time_interval),
+                              covar=np.diag([1, 1]),
+                              timestamp=new_timestamp)
+
+    detection = Detection(lg.function(new_state,
+                                      noise=True),
+                          timestamp=new_timestamp,
+                          measurement_model=lg)
+
+    predictions = [kf_predictor.predict(
+        GaussianState(particle_sv, np.zeros_like(prior.covar), prior.timestamp),
+        timestamp=timestamp)
+        for particle_sv in prior.state_vector]
+
+    updates = [kf_updater.update(SingleHypothesis(prediction, detection))
+               for prediction in predictions]
+
+#    eval_state = kf_updater.update(SingleHypothesis(prediction, detection))
+
+    proposal = KFasProposal(KalmanPredictor(cv),
+                            KalmanUpdater(lg))
+
+    x = proposal.rvs(prior, measurement=detection, time_interval=time_interval)
+
+    # pf_predictor = ParticlePredictor(cv,
+    #                                  proposal=proposal)
+    #
+    # pf_updater = ParticleUpdater(lg)
+    #
+    # pred_state = pf_predictor.predict(prior, timestamp=new_timestamp, detection=detection)
+    #
+
+    #print()
+    assert x.state_vector.shape == prior.state_vector.shape
+#    assert np.allclose(pred_state.mean, eval_state.state_vector)
+#    assert np.allclose(x.mean, eval_state.state_vector)
+    assert pred_state.timestamp == new_timestamp


### PR DESCRIPTION
This PR updates the particle filter implementation with proposals, in particular **prior as proposal** and **(local) kalman filter**. 
This is developed by @sglvladi and myself.

Now the particle filter uses **prior as proposal** as default, otherwise a Kalman filter proposal can be used. 
Since in the prediction step we need to perform an update, we have modified as well the distance hypothesiser to include the measurements (or detections) to perform correctly the predict-update step.

We have implemented the **local** Lalman Filter proposal which propagates each particle using the kalman filter predict and update and then samples once for each particle the new state (before doing the particle update).
There is another way, commonly known as **global** Kalman Filter, where the particle distribution is approximated by a gaussian, which is propagated using the Kalman Filter and then a new set of particles is drawn from the new state. However, we encountered a number of issues in the making it working accordingly, in particular with problems with weights normalisation during the data-association step.  I will open an issue to try to get to the bottom of this. 

[Summary paper that highlights the two implementations](https://onlinelibrary.wiley.com/doi/10.1155/2014/175820)

A couple of stone soup examples are :
[single target no data association case](https://gist.github.com/A-acuto/da62c375db90f26b456c31d7e705ee5d)
[data association case](https://gist.github.com/A-acuto/471c4be3221b55bc7e78647d8da38a00)