### PR TITLE
Sample Position Action Generator and Movable

### DIFF
--- a/docs/source/stonesoup.movable.rst
+++ b/docs/source/stonesoup.movable.rst
@@ -16,3 +16,10 @@ Grid-based Movables
 
 .. automodule:: stonesoup.movable.grid
     :show-inheritance:
+
+
+Sample-based Movables
+---------------------
+
+.. automodule:: stonesoup.movable.sample
+    :show-inheritance:

--- a/stonesoup/movable/action/__init__.py
+++ b/stonesoup/movable/action/__init__.py
@@ -1,0 +1,7 @@
+from .move_position_action import MovePositionAction, GridActionGenerator, \
+    NStepDirectionalGridActionGenerator, SamplePositionActionGenerator, \
+    CircleSamplePositionActionGenerator
+
+
+__all__ = ['MovePositionAction', 'GridActionGenerator', 'NStepDirectionalGridActionGenerator',
+           'SamplePositionActionGenerator', 'CircleSamplePositionActionGenerator']

--- a/stonesoup/movable/action/move_position_action.py
+++ b/stonesoup/movable/action/move_position_action.py
@@ -104,3 +104,105 @@ class NStepDirectionalGridActionGenerator(GridActionGenerator):
                     yield MovePositionAction(generator=self,
                                              end_time=self.end_time,
                                              target_value=target_value)
+
+
+class SamplePositionActionGenerator(ActionGenerator):
+    """Base action generator for sampling approaches to action generation. The action
+    generator requires the user to define a number of samples to generate
+    (:attr:`n_samples`) according to the defined sampling technique."""
+
+    action_space: np.ndarray = Property(
+        default=None,
+        doc="The bounds of the action space that should not be exceeded. Of shape (ndim, 2) "
+            "where ndim is the length of the action_mapping. For example, "
+            ":code:`np.array([[xmin, xmax], [ymin, ymax]])`."
+    )
+
+    action_mapping: Sequence[int] = Property(
+        default=(0, 1),
+        doc="The state dimensions that actions are applied to."
+    )
+
+    n_samples: int = Property(
+        default=10,
+        doc="Number of samples to generate. This does not include the action "
+        "to remain at the current position, meaning :attr:`n_samples` +1 "
+        "actions will be generated."
+    )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        if self.action_space is not None:
+            if len(self.action_space) != len(self.action_mapping):
+                raise ValueError(f"Dimensions of action_space {self.action_space.shape} "
+                                 f"are not compatible with action_mapping of length "
+                                 f"{len(self.action_mapping)}. action_space should be "
+                                 f"of shape (ndim, 2) where ndim is the length of the "
+                                 f"action_mapping.")
+
+            if (np.any(self.current_value[self.action_mapping, :] < self.action_space[:, [0]])
+                    or np.any(self.current_value[self.action_mapping, :] > self.action_space[:, [1]])):  # noqa: E501
+                raise ValueError(f"Initial platform location {self.current_value} is not within "
+                                 f"the bounds of the action space {self.action_space}.")
+
+    @property
+    def default_action(self):
+        return MovePositionAction(generator=self,
+                                  end_time=self.end_time,
+                                  target_value=self.current_value)
+
+    def __contains__(self, item):
+        return item in iter(self)
+
+    @abstractmethod
+    def __iter__(self):
+        raise NotImplementedError
+
+
+class CircleSamplePositionActionGenerator(SamplePositionActionGenerator):
+    """Action generator which samples candidate future positions uniformly within
+    a circle around the current position. Circle radius is defined by the user
+    with :attr:`maximum_travel`. This generator is only applicable to 2D position
+    actions."""
+
+    maximum_travel: float = Property(
+        default=1.0,
+        doc="Maximum possible travel distance. Specifies the radius of "
+        "sampling area."
+    )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        if self.action_space is not None and len(self.action_space) != 2:
+            raise ValueError(f"Action mapping {self.action_mapping} does "
+                             f"not have 2 dimensions. "
+                             f":class:`~.CircleSamplePositionActionGenerator` "
+                             f"is designed for 2D action generation only.")
+
+    def __iter__(self):
+
+        yield MovePositionAction(generator=self,
+                                 end_time=self.end_time,
+                                 target_value=self.current_value)
+
+        generated_samples = 0
+
+        while generated_samples < self.n_samples:
+
+            radius_angle_sample = np.random.uniform([0, 0], [1, 2*np.pi], 2)
+
+            value = self.maximum_travel*np.sqrt(radius_angle_sample[0]) *\
+                np.array([[np.sin(radius_angle_sample[1])], [np.cos(radius_angle_sample[1])]])
+
+            target_value = self.current_value + value
+
+            if self.action_space is None or \
+                (np.all(target_value[self.action_mapping, :] >= self.action_space[:, [0]])
+                 and np.all(target_value[self.action_mapping, :] <= self.action_space[:, [1]])):
+
+                generated_samples += 1
+                yield MovePositionAction(generator=self,
+                                         end_time=self.end_time,
+                                         target_value=target_value)

--- a/stonesoup/movable/action/tests/test_move_position_action.py
+++ b/stonesoup/movable/action/tests/test_move_position_action.py
@@ -7,6 +7,7 @@ import copy
 from ....types.state import StateVector, State, StateVectors
 from ....platform import FixedPlatform
 from ...grid import NStepDirectionalGridMovable
+from ...sample import CircleSampleActionableMovable
 
 
 @pytest.mark.parametrize(
@@ -136,3 +137,130 @@ def test_n_step_directional_grid_action_gen(generator_params, state, position_ma
     platform.act(end_timestamp)
 
     assert np.all(np.isclose(platform.position, actions[1]))
+
+
+@pytest.mark.parametrize(
+    'gen_param_dict, state, position_mapping',
+    [
+        (
+            {'n_samples': None,
+             'action_space': None,
+             'action_mapping': (0, 1),
+             'maximum_travel': 4},
+            StateVector([0.0, 0.0]),  # state
+            (0, 1)  # position_mapping
+        ), (
+            {'n_samples': 15,
+             'action_space': StateVectors([[-5, 5], [-5, 5]]),
+             'action_mapping': (0, 1),
+             'maximum_travel': None},
+            StateVector([0.0, 0.0]),  # state
+            (0, 1)  # position_mapping
+        ), (
+            {'n_samples': 20,
+             'action_space': StateVectors([[-10, 5], [-10, 5]]),
+             'action_mapping': (0, 1),
+             'maximum_travel': 10},
+            StateVector([2.0, 3.0, 2.0]),  # state
+            (0, 1)  # position_mapping
+        ), (
+            {'n_samples': 20,
+             'action_space': StateVectors([[-5, 5], [-5, 5]]),
+             'action_mapping': (0, 1),
+             'maximum_travel': 10},
+            StateVector([6.0, 6.0]),  # state
+            (0, 1)  # position_mapping
+        ), (
+            {'n_samples': 20,
+             'action_space': StateVectors([[-5, 5], [-5, 5], [-5, 5]]),
+             'action_mapping': (0, 1),
+             'maximum_travel': 10},
+            StateVector([0.0, 0.0]),  # state
+            (0, 1)  # position_mapping
+        ), (
+            {'n_samples': 20,
+             'action_space': StateVectors([[-5, 5], [-5, 5], [-5, 5]]),
+             'action_mapping': (0, 1, 2),
+             'maximum_travel': 10},
+            StateVector([0.0, 0.0, 0.0]),  # state
+            (0, 1, 2)  # position_mapping
+        )
+    ],
+
+    ids=["defauls_n_samples_no_space", "default_travel_in_space", "max_travel_larger_than_space",
+         "outside_space_start", "incompatible_action_space_and_mapping", "3d_action_value_error"]
+)
+def test_circle_sample_action_gen(gen_param_dict, state, position_mapping):
+
+    start_timestamp = datetime.now()
+    end_timestamp = start_timestamp + timedelta(seconds=1)
+
+    n_samples, action_space, action_mapping, maximum_travel = \
+        (gen_param_dict.get(key) for key in ['n_samples',
+                                             'action_space',
+                                             'action_mapping',
+                                             'maximum_travel'])
+
+    if n_samples is None:
+        gen_param_dict.pop('n_samples')
+        n_samples = 10  # if none, it should use default
+
+    if action_space is None:
+        gen_param_dict.pop('action_space')
+
+    if maximum_travel is None:
+        gen_param_dict.pop('maximum_travel')
+        maximum_travel = 1  # if non it should use default
+
+    platform = \
+        FixedPlatform(
+            movement_controller=CircleSampleActionableMovable(
+                states=[State(state, timestamp=start_timestamp)],
+                position_mapping=position_mapping,
+                **gen_param_dict))  # Dummy platform for initiating the generator
+
+    # Test error raises for invalid action space, action mapping or incompatibility of the two
+    if action_space is not None:
+        if (len(action_space) != len(action_mapping)) or \
+                (np.any(state[action_mapping, :] < action_space[:, [0]]) or
+                 np.any(state[action_mapping, :] > action_space[:, [1]])) or \
+                (len(action_mapping) != 2):
+
+            with pytest.raises(ValueError):
+                generator = platform.actions(start_timestamp).pop()
+            return
+
+    generator = platform.actions(start_timestamp).pop()
+
+    # Check that parameters have been set correctly
+    assert generator.n_samples == n_samples
+    assert generator.action_mapping == action_mapping
+    assert np.all(generator.action_space == action_space)
+    assert generator.maximum_travel == maximum_travel
+
+    # Test generator default action
+    assert np.all(generator.default_action.target_value == state[action_mapping, :])
+
+    # Check that actions are generated correctly
+    generator_set = set()
+    generator_set.add(generator)
+    move_position_actions = list(it.product(*generator_set))
+
+    # Check that the correct number of actions have been generated
+    assert len(move_position_actions) == n_samples + 1
+
+    # Verify each action is within range of the current platform position
+    # and within the action space
+    for action in move_position_actions:
+
+        temp_platform = copy.deepcopy(platform)
+        temp_platform.add_actions(action)
+        temp_platform.act(end_timestamp)
+        assert np.linalg.norm(temp_platform.position - platform.position,
+                              axis=0) <= maximum_travel
+
+        if action_space is not None:
+            assert (temp_platform.position[0] > action_space[0, 0] and
+                    temp_platform.position[0] < action_space[0, 1])
+            assert (temp_platform.position[1] > action_space[1, 0] and
+                    temp_platform.position[1] < action_space[1, 1])

--- a/stonesoup/movable/sample.py
+++ b/stonesoup/movable/sample.py
@@ -1,0 +1,99 @@
+from collections.abc import Sequence
+
+import numpy as np
+
+from ..base import Property
+from ..types.state import State
+from . import FixedMovable
+from .action.move_position_action import CircleSamplePositionActionGenerator
+
+
+class _SampleActionableMovable(FixedMovable):
+    """Base class for movables which sample actions. To be
+    used with :class:`~.SamplePositionActionGenerator` types."""
+
+    generator = None
+    _generator_kwargs = {'action_space', 'action_mapping', 'n_samples'}
+
+    action_space: np.ndarray = Property(
+        default=None,
+        doc="The bounds of the action space that should not be exceeded. Of shape (ndim, 2) "
+            "where ndim is the length of the action_mapping. For example, "
+            ":code:`np.array([[xmin, xmax], [ymin, ymax]])`."
+    )
+
+    action_mapping: Sequence[int] = Property(
+        default=(0, 1),
+        doc="The state dimensions that actions are applied to."
+    )
+
+    n_samples: int = Property(
+        default=10,
+        doc="Number of samples to generate. This does not include the action "
+        "to remain at the current position, meaning :attr:`n_samples` +1 "
+        "actions will be generated."
+    )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._next_action = None
+
+    def actions(self, timestamp, start_timestamp=None):
+        """Method to return a set of sample action generators available up to a provided timestamp.
+
+        A generator is returned for each actionable property that the sensor has.
+
+        Parameters
+        ----------
+        timestamp: datetime.datetime
+            Time of action finish.
+        start_timestamp: datetime.datetime, optional
+            Time of action start.
+
+        Returns
+        -------
+        : set of :class:`~.SamplePositionActionGenerator`
+            Set of grid action generators, that describe the bounds of each action space.
+        """
+        generators = set()
+        generators.add(self.generator(
+            owner=self,
+            attribute="position",
+            start_time=start_timestamp,
+            end_time=timestamp,
+            **{name: getattr(self, name) for name in type(self)._generator_kwargs}))
+
+        return generators
+
+    def move(self, timestamp, *args, **kwargs):
+        current_time = self.states[-1].timestamp
+        new_state = State.from_state(self.state, timestamp=timestamp)
+        new_state.state_vector = new_state.state_vector.copy()
+        self.states.append(new_state)
+        action = self._next_action
+        if action is not None:
+            self.position = action.act(current_time, timestamp, self.position)
+        self._next_action = None
+
+    def add_actions(self, actions):
+        self._next_action = actions[0]
+        return True
+
+    def act(self, timestamp, *args, **kwargs):
+        self.move(timestamp, *args, **kwargs)
+
+
+class CircleSampleActionableMovable(_SampleActionableMovable):
+    """This movable implements sampling based movement according to a circle
+    around the current position, defined by the maximum travel defined by
+    the user. Samples are uniformly generated within the circle. To be used
+    with :class:`~.CircleSamplePositionActionGenerator` """
+
+    generator = CircleSamplePositionActionGenerator
+    _generator_kwargs = _SampleActionableMovable._generator_kwargs | {'maximum_travel'}
+
+    maximum_travel: float = Property(
+        default=1.0,
+        doc="Maximum possible travel distance. Specifies the radius of "
+        "sampling area."
+    )


### PR DESCRIPTION
This PR introduces additional `movable` components for actionable platforms. New sample based category of `movable` and action generator have been introduced: `_SampleActionableMovable` and `SamplePositionActionGenerator`, along with an implementation based on uniform sampling within a circle around the current platform position.

`CircleSamplePositionActionGenerator` implements the generator logic behind the contribution, yielding `MovePositionAction`s based on sampling from a circle around the current position. Radius of the circle is defined by the user with the property: `maximum_travel`. The user can also specify the number of samples to generate with `n_samples`. This generator is implemented with `CircleSampleActionableMovable` and inherits its base methods from `_SampleActionableMovable`.

Tests have been written for the new components and they have been incorporated into the documentation.