### PR TITLE
Allow setting of gm_method at instance level for PDAUpdater

### DIFF
--- a/stonesoup/updater/probability.py
+++ b/stonesoup/updater/probability.py
@@ -3,9 +3,10 @@ import numpy as np
 from copy import copy
 
 from .kalman import ExtendedKalmanUpdater
-from ..types.update import Update
-from ..types.array import StateVectors
+from ..base import Property
 from ..functions import gm_reduce_single
+from ..types.array import StateVectors
+from ..types.update import Update
 
 
 class PDAUpdater(ExtendedKalmanUpdater):
@@ -55,7 +56,12 @@ class PDAUpdater(ExtendedKalmanUpdater):
            Control Systems Magazine
     .. [#] https://gist.github.com/jmbarr/92dc83e28c04026136d4f8706a1159c1
     """
-    def update(self, hypotheses, gm_method=False, **kwargs):
+    gm_method: bool = Property(
+        default=False,
+        doc="Use the innovation-based update method if False (default), "
+            "or the GM-reduction (True).")
+
+    def update(self, hypotheses, gm_method=None, **kwargs):
         r"""The update step.
 
         Parameters
@@ -68,8 +74,9 @@ class PDAUpdater(ExtendedKalmanUpdater):
 
             In a single case (the missed detection hypothesis), the hypothesis will not have an
             associated measurement or measurement prediction.
-        gm_method : bool
-            Use the innovation-based update method if False (default), or the GM-reduction (True).
+        gm_method : bool or None
+            Use the innovation-based update method (False), or the GM-reduction (True). Default
+            is ``None`` where the current instance value is used.
         **kwargs : various
             These are passed to :meth:`predict_measurement`
 
@@ -79,7 +86,7 @@ class PDAUpdater(ExtendedKalmanUpdater):
             The update, :math:`\mathbf{x}_{k|k}, P_{k|k}`
 
         """
-        if gm_method:
+        if (gm_method is not None and gm_method) or (gm_method is None and self.gm_method):
             posterior_mean, posterior_covariance = self._update_via_GM_reduction(hypotheses,
                                                                                  **kwargs)
         else:

--- a/stonesoup/updater/probability.py
+++ b/stonesoup/updater/probability.py
@@ -162,6 +162,8 @@ class PDAUpdater(ExtendedKalmanUpdater):
         : :class:`~.CovarianceMatrix`
             The covariance of the reduced/single Gaussian
         """
+        sum_of_innovations = 0
+        sum_of_weighted_cov = 0
 
         for n, hypothesis in enumerate(hypotheses):
             # Check for the existence of an associated measurement. Because of the way the
@@ -181,15 +183,8 @@ class PDAUpdater(ExtendedKalmanUpdater):
                 innovation = hypothesis.measurement.state_vector - \
                              hypothesis.measurement_prediction.state_vector
 
-            # probably exists a less clunky way of doing this using exists() or overwritten +=
-            # All these floats should be redundant if/when the bug in Probability.__mult__() is
-            # fixed.
-            if n == 0:
-                sum_of_innovations = float(hypothesis.probability) * innovation
-                sum_of_weighted_cov = float(hypothesis.probability) * (innovation @ innovation.T)
-            else:
-                sum_of_innovations += float(hypothesis.probability) * innovation
-                sum_of_weighted_cov += float(hypothesis.probability) * (innovation @ innovation.T)
+            sum_of_innovations += hypothesis.probability * innovation
+            sum_of_weighted_cov += hypothesis.probability * (innovation @ innovation.T)
 
         posterior_mean += kalman_gain @ sum_of_innovations
         posterior_covariance += \


### PR DESCRIPTION
This is generally useful where looking to use this method, but can't easily pass arguments into updater.

Also remove some unneeded work around code.