### PR TITLE
Small error PointProcessUpdater regarding the use of the survival probability term

### DIFF
--- a/stonesoup/updater/pointprocess.py
+++ b/stonesoup/updater/pointprocess.py
@@ -75,7 +75,8 @@ class PointProcessUpdater(Base):
                     cov=measurement_prediction.covar
                 )
                 new_weight = self.prob_detection\
-                    * prediction.weight * q * self.prob_survival
+                    * prediction.weight * q
+                if prediction.tag != 'birth': new_weight *= self.prob_survival
                 weight_sum += new_weight
                 # Perform single target Kalman Update
                 temp_updated_component = self.updater.update(hypothesis)
@@ -105,7 +106,7 @@ class PointProcessUpdater(Base):
                 component = TaggedWeightedGaussianState(
                     tag=missed_detected_hypotheses.prediction.tag,
                     weight=missed_detected_hypotheses.prediction.weight
-                    * (1-self.prob_detection) * l1,
+                    * (1-self.prob_detection) * l1 * self.prob_survival,
                     state_vector=missed_detected_hypotheses.prediction.mean,
                     covar=missed_detected_hypotheses.prediction.covar,
                     timestamp=missed_detected_hypotheses.prediction.timestamp)

--- a/stonesoup/updater/pointprocess.py
+++ b/stonesoup/updater/pointprocess.py
@@ -76,7 +76,8 @@ class PointProcessUpdater(Base):
                 )
                 new_weight = self.prob_detection\
                     * prediction.weight * q
-                if prediction.tag != 'birth': new_weight *= self.prob_survival
+                if prediction.tag != 'birth':
+                    new_weight *= self.prob_survival
                 weight_sum += new_weight
                 # Perform single target Kalman Update
                 temp_updated_component = self.updater.update(hypothesis)


### PR DESCRIPTION
I believe I noticed a small error in your PointProcessUpdater component regarding the use of the survival probability term

Point 1 (line 78) To be fully consistent with Mr. Vo's pseudocode, it is necessary to discriminate between new and existing targets when applying survival probability. Indeed, only the weight of existing targets should be multiplied by the survival probability. Therefore, it seems that a test is missing at this point. It should be noted that this is not a critical issue, as it only results in a different weighting for the components related to spontaneous births.

Point 2 (line 108): added "* self.prob_survival".
When you process the "missed_detection" hypotheses, it seems that the survival probability is not taken into account (note: the correction term l1 is always 1). However, it  should apply to all existing targets, even those without detection in current scan.