### PR TITLE
Add init file for proposal class

### DIFF
--- a/stonesoup/proposal/__init__.py
+++ b/stonesoup/proposal/__init__.py
@@ -1,0 +1,3 @@
+from .base import Proposal
+
+__all__ = ['Proposal']


### PR DESCRIPTION
A missing `__init__` file in the proposal class created a problem when calling stonesoup as a module. 

Spotted by @sglvladi 