### PR TITLE
Use full test template for Python 3.13 CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,40 +63,9 @@ jobs:
     docker:
       - image: cimg/python:3.12
   test-313:
+    <<: *test-template
     docker:
       - image: cimg/python:3.13
-    steps:
-      - checkout
-      - restore_cache:
-          key: dependencies-{{ .Environment.CACHE_VERSION }}-{{ checksum "/home/circleci/.pyenv/version" }}-{{ checksum "pyproject.toml" }}
-      - run:
-          name: Install Dependencies
-          command: |
-            python -m venv venv
-            . venv/bin/activate
-            pip install --upgrade pip
-            pip install -e .[ehm,optuna,orbital] opencv-python-headless plotly pytest-cov pytest-remotedata pytest-skip-slow pyehm confluent-kafka h5py pandas
-      - save_cache:
-          paths:
-            - ./venv
-          key: dependencies-{{ .Environment.CACHE_VERSION }}-{{ checksum "/home/circleci/.pyenv/version" }}-{{ checksum "pyproject.toml" }}
-      - run:
-          name: Run Tests
-          command: |
-            . venv/bin/activate
-            mkdir test-reports
-            pytest --junitxml=test-reports/junit.xml --cov --cov-report=xml:test-reports/coverage.xml --slow stonesoup
-      - store_test_results:
-          path: test-reports/junit.xml
-      - store_artifacts:
-          path: test-reports
-      - run:
-          name: Upload Coverage Results
-          command: |
-            bash <(curl -s https://codecov.io/bash) \
-              -f test-reports/coverage.xml \
-              -F unittests \
-              -n ${CIRCLE_BUILD_NUM}
   flake8:
     docker:
       - image: cimg/python:3.12


### PR DESCRIPTION
This is follow on from #1092, where a subset of dependencies were used for Python 3.13 as some libraries weren't available for 3.13 at that time.