### PR TITLE
Platform orientation calculated from previous velocity

### DIFF
--- a/stonesoup/movable/movable.py
+++ b/stonesoup/movable/movable.py
@@ -295,8 +295,8 @@ class MovingMovable(Movable):
                 _, bearing = cart2pol(*velocity.flat)
                 self._property_orientation = StateVector([0, 0, bearing])
             else:
-                raise NotImplementedError('Orientation of a moving platform is only implemented for 2'
-                                          'and 3 dimensions')
+                raise NotImplementedError('Orientation of a moving platform is only' 
+                                          'implemented for 2 and 3 dimensions')
 
         return self._property_orientation
 

--- a/stonesoup/movable/movable.py
+++ b/stonesoup/movable/movable.py
@@ -295,7 +295,7 @@ class MovingMovable(Movable):
                 _, bearing = cart2pol(*velocity.flat)
                 self._property_orientation = StateVector([0, 0, bearing])
             else:
-                raise NotImplementedError('Orientation of a moving platform is only' 
+                raise NotImplementedError('Orientation of a moving platform is only'
                                           'implemented for 2 and 3 dimensions')
 
         return self._property_orientation

--- a/stonesoup/movable/movable.py
+++ b/stonesoup/movable/movable.py
@@ -266,22 +266,39 @@ class MovingMovable(Movable):
 
         Notes
         -----
-        A non-moving platform (``self.is_moving == False``) does not have a defined orientation in
-        this approximations and so raises an :class:`AttributeError`
+        Where the velocity of the platform is small, the orientation is calculated based
+        on the direction it travelled from its previous position.
+        Where the platform has only moved a small distance, and for a non-moving platform
+        (``self.is_moving == False``) the orientation from the previous
+        time step is used.
         """
-        if not self.is_moving:
-            raise AttributeError('Orientation of a zero-velocity moving platform is not defined')
-        velocity = self.velocity
+        # For low velocity platforms, calculate orientation based on previous position
+        if len(self) >= 2 and np.linalg.norm(self.velocity) < 1e-6 and 2 <= self.ndim <= 3:
+            c_pos = self.position
+            p_pos = self[-2].state_vector[self.position_mapping, ]
+            # If change in position is very small, return previous orientation
+            if np.linalg.norm(c_pos - p_pos) < 1e-6:
+                return self._property_orientation
+            if self.ndim == 2:
+                _, bearing = cart2pol(*(c_pos - p_pos))
+                elevation = 0
+            else:
+                _, bearing, elevation = cart2sphere(*(c_pos - p_pos))
+            self._property_orientation = StateVector([0, elevation, bearing])
 
-        if self.ndim == 3:
-            _, bearing, elevation = cart2sphere(*velocity.flat)
-            return StateVector([0, elevation, bearing])
-        elif self.ndim == 2:
-            _, bearing = cart2pol(*velocity.flat)
-            return StateVector([0, 0, bearing])
-        else:
-            raise NotImplementedError('Orientation of a moving platform is only implemented for 2'
-                                      'and 3 dimensions')
+        elif self.is_moving:
+            velocity = self.velocity
+            if self.ndim == 3:
+                _, bearing, elevation = cart2sphere(*velocity.flat)
+                self._property_orientation = StateVector([0, elevation, bearing])
+            elif self.ndim == 2:
+                _, bearing = cart2pol(*velocity.flat)
+                self._property_orientation = StateVector([0, 0, bearing])
+            else:
+                raise NotImplementedError('Orientation of a moving platform is only implemented for 2'
+                                          'and 3 dimensions')
+
+        return self._property_orientation
 
     @property
     def is_moving(self) -> bool:

--- a/stonesoup/movable/movable.py
+++ b/stonesoup/movable/movable.py
@@ -277,7 +277,7 @@ class MovingMovable(Movable):
         if not self.is_moving:
             self._property_orientation = StateVector([0, 0, 0])
             warnings.warn('A default initial orientation has been set as StateVector([0, 0, 0])')
-        
+
         # For low velocity platforms, calculate orientation based on previous position
         if len(self) >= 2 and np.linalg.norm(self.velocity) < 1e-6 and 2 <= self.ndim <= 3:
             c_pos = self.position

--- a/stonesoup/movable/movable.py
+++ b/stonesoup/movable/movable.py
@@ -2,6 +2,7 @@ import datetime
 from abc import abstractmethod, ABC
 from functools import lru_cache
 from typing import Sequence, Tuple, MutableSequence, Optional
+import warnings
 
 import numpy as np
 from math import cos, sin
@@ -272,6 +273,11 @@ class MovingMovable(Movable):
         (``self.is_moving == False``) the orientation from the previous
         time step is used.
         """
+
+        if not self.is_moving:
+            self._property_orientation = StateVector([0, 0, 0])
+            warnings.warn('A default initial orientation has been set as StateVector([0, 0, 0])')
+        
         # For low velocity platforms, calculate orientation based on previous position
         if len(self) >= 2 and np.linalg.norm(self.velocity) < 1e-6 and 2 <= self.ndim <= 3:
             c_pos = self.position

--- a/stonesoup/platform/tests/test_platform_base.py
+++ b/stonesoup/platform/tests/test_platform_base.py
@@ -333,25 +333,25 @@ def test_low_velocity_orientation():
 
     transition_model = CombinedLinearGaussianTransitionModel(
         [ConstantVelocity(0.), ConstantVelocity(0.), ConstantVelocity(0.)])
-    
+
     platform = MovingPlatform(states=platform_state,
                               position_mapping=(0, 2, 4),
                               velocity_mapping=(1, 3, 5),
                               transition_model=transition_model)
-    assert np.allclose(platform.orientation, [[0],[0],[0]])
-    
+    assert np.allclose(platform.orientation, [[0], [0], [0]])
+
     timediff = 2  # 2sec
     new_timestamp = timestamp + datetime.timedelta(seconds=timediff)
     platform.move(new_timestamp)
     # platform has moved diagonally, velocity is low
     platform.state.state_vector = StateVector([1, 1e-7, 1, 0, 0, 0])
-    assert np.allclose(platform.orientation, [[0],[0],[0.78539816]])
+    assert np.allclose(platform.orientation, [[0], [0], [0.78539816]])
 
     new_timestamp2 = timestamp + datetime.timedelta(seconds=timediff)
     platform.move(new_timestamp2)
     # platform has moved in x direction by small distance, velocity is low
     platform.state.state_vector = StateVector([1+1e-7, 1e-7, 1, 0, 0, 0])
-    assert np.allclose(platform.orientation, [[0],[0],[0.78539816]])
+    assert np.allclose(platform.orientation, [[0], [0], [0.78539816]])
 
 
 # noinspection PyPropertyAccess


### PR DESCRIPTION
Slight change to how orientation is calculated for moving platforms. Where the velocity of the platform is small, the orientation is calculated based on the direction it travelled from its previous position. Where the platform has only moved a small distance, and for a non-moving platform the orientation from the previous time step is used.