### PR TITLE
Fix StateMutableSequence to allow for subclasses with mandatory properties

### DIFF
--- a/stonesoup/movable/tests/test_movable.py
+++ b/stonesoup/movable/tests/test_movable.py
@@ -32,7 +32,7 @@ def test_empty_state_error():
                       velocity_mapping=[1, 2, 5],
                       transition_model=None,
                       )
-    with pytest.raises(ValueError, match='States must not be empty'):
+    with pytest.raises(TypeError, match="MovingMovable is missing a required argument: 'states'"):
         _ = MovingMovable(position_mapping=[0, 2, 4],
                           velocity_mapping=[1, 2, 5],
                           transition_model=None,

--- a/stonesoup/types/state.py
+++ b/stonesoup/types/state.py
@@ -308,13 +308,13 @@ class StateMutableSequence(Type, MutableSequence):
         default=None,
         doc="The initial list of states. Default `None` which initialises with empty list.")
 
-    def __init__(self, states=None, *args, **kwargs):
-        if states is None:
-            states = []
-        elif not isinstance(states, Sequence):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if self.states is None:
+            self.states = []
+        elif not isinstance(self.states, Sequence):
             # Ensure states is a list
-            states = [states]
-        super().__init__(states, *args, **kwargs)
+            self.states = [self.states]
 
     def __len__(self):
         return self.states.__len__()

--- a/stonesoup/types/tests/test_state.py
+++ b/stonesoup/types/tests/test_state.py
@@ -600,6 +600,64 @@ def test_state_mutable_sequence_copy():
     assert sequence2[-1] is not sequence[-1]
 
 
+def test_state_mutable_sequence_subclass():
+    class TestSMS(StateMutableSequence):
+        test_property = Property(cls=int)
+        test_property_with_default = Property(default=2, cls=int)
+
+    state = State(StateVector([[0]]), timestamp=datetime.datetime.now())
+
+    sequence = TestSMS(1)
+    assert sequence.test_property == 1
+    assert sequence.test_property_with_default == 2
+    assert sequence.states == []
+
+    sequence = TestSMS(test_property=1)
+    assert sequence.test_property == 1
+    assert sequence.test_property_with_default == 2
+    assert sequence.states == []
+
+    sequence = TestSMS(1, state)
+    assert sequence.test_property == 1
+    assert sequence.test_property_with_default == 2
+    assert sequence.states == [state]
+
+    sequence = TestSMS(1, states=[state])
+    assert sequence.test_property == 1
+    assert sequence.test_property_with_default == 2
+    assert sequence.states == [state]
+
+    sequence = TestSMS(test_property=1, states=[state])
+    assert sequence.test_property == 1
+    assert sequence.test_property_with_default == 2
+    assert sequence.states == [state]
+
+    sequence = TestSMS(test_property=1, test_property_with_default=3)
+    assert sequence.test_property == 1
+    assert sequence.test_property_with_default == 3
+    assert sequence.states == []
+
+    sequence = TestSMS(1, [state], 3)
+    assert sequence.test_property == 1
+    assert sequence.test_property_with_default == 3
+    assert sequence.states == [state]
+
+    sequence = TestSMS(1, [state], test_property_with_default=3)
+    assert sequence.test_property == 1
+    assert sequence.test_property_with_default == 3
+    assert sequence.states == [state]
+
+    sequence = TestSMS(1, states=[state], test_property_with_default=3)
+    assert sequence.test_property == 1
+    assert sequence.test_property_with_default == 3
+    assert sequence.states == [state]
+
+    sequence = TestSMS(test_property=1, states=[state], test_property_with_default=3)
+    assert sequence.test_property == 1
+    assert sequence.test_property_with_default == 3
+    assert sequence.states == [state]
+
+
 def test_from_state():
     start = datetime.datetime.now()
     kwargs = {"state_vector": np.arange(4), "timestamp": start}


### PR DESCRIPTION
Thank you for nice software.

In this PR, I fixed StateMutableSequence so that its subclasses can have mandatory properties. Indeed, if a subclass has a mandatory property, the subclass cannot be instantiated, or its mandatory property will be unexpectedly put in a list, depending on how arguments are passed to the constructor (see the changes in `stonesoup/types/tests/test_state.py`). A simple fix can resolve this issue.

There is one side effect that affects the error raised by `MovingMovable` when it is instantiated without specifying the mandatory argument "states". This change has made a test for MovingMovable fail, although I think for most users, the change itself is harmless. Therefore, I fix the test to make it pass.