### PR TITLE
Information Coverage Reward

### DIFF
--- a/stonesoup/sensormanager/reward.py
+++ b/stonesoup/sensormanager/reward.py
@@ -2,7 +2,9 @@ from abc import ABC
 import copy
 import datetime
 from collections.abc import Mapping, Sequence
+from typing import Set, Callable
 
+from scipy.spatial import cKDTree
 import numpy as np
 
 from ..base import Base, Property
@@ -25,6 +27,7 @@ from ..types.track import Track
 from ..updater import Updater
 from ..updater.kalman import ExtendedKalmanUpdater
 from ..updater.particle import ParticleUpdater
+from ..types.state import StateVectors
 
 
 class RewardFunction(Base, ABC):
@@ -590,3 +593,238 @@ class AOIRewardFunction2D(RewardFunction):
                         reward_func = self.default_reward
 
         return reward_func(config, tracks, metric_time, *args, **kwargs)
+
+
+class InformationCoverageReward(RewardFunction):
+    """Reward function that encourages coverage of a distribution based on the
+    current state of information about the environment and a reference level
+    of information. Information in this context is represented by a set
+    points in the environment which each have an information value (information state).
+    The information state is decayed through time, with :attr:`decay_rate`,
+    and new information from sensing actions, calculated by :attr:`sensing_info_func`,
+    added to the information state. This reward compares the difference between a
+    user defined information setpoint and the current information setpoint and
+    rewards minimisation of the difference between the two, focussed on an
+    underlying density. In the absence of target tracks, this is a uniform
+    density across the environment and in the presence of a target, this density
+    is a mixture between a uniform density and the target estimate density, with
+    :attr:`search_weight` defining the mixture composition. """
+
+    predictor: ParticlePredictor = Property(
+        doc="Predictor used to predict the track to a new state. This reward "
+        "function is only compatible with :class:`~.ParticlePredictor` types."
+    )
+
+    updater: ParticleUpdater = Property(
+        doc="Updater used to update the track to the new state. This reward "
+        "function is only compatible with :class:`~.ParticleUpdater` types."
+    )
+
+    environment_cells: StateVectors = Property(
+        doc="Coordinates defining cells approximating the environment for "
+        "the information state. Vector of shape (2, n) where n is the number of cells."
+    )
+
+    reference_information: StateVectors = Property(
+        doc="Reference level of information to achieve in each grid cell. "
+        "Vector of shape (1, n) where n is the number of cells. This should "
+        "match :attr:`environment_cells`."
+    )
+
+    sensing_info_func: Callable = Property(
+        doc="Function describing the information from a sensing action."
+    )
+
+    track_thresh_func: Callable = Property(
+        doc="Callable function that implements the trigger for including track "
+        "information in the reward function. Allows the user to take advantage "
+        "of specific filter properties, such as the existence probability in "
+        "the Bernoulli Filter. Takes input of a track object and must return "
+        "`True` or `False`."
+    )
+
+    information_decay: float = Property(
+        default=-0.05,
+        doc="The decay rate of information acquired by sensing actions. Higher "
+        "value leads to historical actions being *forgotten* in less time. Value "
+        "should be 0 or negative."
+    )
+
+    measurement_noise: bool = Property(
+        default=False,
+        doc="Decide whether or not to apply measurement model noise to the "
+        "predicted measurements for sensor management."
+    )
+
+    return_tracks: bool = Property(
+        default=False,
+        doc="A flag for allowing the predicted track, used to calculate the "
+        "reward, to be returned."
+    )
+
+    position_mapping: Sequence[int] = Property(
+        default=(0, 1),
+        doc="Mapping for the :math:`x`, :math:`y` position of the target state vector."
+    )
+
+    search_weight: float = Property(
+        default=0.5,
+        doc="Density used in the reward function is a mixture between target "
+        "density and search density. This controls the weighting of the mixture."
+    )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._environment_cell_tree = cKDTree(self.environment_cells.T)
+
+    def __call__(self, config: Mapping[Sensor, Sequence[Action]], tracks: Set[Track],
+                 metric_time: datetime.datetime, *args, **kwargs):
+        """
+        For a given configuration of sensors and actions this reward function
+        calculates the information coverage reward based on sensing actions and the
+        current information state stored in track metadata. It is calculated by
+        subtracting the updated information state from the information reference,
+        multiplied into the coverage density.
+
+        This requires a mapping of sensors to action(s) to be evaluated by the
+        reward function, a set of tracks at given time and the time at which
+        the actions would be carried out until. Track metadata should contain
+        the information state, which gets updated outside of sensor management
+        between calls to :meth:`choose_action`, reflecting the impact of the
+        selected action. This has currently been tested with tracks containing
+        a single :class:`~.Track`.
+
+        The metric returned is the information coverage reward calculated
+        based on all tracks.
+
+        Returns
+        -------
+        : float
+            Information coverage reward for given configuration
+
+        : Set[Track] (if defined)
+            Set of tracks that have been predicted and updated in reward
+            calculation if :attr:`return_tracks` is `True`
+
+        """
+        # Reward value
+        config_metric = 0
+
+        predicted_sensors = set()
+        memo = {}
+        # For each sensor/platform in the configuration
+        for actionable, actions in config.items():
+            predicted_actionable = copy.deepcopy(actionable, memo)
+            predicted_actionable.add_actions(actions)
+            predicted_actionable.act(metric_time, noise=False)
+            if isinstance(actionable, Sensor):
+                predicted_sensors.add(predicted_actionable)  # checks if it's a sensor
+
+        # If no actionables provided then return.
+        if len(config.items()) > 0:
+            # Calculate sample time for information decal. Assumes all actionables have the same
+            sample_time = metric_time - actionable.timestamp
+
+            # calculate the density used in the reward. Initialise to a uniform value
+            overall_density = 1/self.environment_cells.shape[1] \
+                * np.ones((1, self.environment_cells.shape[1]))
+            n_tracks = len(tracks)
+
+            # Create set of predictions for the tracks in the configuration
+            predicted_tracks = set()
+            for track in tracks:
+                predicted_track = copy.copy(track)
+                information_state = copy.copy(predicted_track.metadata['information_state'])
+
+                # Predict track if it passes the track_thresh_func
+                if self.track_thresh_func(predicted_track):
+                    predicted_track.append(Prediction.from_state(track[-1],
+                                                                 timestamp=metric_time))
+                else:
+                    predicted_track.append(self.predictor.predict(predicted_track,
+                                                                  timestamp=metric_time))
+                predicted_tracks.add(predicted_track)
+
+            for sensor in predicted_sensors:
+
+                # Assumes one detection per track
+                detections = {predicted_track: detection
+                              for detection in
+                              sensor.measure({GroundTruthState(predicted_track.mean,
+                                                               timestamp=predicted_track.timestamp,
+                                                               metadata=predicted_track.metadata)},
+                                             noise=self.measurement_noise)
+                              for predicted_track in predicted_tracks
+                              if isinstance(detection, TrueDetection)}
+
+                # Only update is track passes track_thresh_func
+                for predicted_track, detection in detections.items():
+                    if self.track_thresh_func(predicted_track):
+                        # Generate hypothesis based on prediction/previous update and detection
+                        hypothesis = SingleHypothesis(predicted_track.state, detection)
+
+                        # Do the update based on this hypothesis and store covariance matrix
+                        update = self.updater.update(hypothesis)
+
+                        # Replace prediction with update
+                        predicted_track.append(update)
+
+            # Construct the coverage density
+            for predicted_track in predicted_tracks:
+                if self.track_thresh_func(predicted_track):
+                    # Calculate which environment_cell points that predicted track
+                    # particle states are closest to
+                    _, nearest_cells = self._environment_cell_tree.query(
+                        predicted_track.state.state_vector[self.position_mapping,
+                                                           :].T)
+
+                    # Multiply currently uniform density by search weight
+                    overall_density *= self.search_weight
+
+                    # Get weight values and multiply them by (1-search weight) and (1/n_tracks)
+                    weight_vals = \
+                        np.exp(np.log((1-self.search_weight)*(1/n_tracks))
+                               + predicted_track.log_weight)
+
+                    # Add weight values to each environment cell point that
+                    # particles are closest to
+                    np.add.at(overall_density, (0, nearest_cells), weight_vals)
+
+            # update information state according to candidate sensing and platform actions
+            information_state = self.update_information_state(predicted_sensors,
+                                                              information_state,
+                                                              sample_time)
+
+            # calculate error between reference information and information state
+            information_error = self.reference_information - information_state
+            # Ensure no negative values remain in the error to prevent
+            # penalisation of gaining too much information.
+            information_error[information_error < 0] = 0.
+
+            # Calculate reward
+            config_metric = -1*np.sum(information_error * overall_density)
+
+        # Return value of configuration metric
+        if self.return_tracks:
+            # if returning tracks, update track information state in metadata
+            for track in predicted_tracks:
+                track.metadata['information_state'] = information_state
+            return config_metric, predicted_tracks
+        else:
+            return config_metric
+
+    def update_information_state(self, sensors, information_state, sample_time):
+        # Implements the information model, which decays the current information
+        # state and adds latest information.
+
+        # call user defined sensing information function to calculate information
+        # from sensing actions
+        sensing_info = self.sensing_info_func(sensors, self.environment_cells)
+
+        # Calculate information rate based on decay on new sensing actions
+        information_rate = information_state*self.information_decay + sensing_info
+
+        # Calculate updated information state
+        information_state += information_rate*sample_time.total_seconds()
+
+        return information_state

--- a/stonesoup/sensormanager/reward.py
+++ b/stonesoup/sensormanager/reward.py
@@ -738,11 +738,11 @@ class InformationCoverageReward(RewardFunction):
 
                 # Predict track if it passes the track_thresh_func
                 if self.track_thresh_func(predicted_track):
-                    predicted_track.append(Prediction.from_state(track[-1],
-                                                                 timestamp=metric_time))
-                else:
                     predicted_track.append(self.predictor.predict(predicted_track,
                                                                   timestamp=metric_time))
+                else:
+                    predicted_track.append(Prediction.from_state(track[-1],
+                                                                 timestamp=metric_time))
                 predicted_tracks.add(predicted_track)
 
             for sensor in predicted_sensors:


### PR DESCRIPTION
This pull request introduces the `InformationCoverageReward` class which implements an information coverage control objective for the sensor management module. The reward works with an information state which spatially quantifies the level of information at discrete points throughout the environment. The class rewards minimisation of the difference between the information state and a user defined reference information state multiplied into, if triggered, a target density or a uniform density, depending on whether a target is tracked or whether it is being searched for. Information here is a quantification of the area covered by sensors, and is left to the user to define for generality across sensor types and applications. 

The class requires that the information state is stored in track metadata in this implementation as the state should be carried through time as it evolves according to the information model.

The reward has also only been tested with a single target scenario but the concept is applicable to multitarget tracking problems and the implementation should allow this.

The new reward class has been incorporated into existing sensor manager tests. There is a problem with it being used with the `OptimizeBasinHoppingSensorManager` so assertions for this sensor manager and `InformationCoverageReward` are skipped until the problem is resolved.