### PR TITLE
Extend `MetricGenerator` interface with `generator_name` and add  it to `ClearMotMetrics`

### DIFF
--- a/stonesoup/metricgenerator/base.py
+++ b/stonesoup/metricgenerator/base.py
@@ -30,6 +30,17 @@ class MetricGenerator(Base):
         """
         raise NotImplementedError
 
+    @property
+    @abstractmethod
+    def generator_name(self) -> str:
+        """Unique identifier when accessing generated metrics from MultiManager.
+
+        Returns
+        -------
+        : unique identifier as string
+        """
+        raise NotImplementedError
+
 
 class MetricManager(Base):
     """Metric Manager base class

--- a/stonesoup/metricgenerator/clearmotmetrics.py
+++ b/stonesoup/metricgenerator/clearmotmetrics.py
@@ -33,6 +33,9 @@ class ClearMotMetrics(MetricGenerator):
         [1] Evaluating Multiple Object Tracking Performance: The CLEAR MOT Metrics,
         Bernardin et al, 2008
     """
+    generator_name: str = Property(doc="Unique identifier to use when accessing generated metrics "
+                                       "from MultiManager",
+                                   default='clearmot_generator')
     tracks_key: str = Property(doc='Key to access set of tracks added to MetricManager',
                                default='tracks')
     truths_key: str = Property(doc="Key to access set of ground truths added to MetricManager. "

--- a/stonesoup/metricgenerator/manager.py
+++ b/stonesoup/metricgenerator/manager.py
@@ -1,14 +1,13 @@
 from itertools import chain
-from typing import Sequence, Dict, Iterable, Union
+from typing import Dict, Iterable, Sequence, Union
 
-from .base import MetricManager, MetricGenerator
 from ..base import Property
 from ..dataassociator import Associator
-
+from ..platform import Platform
+from ..types.detection import Detection
 from ..types.groundtruth import GroundTruthPath
 from ..types.track import Track
-from ..types.detection import Detection
-from ..platform import Platform
+from .base import MetricGenerator, MetricManager
 
 
 class MultiManager(MetricManager):
@@ -78,7 +77,7 @@ class MultiManager(MetricManager):
             Metrics generated
         """
 
-        metrics = {}
+        metrics: Dict[Dict] = {}
 
         generators = self.generators if isinstance(self.generators, list) else [self.generators]
 

--- a/stonesoup/metricgenerator/metrictables.py
+++ b/stonesoup/metricgenerator/metrictables.py
@@ -1,12 +1,12 @@
 from operator import attrgetter
 from typing import Collection
 
-import numpy as np
 import matplotlib
+import numpy as np
 from matplotlib import pyplot as plt
 
-from .base import MetricTableGenerator, MetricGenerator
 from ..base import Property
+from .base import MetricGenerator, MetricTableGenerator
 
 
 class RedGreenTableGenerator(MetricTableGenerator):
@@ -16,6 +16,9 @@ class RedGreenTableGenerator(MetricTableGenerator):
     values to color code an output table with respect to how
     well the tracker performed in relation to each metric, where
     red is worse and green is better"""
+
+    # needed because of MetricGenerator parent class
+    generator_name: str = ""
 
     metrics: Collection[MetricGenerator] = Property(doc="Set of metrics to put in the table")
 
@@ -84,6 +87,9 @@ class SIAPTableGenerator(RedGreenTableGenerator):
 
     Contains methods to specify the ranges, descriptions and target values specifically for SIAP
     metrics."""
+
+    # needed because of MetricGenerator parent class
+    generator_name: str = ""
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/stonesoup/types/tests/test_metric.py
+++ b/stonesoup/types/tests/test_metric.py
@@ -1,10 +1,24 @@
-import pytest
 import datetime
 
-from ..metric import Metric, PlottingMetric, SingleTimePlottingMetric, \
-    SingleTimeMetric, TimeRangePlottingMetric, TimeRangeMetric
-from ..time import TimeRange
+import pytest
+
 from ...metricgenerator import MetricGenerator
+from ..metric import (
+    Metric,
+    PlottingMetric,
+    SingleTimeMetric,
+    SingleTimePlottingMetric,
+    TimeRangeMetric,
+    TimeRangePlottingMetric,
+)
+from ..time import TimeRange
+
+
+class TempGenerator(MetricGenerator):
+    generator_name = "temp-generator"
+
+    def compute_metric(self, manager):
+        return 5
 
 
 def test_metric():
@@ -14,12 +28,7 @@ def test_metric():
     title = "Test metric"
     value = 5
 
-    class temp_generator(MetricGenerator):
-
-        def compute_metric(self, manager):
-            return 5
-
-    generator = temp_generator()
+    generator = TempGenerator()
 
     temp_metric = Metric(title=title,
                          value=value,
@@ -37,12 +46,7 @@ def test_plottingmetric():
     title = "Test metric"
     value = 5
 
-    class temp_generator(MetricGenerator):
-
-        def compute_metric(self, manager):
-            return 5
-
-    generator = temp_generator()
+    generator = TempGenerator()
     temp_metric = PlottingMetric(title=title,
                                  value=value,
                                  generator=generator)
@@ -60,12 +64,7 @@ def test_singletimemetric():
     value = 5
     timestamp = datetime.datetime.now()
 
-    class temp_generator(MetricGenerator):
-
-        def compute_metric(self, manager):
-            return 5
-
-    generator = temp_generator()
+    generator = TempGenerator()
     temp_metric = SingleTimeMetric(title=title,
                                    value=value,
                                    timestamp=timestamp,
@@ -88,12 +87,7 @@ def test_timerangemetric():
     time_range = TimeRange(start=timestamp1,
                            end=timestamp2)
 
-    class temp_generator(MetricGenerator):
-
-        def compute_metric(self, manager):
-            return 5
-
-    generator = temp_generator()
+    generator = TempGenerator()
     temp_metric = TimeRangeMetric(title=title,
                                   value=value,
                                   time_range=time_range,
@@ -116,12 +110,7 @@ def test_timerangeplottingmetric():
     time_range = TimeRange(start=timestamp1,
                            end=timestamp2)
 
-    class temp_generator(MetricGenerator):
-
-        def compute_metric(self, manager):
-            return 5
-
-    generator = temp_generator()
+    generator = TempGenerator()
     temp_metric = TimeRangePlottingMetric(title=title,
                                           value=value,
                                           time_range=time_range,
@@ -141,12 +130,7 @@ def test_single_timeplottingmetric():
     value = 5
     timestamp = datetime.datetime.now()
 
-    class temp_generator(MetricGenerator):
-
-        def compute_metric(self, manager):
-            return 5
-
-    generator = temp_generator()
+    generator = TempGenerator()
     temp_metric = SingleTimePlottingMetric(title=title,
                                            value=value,
                                            timestamp=timestamp,


### PR DESCRIPTION
While working on a metrics example (upcoming PR ...) with `ClearMotMetrics` and `MultiManager`, I recognized that the latter [expects](https://github.com/kopytjuk/Stone-Soup/blob/0b649df4b78b5059794e072579e670013ac4af98/stonesoup/metricgenerator/manager.py#L93) passed metric generators to have a `generator_name` property, which the `ClearMotMetrics` did not have.

Thus, I added the following:

- Added `generator_name` abstract property to `MultiManager` to make it clear for future developers to follow this protocol
- Added `generator_name` property to `ClearMotMetrics`