### PR TITLE
Add multi data feeders with queues

### DIFF
--- a/stonesoup/feeder/multi.py
+++ b/stonesoup/feeder/multi.py
@@ -70,7 +70,7 @@ class FIFOMultiDataFeeder(_QueueMultiDataFeeder):
     """FIFO Multi-data Feeder
 
     This returns data from multiple data readers as a single stream,
-    where each reader is consumed in separate thread and put into a
+    where each reader is consumed in a separate thread and put into a
     queue. The data is consumed first in, first out.
 
     This is aimed at sources of data that are real-time streams, for
@@ -86,7 +86,7 @@ class LIFOMultiDataFeeder(_QueueMultiDataFeeder):
     """LIFO Multi-data Feeder
 
     This returns data from multiple data readers as a single stream,
-    where each reader is consumed in separate thread and put into a
+    where each reader is consumed in a separate thread and put into a
     queue. The data is consumed last in, first out.
 
     This is aimed at sources of data that are real-time streams, for
@@ -102,7 +102,7 @@ class PriorityMultiDataFeeder(_QueueMultiDataFeeder):
     """Priority Multi-data Feeder
 
     This returns data from multiple data readers as a single stream,
-    where each reader is consumed in separate thread and put into a
+    where each reader is consumed in a separate thread and put into a
     queue. The data is consumed prioritised by time, earlier to later.
 
     This is aimed at sources of data that are real-time streams, for
@@ -137,7 +137,7 @@ class MaxSizePriorityMultiDataFeeder(_QueueMultiDataFeeder):
     """Max Size Priority Multi-data Feeder
 
     This returns data from multiple data readers as a single stream,
-    where each reader is consumed in separate thread and put into a
+    where each reader is consumed in a separate thread and put into a
     queue. The data is consumed prioritised by time, earlier to later.
 
     Unlike :class:`~.PriorityMultiDataFeeder`, rather than blocking

--- a/stonesoup/feeder/multi.py
+++ b/stonesoup/feeder/multi.py
@@ -1,5 +1,9 @@
 import heapq
+from abc import abstractmethod
 from collections.abc import Collection
+from functools import cached_property
+from queue import Empty, Full, Queue, LifoQueue, PriorityQueue
+from threading import Thread
 
 from .base import DetectionFeeder, GroundTruthFeeder
 from ..base import Property
@@ -19,3 +23,133 @@ class MultiDataFeeder(DetectionFeeder, GroundTruthFeeder):
     @BufferedGenerator.generator_method
     def data_gen(self):
         yield from heapq.merge(*self.readers)
+
+
+class _QueueMultiDataFeeder(DetectionFeeder, GroundTruthFeeder):
+    reader = None
+    readers: Collection[Reader] = Property(doc='Readers to yield from')
+    max_size: int = Property(
+        default=0,
+        doc="Max queue size, where it will block more data being added. Default 0, unbounded.")
+
+    @cached_property
+    @abstractmethod
+    def _queue(self):
+        raise NotImplementedError
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._threads = None
+
+    @staticmethod
+    def _run(queue: Queue, reader: Reader):
+        for time, data in reader:
+            queue.put((time, data))
+
+    @BufferedGenerator.generator_method
+    def data_gen(self):
+        if self._threads is None:
+            self._threads = [
+                Thread(target=self._run, args=(self._queue, reader), daemon=True)
+                for reader in self.readers
+            ]
+            for thread in self._threads:
+                thread.start()
+
+        while any(thread.is_alive() for thread in self._threads) \
+                or not self._queue.empty():
+            try:
+                time, data = self._queue.get_nowait()
+            except Empty:
+                continue
+            yield time, data
+            self._queue.task_done()
+
+
+class FIFOMultiDataFeeder(_QueueMultiDataFeeder):
+    """FIFO Multi-data Feeder
+
+    This returns data from multiple data readers as a single stream,
+    where each reader is consumed in separate thread and put into a
+    queue. The data is consumed first in, first out.
+
+    This is aimed at sources of data that are real-time streams, for
+    example sensors sending data via network.
+    """
+
+    @cached_property
+    def _queue(self):
+        return Queue(self.max_size)
+
+
+class LIFOMultiDataFeeder(_QueueMultiDataFeeder):
+    """LIFO Multi-data Feeder
+
+    This returns data from multiple data readers as a single stream,
+    where each reader is consumed in separate thread and put into a
+    queue. The data is consumed last in, first out.
+
+    This is aimed at sources of data that are real-time streams, for
+    example sensors sending data via network.
+    """
+
+    @cached_property
+    def _queue(self):
+        return LifoQueue(self.max_size)
+
+
+class PriorityMultiDataFeeder(_QueueMultiDataFeeder):
+    """Priority Multi-data Feeder
+
+    This returns data from multiple data readers as a single stream,
+    where each reader is consumed in separate thread and put into a
+    queue. The data is consumed prioritised by time, earlier to later.
+
+    This is aimed at sources of data that are real-time streams, for
+    example sensors sending data via network.
+    """
+
+    @cached_property
+    def _queue(self):
+        return PriorityQueue(self.max_size)
+
+
+class _MaxSizePriorityQueue(PriorityQueue):
+    def put(self, item, block=True, timeout=None):
+        try:
+            # Call super, so can at least try or wait timeout before
+            # overwriting.
+            super().put(item, False, timeout)
+        except Full:
+            with self.not_full:
+                self._put(item)
+                self.unfinished_tasks += 1
+                self.not_empty.notify()
+
+    def _put(self, item):
+        if self.maxsize <= 0 or self.maxsize > len(self.queue):
+            heapq.heappush(self.queue, item)
+        else:
+            heapq.heappushpop(self.queue, item)
+
+
+class MaxSizePriorityMultiDataFeeder(_QueueMultiDataFeeder):
+    """Max Size Priority Multi-data Feeder
+
+    This returns data from multiple data readers as a single stream,
+    where each reader is consumed in separate thread and put into a
+    queue. The data is consumed prioritised by time, earlier to later.
+
+    Unlike :class:`~.PriorityMultiDataFeeder`, rather than blocking
+    when the queue is full, it will drop the oldest data.
+
+    This is aimed at sources of data that are real-time streams, for
+    example sensors sending data via network.
+    """
+    max_size: int = Property(
+        default=0,
+        doc="Max queue size, where it will drop oldest data when full. Default 0, unbounded.")
+
+    @cached_property
+    def _queue(self):
+        return _MaxSizePriorityQueue(self.max_size)

--- a/stonesoup/feeder/tests/test_multi.py
+++ b/stonesoup/feeder/tests/test_multi.py
@@ -1,6 +1,11 @@
+import time
+from datetime import datetime, timedelta
+
 import pytest
 
-from ..multi import MultiDataFeeder
+from ..multi import (
+    MultiDataFeeder, FIFOMultiDataFeeder, LIFOMultiDataFeeder,
+    PriorityMultiDataFeeder, MaxSizePriorityMultiDataFeeder)
 
 
 @pytest.mark.parametrize('n', [1, 2, 3])
@@ -9,12 +14,119 @@ def test_multi_detections(n, reader):
     multi_time_list = list()
 
     multi_detector = MultiDataFeeder([reader]*n)
-    for single_iterations, (time, _) in enumerate(reader, 1):
-        single_time_list.append(time)
-    for multi_iterations, (time, _) in enumerate(multi_detector, 1):
-        multi_time_list.append(time)
+    for single_iterations, (timestamp, _) in enumerate(reader, 1):
+        single_time_list.append(timestamp)
+    for multi_iterations, (timestamp, _) in enumerate(multi_detector, 1):
+        multi_time_list.append(timestamp)
     assert multi_iterations == single_iterations * n
     # Compare every other element but skip last ones due to out of sequence
     # measurements coming from detector.
     assert multi_time_list[:-n:n] == single_time_list[:-1]
     assert multi_time_list[-1] == single_time_list[-1]
+
+
+@pytest.fixture(scope="function")
+def readers():
+    start_time = datetime(2025, 3, 26)
+
+    def reader1():
+        timestamp = start_time
+        yield timestamp, {1}
+        time.sleep(0.2)
+        timestamp += timedelta(hours=2)
+        yield timestamp, {1}
+        time.sleep(0.2)
+        timestamp += timedelta(hours=2)
+        yield timestamp, {1}
+        time.sleep(0.4)
+        timestamp += timedelta(hours=1)
+        yield timestamp, {1}
+
+    def reader2():
+        timestamp = start_time
+        time.sleep(0.1)
+        timestamp += timedelta(hours=1)
+        yield timestamp, {2}
+        time.sleep(0.2)
+        timestamp += timedelta(hours=2)
+        yield timestamp, {2}
+        time.sleep(0.2)
+        timestamp += timedelta(hours=3)
+        yield timestamp, {2}
+        time.sleep(0.1)
+        timestamp += timedelta(hours=1)
+        yield timestamp, {2}
+
+    return [reader1(), reader2()]
+
+
+def test_fifo_feeder(readers):
+    feeder = FIFOMultiDataFeeder(readers)
+    assert list((t, d) for t, d in feeder if not time.sleep(0.21)) == [
+        (datetime(2025, 3, 26, 0), {1}),
+        (datetime(2025, 3, 26, 1), {2}),
+        (datetime(2025, 3, 26, 2), {1}),
+        (datetime(2025, 3, 26, 3), {2}),
+        (datetime(2025, 3, 26, 4), {1}),
+        (datetime(2025, 3, 26, 6), {2}),
+        (datetime(2025, 3, 26, 7), {2}),
+        (datetime(2025, 3, 26, 5), {1}),
+    ]
+
+
+def test_lifo_feeder(readers):
+    feeder = LIFOMultiDataFeeder(readers)
+    assert list((t, d) for t, d in feeder if not time.sleep(0.21)) == [
+        (datetime(2025, 3, 26, 0), {1}),
+        (datetime(2025, 3, 26, 2), {1}),
+        (datetime(2025, 3, 26, 4), {1}),
+        (datetime(2025, 3, 26, 7), {2}),
+        (datetime(2025, 3, 26, 5), {1}),
+        (datetime(2025, 3, 26, 6), {2}),
+        (datetime(2025, 3, 26, 3), {2}),
+        (datetime(2025, 3, 26, 1), {2}),
+    ]
+
+
+def test_priority_feeder(readers):
+    feeder = PriorityMultiDataFeeder(readers)
+    assert list((t, d) for t, d in feeder if not time.sleep(0.21)) == [
+        (datetime(2025, 3, 26, 0), {1}),
+        (datetime(2025, 3, 26, 1), {2}),
+        (datetime(2025, 3, 26, 2), {1}),
+        (datetime(2025, 3, 26, 3), {2}),
+        (datetime(2025, 3, 26, 4), {1}),
+        (datetime(2025, 3, 26, 5), {1}),
+        (datetime(2025, 3, 26, 6), {2}),
+        (datetime(2025, 3, 26, 7), {2}),
+    ]
+
+
+def test_max_priority_feeder(readers):
+    feeder = MaxSizePriorityMultiDataFeeder(readers, 3)
+    assert list((t, d) for t, d in feeder if not time.sleep(0.21)) == [
+        (datetime(2025, 3, 26, 0), {1}),
+        (datetime(2025, 3, 26, 1), {2}),
+        (datetime(2025, 3, 26, 2), {1}),
+        # (datetime(2025, 3, 26, 3), {2}), # Dropped before consumed
+        (datetime(2025, 3, 26, 4), {1}),
+        (datetime(2025, 3, 26, 5), {1}),
+        (datetime(2025, 3, 26, 6), {2}),
+        (datetime(2025, 3, 26, 7), {2}),
+    ]
+
+
+def test_no_wait(readers):
+    # Testing code handles empty queues
+    feeder = PriorityMultiDataFeeder(readers)
+    # Same as FIFO as not allowing time to prioritise
+    assert list((t, d) for t, d in feeder) == [
+        (datetime(2025, 3, 26, 0), {1}),
+        (datetime(2025, 3, 26, 1), {2}),
+        (datetime(2025, 3, 26, 2), {1}),
+        (datetime(2025, 3, 26, 3), {2}),
+        (datetime(2025, 3, 26, 4), {1}),
+        (datetime(2025, 3, 26, 6), {2}),
+        (datetime(2025, 3, 26, 7), {2}),
+        (datetime(2025, 3, 26, 5), {1}),
+    ]


### PR DESCRIPTION
These multi data feeders are designed to allow reading from real-time data sources, where there may be latencies or data coming out of sequence. This includes the standard FIFO, LIFO and Priorty Queue classes from Python standard library, as well as a custom prioity queue which drops old data, rather than blocking or raising error when full.