### PR TITLE
Check for State type more explicitly with StateMutableSequence

### DIFF
--- a/stonesoup/metricgenerator/ospametric.py
+++ b/stonesoup/metricgenerator/ospametric.py
@@ -127,7 +127,7 @@ class GOSPAMetric(MetricGenerator):
         state_list = StateMutableSequence()
         ids = []
         for i, element in enumerate(list(object_with_states)):
-            if isinstance(element, StateMutableSequence):
+            if isinstance(element, StateMutableSequence) and not isinstance(element, State):
                 states = list(element.last_timestamp_generator())
                 state_list.extend(states)
                 ids.extend([i]*len(states))

--- a/stonesoup/metricgenerator/uncertaintymetric.py
+++ b/stonesoup/metricgenerator/uncertaintymetric.py
@@ -54,7 +54,7 @@ class _CovarianceNormsMetric(MetricGenerator):
 
         state_list = StateMutableSequence()
         for element in list(object_with_states):
-            if isinstance(element, StateMutableSequence):
+            if isinstance(element, StateMutableSequence) and not isinstance(element, State):
                 state_list.extend(element.states)
             elif isinstance(element, State):
                 state_list.append(element)

--- a/stonesoup/predictor/_utils.py
+++ b/stonesoup/predictor/_utils.py
@@ -1,6 +1,6 @@
 import functools
 
-from ..types.state import StateMutableSequence
+from ..types.state import State, StateMutableSequence
 
 
 def predict_lru_cache(*args, **kwargs):
@@ -19,7 +19,7 @@ def predict_lru_cache(*args, **kwargs):
 
         @functools.wraps(func)
         def predict(self, prior, *args, **kwargs):
-            if isinstance(prior, StateMutableSequence):
+            if isinstance(prior, StateMutableSequence) and not isinstance(prior, State):
                 prior = prior.state
             return func(self, prior, *args, **kwargs)
         return predict

--- a/stonesoup/types/state.py
+++ b/stonesoup/types/state.py
@@ -63,7 +63,7 @@ class State(Type):
             on the `state` parameter.
         """
         # Handle being initialised with state sequence
-        if isinstance(state, StateMutableSequence):
+        if isinstance(state, StateMutableSequence) and not isinstance(state, State):
             state = state.state
 
         if target_type is None:
@@ -155,7 +155,7 @@ class CreatableFromState:
             those on the ``state`` parameter.
         """
         # Handle being initialised with state sequence
-        if isinstance(state, StateMutableSequence):
+        if isinstance(state, StateMutableSequence) and not isinstance(state, State):
             state = state.state
         try:
             state_type = next(type_ for type_ in type(state).mro()


### PR DESCRIPTION
There is some inconsistent behaviour between Python versions, whether running code in debug or tests run; that effect the isinstance check with States that may have properties similar to StateMutableSequnce type.

This particularly seems to effect ASDState, and multi-model particle states. This extra check now ensure that anything that in itself is defined as a State type is mistaken.