### PR TITLE
Rename PriorAsProposal to DynamicsProposal, and KFasProposal to KalmanProposal

### DIFF
--- a/stonesoup/predictor/particle.py
+++ b/stonesoup/predictor/particle.py
@@ -12,7 +12,7 @@ from .kalman import KalmanPredictor, ExtendedKalmanPredictor
 from ..base import Property
 from ..models.transition import TransitionModel
 from ..proposal.base import Proposal
-from ..proposal.simple import PriorAsProposal
+from ..proposal.simple import DynamicsProposal
 from ..sampler.particle import ParticleSampler
 from ..types.numeric import Probability
 from ..types.prediction import Prediction
@@ -35,7 +35,7 @@ class ParticlePredictor(Predictor):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         if self.proposal is None:
-            self.proposal = PriorAsProposal(self.transition_model)
+            self.proposal = DynamicsProposal(self.transition_model)
 
     @predict_lru_cache()
     def predict(self, prior, timestamp=None, measurement=None, **kwargs):

--- a/stonesoup/proposal/simple.py
+++ b/stonesoup/proposal/simple.py
@@ -16,7 +16,7 @@ from stonesoup.predictor.kalman import SqrtKalmanPredictor
 from stonesoup.types.hypothesis import SingleHypothesis
 
 
-class PriorAsProposal(Proposal):
+class DynamicsProposal(Proposal):
     """Proposal that uses the dynamics model as the importance density.
     This proposal uses the dynamics model to predict the next state, and then
     uses the predicted state as the prior for the measurement model.
@@ -61,7 +61,7 @@ class PriorAsProposal(Proposal):
                                      prior=prior)
 
 
-class KFasProposal(Proposal):
+class KalmanProposal(Proposal):
     """This proposal uses the Kalman filter prediction and update steps to
     generate new set of particles and weights
     """

--- a/stonesoup/proposal/simple.py
+++ b/stonesoup/proposal/simple.py
@@ -15,6 +15,27 @@ from stonesoup.predictor.base import Predictor
 from stonesoup.predictor.kalman import SqrtKalmanPredictor
 from stonesoup.types.hypothesis import SingleHypothesis
 
+import warnings
+
+__all__ = ["DynamicsProposal", "KalmanProposal"]
+
+DEPRECATED_NAMES = [("PriorAsProposal", "DynamicsProposal"), ("KFasProposal", "KalmanProposal")]
+
+
+def __getattr__(name):
+    for old_name, new_name in DEPRECATED_NAMES:
+        if name == old_name:
+            warnings.warn(f"The '{old_name}' class or function has renamed to '{new_name}' "
+                          f"and will be removed in a future release.",
+                          DeprecationWarning,
+                          stacklevel=2)
+            return globals()[new_name]
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__():
+    return sorted(__all__ + [names[0] for names in DEPRECATED_NAMES])
+
 
 class DynamicsProposal(Proposal):
     """Proposal that uses the dynamics model as the importance density.

--- a/stonesoup/proposal/tests/test_simple.py
+++ b/stonesoup/proposal/tests/test_simple.py
@@ -4,7 +4,7 @@ import datetime
 import numpy as np
 
 # Import the proposals
-from stonesoup.proposal.simple import PriorAsProposal, KFasProposal
+from stonesoup.proposal.simple import DynamicsProposal, KalmanProposal
 from stonesoup.models.transition.linear import ConstantVelocity
 from stonesoup.types.particle import Particle
 from stonesoup.types.prediction import ParticleStatePrediction
@@ -39,7 +39,7 @@ def test_prior_proposal():
 
     # predictors prior and standard stone soup
     predictor_prior = ParticlePredictor(cv,
-                                        proposal=PriorAsProposal(cv))
+                                        proposal=DynamicsProposal(cv))
 
     # Check that the predictor without prior specified works with the prior as
     # proposal
@@ -119,8 +119,7 @@ def test_kf_proposal():
 
     eval_state = kf_updater.update(SingleHypothesis(prediction, detection))
 
-    proposal = KFasProposal(KalmanPredictor(cv),
-                            KalmanUpdater(lg))
+    proposal = KalmanProposal(KalmanPredictor(cv), KalmanUpdater(lg))
     # particle proposal
     particle_proposal = proposal.rvs(prior, measurement=detection, time_interval=time_interval)
 

--- a/stonesoup/proposal/tests/test_simple.py
+++ b/stonesoup/proposal/tests/test_simple.py
@@ -2,6 +2,7 @@ import itertools
 
 import datetime
 import numpy as np
+import pytest
 
 # Import the proposals
 from stonesoup.proposal.simple import DynamicsProposal, KalmanProposal
@@ -15,6 +16,20 @@ from stonesoup.predictor.particle import ParticlePredictor
 from stonesoup.types.detection import Detection
 from stonesoup.models.measurement.linear import LinearGaussian
 from stonesoup.types.hypothesis import SingleHypothesis
+
+
+def test_deprecated_names():
+    # Test handling of deprecated class names
+
+    # Test the deprecation warnings
+    with pytest.warns(DeprecationWarning):
+        from stonesoup.proposal.simple import PriorAsProposal
+    with pytest.warns(DeprecationWarning):
+        from stonesoup.proposal.simple import KFasProposal
+
+    # Ensure the deprecated names are still available and point to the new names
+    assert PriorAsProposal == DynamicsProposal
+    assert KFasProposal == KalmanProposal
 
 
 def test_prior_proposal():


### PR DESCRIPTION
This PR renames the proposals introduced in #1080 to make them more intuitive and representative of their purpose. Specifically:
- `PriorAsProposal` has been renamed to `DynamicsProposal`
- `KFasProposal` has been renamed to `KalmanProposal`.

This is also an attempt to make the names of the classes consistent with the names that will be used in the paper we aim to publish to Fusion 2025.

**Note**: This PR introduces breaking changes for code that references the proposals directly. Any legacy code, or more generally code that does not explicitly specify a proposal, should run without errors.