### PR TITLE
Monte Carlo Tree Search action value correction

### DIFF
--- a/stonesoup/sensormanager/tree_search.py
+++ b/stonesoup/sensormanager/tree_search.py
@@ -57,8 +57,8 @@ class MonteCarloTreeSearchSensorManager(SensorManager):
     predicted future state which is used to calculate the action value of this node.
     This is done by providing a :attr:`reward_function`. Finally, this reward is
     added to the node action value, discounted appropriately according to the
-    depth into the future, and combined withaction values of parent nodes (that
-    were descended durting selection) when completing the backpropagation process.
+    depth into the future, and combined with action values of parent nodes (that
+    were descended during selection) when completing the backpropagation process.
     This creates a tradeoff between future and immediate rewards during the next
     iteration of the search process.
 
@@ -105,7 +105,7 @@ class MonteCarloTreeSearchSensorManager(SensorManager):
     discount_factor: float = Property(
         default=0.9,
         doc="The discount factor is applied to rewards beyond the immidiate future timestep "
-            "to reduce the reward of future nodes to refelct the increasing level of uncertainty "
+            "to reduce the reward of future nodes to reflect the increasing level of uncertainty "
             "the further into the horizon the search progresses. It is applied multiplicatively "
             "such that the factor will be raised by power of the number of timesteps "
             "beyond the immidiate future timestep.")

--- a/stonesoup/sensormanager/tree_search.py
+++ b/stonesoup/sensormanager/tree_search.py
@@ -3,6 +3,7 @@ import itertools as it
 from datetime import timedelta
 from typing import Callable
 from enum import Enum
+import warnings
 
 import numpy as np
 
@@ -38,7 +39,7 @@ class MonteCarloTreeSearchSensorManager(SensorManager):
         \text{argmax}_{a} \frac{Q(h, a)}{N(h, a)}+c\sqrt{\frac{\log N(h)}{N(h,a)}},
 
     where :math:`a` is the action, :math:`h` is the history (for POMDP problems a
-    history or belief is commonly used but in MDP problems h would be replaced
+    history or belief is commonly used but in MDP problems :math:`h` would be replaced
     with a state), :math:`Q(h, a)` is the current cumulative action value estimate,
     :math:`N(h, a)` is the number of visits or simulations of this node, :math:`N(h)`
     is the number of visits to the parent node and :math:`c` is the exploration factor,
@@ -55,25 +56,26 @@ class MonteCarloTreeSearchSensorManager(SensorManager):
     generated detection after applying the candidate action. This provides a
     predicted future state which is used to calculate the action value of this node.
     This is done by providing a :attr:`reward_function`. Finally, this reward is
-    added to the current action value estimated in each node on the search tree
-    branch that was descended during selection. This creates a tradeoff between future
-    and immediate rewards during the next iteration of the search process.
+    added to the node action value, discounted appropriately according to the
+    depth into the future, and combined withaction values of parent nodes (that
+    were descended durting selection) when completing the backpropagation process.
+    This creates a tradeoff between future and immediate rewards during the next
+    iteration of the search process.
 
     Once a predefined computational budget has been reached, which in this implementation
     is the :attr:`niterations` attribute, the best child to the root node in the tree
     is determined and returned from the :meth:`choose_actions`. The user can select which
     criteria used to select this best action by defining the :attr:`best_child_policy`.
-    Further detail on this particular implementation, including the rollout process in
-    :class:`~.MCTSRolloutSensorManager` can be seen in work by Glover et al [1]_.
-    Further detail on MCTS and its variations can also be seen in [2]_.
+    The initial implementation of MCTS with rollout (:class:`~.MCTSRolloutSensorManager`)
+    can be seen in work by Glover et al [1]_ and further detail on MCTS and its
+    variations can also be seen in [2]_.
 
     References
     ----------
     .. [1] Glover, Timothy & Nanavati, Rohit V. & Coombes, Matthew & Liu, Cunjia &
            Chen, Wen-Hua & Perree, Nicola & Hiscocks, Steven. "A Monte Carlo Tree Search
            Framework for Autonomous Source Term Estimation in Stone Soup, 2024 27th
-           International Conference on Information Fusion (FUSION), 1-8, 2024. Accepted,
-           awaiting publication"
+           International Conference on Information Fusion (FUSION), 1-8, 2024"
     .. [2] Kochenderfer, Mykel J. & Wheeler, Tim A. & Wray, Kyle H. "Algorithms for
            decision making", MIT Press, 2022 (https://algorithmsbook.com/)
     """
@@ -98,13 +100,28 @@ class MonteCarloTreeSearchSensorManager(SensorManager):
         doc="The policy for selecting the best child. Options are ``'max_average_reward'`` for "
             "the maximum reward per visit to a node, ``'max_cumulative_reward'`` for the maximum "
             "total reward after all simulations and ``'max_visits'`` for the node with the "
-            "maximum number of visits. Default is ``'max_cumulative_reward'``."
-    )
+            "maximum number of visits. Default is ``'max_cumulative_reward'``.")
+
+    discount_factor: float = Property(
+        default=0.9,
+        doc="The discount factor is applied to rewards beyond the immidiate future timestep "
+            "to reduce the reward of future nodes to refelct the increasing level of uncertainty "
+            "the further into the horizon the search progresses. It is applied multiplicatively "
+            "such that the factor will be raised by power of the number of timesteps "
+            "beyond the immidiate future timestep.")
+
+    search_depth: int = Property(
+        default=None,
+        doc="The maximum depth to apply to the search tree, specifying the maximum number of "
+            "future timesteps to expand to.")
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         # Ensure birth scheme is a valid BirthSchemeEnum
         self.best_child_policy = MCTSBestChildPolicyEnum(self.best_child_policy)
+        # if search depth none, replace with inf to allow logical operations
+        if not self.search_depth:
+            self.search_depth = np.inf
 
     def choose_actions(self, tracks, timestamp, nchoose=1, **kwargs):
         """Returns a list of actions that reflect the best child nodes to the
@@ -132,6 +149,7 @@ class MonteCarloTreeSearchSensorManager(SensorManager):
                   'action_count': 0,
                   'visits': 0,
                   'reward': 0,
+                  'action_value': 0,
                   'tracks': copy.deepcopy(tracks),
                   'timestamp': timestamp-self.time_step,
                   'level': 0}]
@@ -142,64 +160,76 @@ class MonteCarloTreeSearchSensorManager(SensorManager):
             # select best child node
             node_indx = 0
             selected_branch = [0]
-            level = 1
+            level = 0
             while (len(nodes[node_indx]['Child_IDs']) > 0 and
                    len(nodes[node_indx]['Child_IDs']) == nodes[node_indx]['action_count']):
                 node_indx = self.tree_policy(nodes, node_indx)
                 selected_branch.insert(0, node_indx)
                 level += 1
 
-            next_timestamp = nodes[node_indx]['timestamp'] + self.time_step
-            if not nodes[node_indx]['Child_IDs']:
-                action_count = 1
-                all_action_choices = dict()
+            if level <= self.search_depth:
 
-                for sensor in nodes[node_indx]['sensors']:
-                    # get action 'generator(s)'
-                    action_generators = sensor.actions(next_timestamp)
-                    # list possible action combinations for the sensor
-                    action_choices = list(it.product(*action_generators))
-                    if len(action_choices) != 1 and len(action_choices[0]) != 0:
-                        action_count *= len(action_choices)
-                    # dictionary of sensors: list(action combinations)
-                    all_action_choices[sensor] = action_choices
+                next_timestamp = nodes[node_indx]['timestamp'] + self.time_step
+                if not nodes[node_indx]['Child_IDs']:
+                    action_count = 1
+                    all_action_choices = dict()
 
-                nodes[node_indx]['action_count'] = action_count
-                configs = [{sensor: action
-                            for sensor, action in zip(all_action_choices.keys(), actionconfig)}
-                           for actionconfig in it.product(*all_action_choices.values())]
+                    for sensor in nodes[node_indx]['sensors']:
+                        # get action 'generator(s)'
+                        action_generators = sensor.actions(next_timestamp)
+                        # list possible action combinations for the sensor
+                        action_choices = list(it.product(*action_generators))
+                        if len(action_choices) != 1 and len(action_choices[0]) != 0:
+                            action_count *= len(action_choices)
+                        # dictionary of sensors: list(action combinations)
+                        all_action_choices[sensor] = action_choices
 
-                nodes[node_indx]['configs'] = configs
+                    nodes[node_indx]['action_count'] = action_count
+                    configs = [{sensor: action
+                                for sensor, action in zip(all_action_choices.keys(), actionconfig)}
+                               for actionconfig in it.product(*all_action_choices.values())]
 
-            # select one of the unsimulated configs
-            config_indx = np.random.randint(0, len(nodes[node_indx]['configs']))
-            nodes[node_indx]['Child_IDs'].append(len(nodes))
-            selected_branch.insert(0, len(nodes))
-            nodes.append({'Child_IDs': [],
-                          'sensors': set(),
-                          'config': nodes[node_indx]['configs'][config_indx],
-                          'configs': [],
-                          'action_count': 0,
-                          'visits': 0,
-                          'reward': 0,
-                          'timestamp': next_timestamp,
-                          'tracks': set(),
-                          'level': level})
+                    nodes[node_indx]['configs'] = configs
 
-            selected_config = copy.deepcopy(nodes[node_indx]['configs'].pop(config_indx))
+                # select one of the unsimulated configs
+                config_indx = np.random.randint(0, len(nodes[node_indx]['configs']))
+                nodes[node_indx]['Child_IDs'].append(len(nodes))
+                selected_branch.insert(0, len(nodes))
+                nodes.append({'Child_IDs': [],
+                              'sensors': set(),
+                              'config': nodes[node_indx]['configs'][config_indx],
+                              'configs': [],
+                              'action_count': 0,
+                              'visits': 0,
+                              'reward': 0,
+                              'action_value': 0,
+                              'timestamp': next_timestamp,
+                              'tracks': set(),
+                              'level': level})
 
-            reward, updates = self.simulate_action(nodes[-1], nodes[node_indx])
+                selected_config = copy.deepcopy(nodes[node_indx]['configs'].pop(config_indx))
 
-            nodes[-1]['tracks'] = updates
+                reward, future_reward, updates = self.simulate_action(nodes[-1], nodes[node_indx])
 
-            for sensor, actions in selected_config.items():
-                sensor.add_actions(actions)
-                sensor.act(nodes[-1]['timestamp'])
-                nodes[-1]['sensors'].add(sensor)
+                nodes[-1]['tracks'] = updates
+                nodes[-1]['reward'] = reward  # store immidiate reward as 'reward'
 
+                for sensor, actions in selected_config.items():
+                    sensor.add_actions(actions)
+                    sensor.act(nodes[-1]['timestamp'])
+                    nodes[-1]['sensors'].add(sensor)
+
+            else:
+                # search depth reached
+                future_reward = 0
+
+            # if future_reward is None, assign it as 0
+            sim_action_value = future_reward if future_reward else 0
             for node_id in selected_branch:
                 nodes[node_id]['visits'] += 1
-                nodes[node_id]['reward'] += reward
+                sim_action_value += nodes[node_id]['reward']
+                nodes[node_id]['action_value'] += sim_action_value
+                sim_action_value *= self.discount_factor
 
         best_children = self.select_best_child(nodes)
         selected_configs = []
@@ -214,7 +244,7 @@ class MonteCarloTreeSearchSensorManager(SensorManager):
 
         uct = []
         for Child_ID in nodes[node_indx]['Child_IDs']:
-            uct.append(nodes[Child_ID]['reward']/nodes[Child_ID]['visits'] +
+            uct.append(nodes[Child_ID]['action_value']/nodes[Child_ID]['visits'] +
                        self.exploration_factor*np.sqrt(np.log(nodes[node_indx]['visits'])
                                                        / nodes[Child_ID]['visits']))
 
@@ -229,7 +259,7 @@ class MonteCarloTreeSearchSensorManager(SensorManager):
         reward_list = []
         for Child_ID in nodes[0]['Child_IDs']:
             visit_list.append(nodes[Child_ID]['visits'])
-            reward_list.append(nodes[Child_ID]['reward'])
+            reward_list.append(nodes[Child_ID]['action_value'])
 
         if self.best_child_policy == MCTSBestChildPolicyEnum.MAXCREWARD:
             max_indx = np.argmax(reward_list)
@@ -247,8 +277,9 @@ class MonteCarloTreeSearchSensorManager(SensorManager):
         reward, updates = self.reward_function(node['config'],
                                                parent_node['tracks'],
                                                node['timestamp'])
+        future_reward = None
 
-        return reward, updates
+        return reward, future_reward, updates
 
 
 class MCTSRolloutSensorManager(MonteCarloTreeSearchSensorManager):
@@ -257,12 +288,17 @@ class MCTSRolloutSensorManager(MonteCarloTreeSearchSensorManager):
     with :class:`~.MonteCarloTreeSearchSensorManager`"""
 
     rollout_depth: int = Property(
-        default=1, doc="The depth of rollout to conduct for each node.")
+        default=None,
+        doc="The depth of rollout to conduct for each node. This is only used when "
+            ":attr:`search_depth` is not set or set to `None`.")
 
-    discount_factor: float = Property(
-        default=0.9, doc="The discount factor is applied to each action evaluated in the "
-                         "tree to assign an incrementally lower multiplier to future actions "
-                         "in the tree.")
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # warn about rollout_depth not being considered when search depth in specified
+        if self.search_depth < np.inf and self.rollout_depth:
+            warnings.warn('`search_depth` and `rollout_depth` have been defined. '
+                          '`search_depth` overrides rollout depth and forces rollout '
+                          'to end at `search_depth`!')
 
     def simulate_action(self, node, parent_node):
         """Simulates the expected reward that would be received by executing
@@ -283,7 +319,9 @@ class MCTSRolloutSensorManager(MonteCarloTreeSearchSensorManager):
             tmp_sensors.add(sensor)
 
         # execute Monte Carlo Rollout from the new node
-        for d in range(self.rollout_depth):
+        n_steps = self.rollout_depth if np.isinf(self.search_depth) \
+            else self.search_depth - node['level']
+        for d in range(n_steps):
             all_action_choices = dict()
             timestamp = node['timestamp'] + ((d + 1) * self.time_step)
 
@@ -314,5 +352,5 @@ class MCTSRolloutSensorManager(MonteCarloTreeSearchSensorManager):
                 sensor.add_actions(actions)
                 sensor.act(timestamp)
 
-        final_reward = sum(reward_list)
-        return final_reward, updates
+        rollout_reward = sum(reward_list[1:])
+        return reward_list[0], rollout_reward, updates


### PR DESCRIPTION
This pull request modifies the action value calculation for Monte Carlo tree search. The fix is most relevant for `MCTSRolloutSensorManager` and introduces a maximum search depth class property that specifies the maximum number of time steps into the future that the algorithm can search to, and ensures that all policy rollouts run to this time step, rather than ensuring that rollouts are run for the same duration. The action value is cumulatively calculated as the sum of all simulation results, recalling previously estimated reward values at existing nodes in the search tree. This fix will correct the over exploratory nature of the algorithm that was happening before the fix.

The MCTS sensor management example has been modified to use the `search_depth` rather than `rollout_depth` to encourage best practice with the algorithm.

Tests have also been modified to incorporate the changes.