### PR TITLE
Fix tests for RadarRotatingElevationBearingRange sensor

### DIFF
--- a/stonesoup/sensor/radar/tests/test_radar.py
+++ b/stonesoup/sensor/radar/tests/test_radar.py
@@ -1,4 +1,5 @@
 import datetime
+from itertools import product
 
 import numpy as np
 from scipy.stats import poisson
@@ -947,91 +948,96 @@ def test_clutter_model(radar, clutter_params):
     assert len(measurements) >= 1
 
 
-sensor = RadarRotatingElevationBearingRange(position_mapping=[0, 1, 2],
-                                            noise_covar=np.diag([np.radians(0.1),
-                                                                 np.radians(0.1),
-                                                                 0.1]),
-                                            ndim_state=3,
-                                            position=np.array([[0], [0], [0]]),
-                                            rpm=60,
-                                            fov_angle=0.5,
-                                            vertical_extent=0.5,
-                                            dwell_centre=StateVector([0]),
-                                            tilt_centre=StateVector([0]),
-                                            max_range=np.inf)
+@pytest.fixture
+def sensor():
+    return RadarRotatingElevationBearingRange(position_mapping=[0, 1, 2],
+                                              noise_covar=np.diag([0, 0, 0]),
+                                              ndim_state=3,
+                                              position=np.array([[0], [0], [0]]),
+                                              rpm=0,
+                                              fov_angle=2*np.pi,
+                                              vertical_extent=np.pi,
+                                              dwell_centre=StateVector([0]),
+                                              tilt_centre=StateVector([0]),
+                                              max_range=np.inf)
 
-targets = [GroundTruthState(StateVector([1,   0, 0])),
-           GroundTruthState(StateVector([1,   1, 0])),
-           GroundTruthState(StateVector([0,   1, 0])),
-           GroundTruthState(StateVector([-1,  1, 0])),
-           GroundTruthState(StateVector([-1,  0, 0])),
-           GroundTruthState(StateVector([-1, -1, 0])),
-           GroundTruthState(StateVector([0,  -1, 0])),
-           GroundTruthState(StateVector([1,  -1, 0])),
-           GroundTruthState(StateVector([1,   0, 1])),
-           GroundTruthState(StateVector([1,   1, 1])),
-           GroundTruthState(StateVector([0,   1, 1])),
-           GroundTruthState(StateVector([-1,  1, 1])),
-           GroundTruthState(StateVector([-1,  0, 1])),
-           GroundTruthState(StateVector([-1, -1, 1])),
-           GroundTruthState(StateVector([0,  -1, 1])),
-           GroundTruthState(StateVector([1,  -1, 1])),
-           GroundTruthState(StateVector([0,   0, 1])),
-           GroundTruthState(StateVector([1,   0, -1])),
-           GroundTruthState(StateVector([1,   1, -1])),
-           GroundTruthState(StateVector([0,   1, -1])),
-           GroundTruthState(StateVector([-1,  1, -1])),
-           GroundTruthState(StateVector([-1,  0, -1])),
-           GroundTruthState(StateVector([-1, -1, -1])),
-           GroundTruthState(StateVector([0,  -1, -1])),
-           GroundTruthState(StateVector([1,  -1, -1])),
-           GroundTruthState(StateVector([0,   0, -1]))]
+
+@pytest.fixture
+def targets():
+    return [GroundTruthState(StateVector([1, 0, 0])),
+            GroundTruthState(StateVector([np.sqrt(1/2), np.sqrt(1/2), 0])),
+            GroundTruthState(StateVector([0, 1, 0])),
+            GroundTruthState(StateVector([-np.sqrt(1/2), np.sqrt(1/2), 0])),
+            GroundTruthState(StateVector([-1, 0, 0])),
+            GroundTruthState(StateVector([-np.sqrt(1/2), -np.sqrt(1/2), 0])),
+            GroundTruthState(StateVector([0, -1, 0])),
+            GroundTruthState(StateVector([np.sqrt(1/2), -np.sqrt(1/2), 0])),
+            GroundTruthState(StateVector([1, 0, 1])),
+            GroundTruthState(StateVector([np.sqrt(1/2), np.sqrt(1/2), 1])),
+            GroundTruthState(StateVector([0, 1, 1])),
+            GroundTruthState(StateVector([-np.sqrt(1/2), np.sqrt(1/2), 1])),
+            GroundTruthState(StateVector([-1, 0, 1])),
+            GroundTruthState(StateVector([-np.sqrt(1/2), -np.sqrt(1/2), 1])),
+            GroundTruthState(StateVector([0, -1, 1])),
+            GroundTruthState(StateVector([np.sqrt(1/2), -np.sqrt(1/2), 1])),
+            GroundTruthState(StateVector([0, 0, 1])),
+            GroundTruthState(StateVector([1, 0, -1])),
+            GroundTruthState(StateVector([np.sqrt(1/2), np.sqrt(1/2), -1])),
+            GroundTruthState(StateVector([0, 1, -1])),
+            GroundTruthState(StateVector([-np.sqrt(1/2), np.sqrt(1/2), -1])),
+            GroundTruthState(StateVector([-1, 0, -1])),
+            GroundTruthState(StateVector([-np.sqrt(1/2), -np.sqrt(1/2), -1])),
+            GroundTruthState(StateVector([0, -1, -1])),
+            GroundTruthState(StateVector([np.sqrt(1/2), -np.sqrt(1/2), -1])),
+            GroundTruthState(StateVector([0, 0, -1]))]
 
 
 @pytest.mark.parametrize(["pan", "tilt", "ans"],
-                         ([0,     0,  0],
-                          [45,    0,  1],
-                          [90,    0,  2],
-                          [135,   0,  3],
-                          [180,   0,  4],
-                          [225,   0,  5],
-                          [270,   0,  6],
-                          [315,   0,  7],
-                          [0,    45,  8],
-                          [45,   45,  9],
-                          [90,   45, 10],
-                          [135,  45, 11],
-                          [180,  45, 12],
-                          [225,  45, 13],
-                          [270,  45, 14],
-                          [315,  45, 15],
-                          [0,    90, 16],
-                          [0,   -45, 17],
-                          [45,  -45, 18],
-                          [90,  -45, 19],
+                         ([0, 0, 0],
+                          [45, 0, 1],
+                          [90, 0, 2],
+                          [135, 0, 3],
+                          [180, 0, 4],
+                          [225, 0, 5],
+                          [270, 0, 6],
+                          [315, 0, 7],
+                          [0, 45, 8],
+                          [45, 45, 9],
+                          [90, 45, 10],
+                          [135, 45, 11],
+                          [180, 45, 12],
+                          [225, 45, 13],
+                          [270, 45, 14],
+                          [315, 45, 15],
+                          [0, 90, 16],
+                          [0, -45, 17],
+                          [45, -45, 18],
+                          [90, -45, 19],
                           [135, -45, 20],
                           [180, -45, 21],
                           [225, -45, 22],
                           [270, -45, 23],
                           [315, -45, 24],
-                          [0,   -90, 25]))
-def test_detectable(pan, tilt, ans):
+                          [0, -90, 25]))
+def test_ebr_detectable(pan, tilt, ans, sensor, targets):
     sensor.dwell_centre = StateVector([np.radians(pan)])
     sensor.tilt_centre = StateVector([np.radians(tilt)])
+    sensor.fov_angle = 0.001
+    sensor.vertical_extent = 0.001
 
     for i, target in enumerate(targets):
-        sensor.fov_angle = 0.5
-        sensor.vertical_extent = 0.5
-
         if i == ans:
             assert sensor.is_detectable(target)
         else:
             assert not sensor.is_detectable(target)
 
-        sensor.fov_angle = 2*np.pi
-        sensor.vertical_extent = np.pi
 
-        detections = sensor.measure({target}, noise=False)
-        detection = next(iter(detections))
-        assert np.allclose(target.state_vector,
-                           detection.measurement_model.inverse_function(detection))
+def test_ebr_detections(sensor, targets):
+    for pan, tilt in product(45*np.arange(8), 45*np.arange(5)-90):
+        sensor.dwell_centre = StateVector([np.radians(pan)])
+        sensor.tilt_centre = StateVector([np.radians(tilt)])
+        for target in targets:
+            detections = sensor.measure({target}, noise=False)
+            detection = next(iter(detections))
+            assert np.allclose(target.state_vector,
+                               detection.measurement_model.inverse_function(detection))

--- a/stonesoup/sensormanager/action.py
+++ b/stonesoup/sensormanager/action.py
@@ -94,7 +94,7 @@ class RealNumberActionGenerator(ActionGenerator):
         raise NotImplementedError
 
     @abstractmethod
-    def action_from_value(self):
+    def action_from_value(self, value):
         raise NotImplementedError
 
 


### PR DESCRIPTION
Positions of targets in the Rotating EBR sensor test were placed in the wrong position previously and so the tests only passed due to the sensor's FOV not being small enough.
Targets have been moved to the correct positions and the FOV's have been reduced.

The argument `value` has been added to the abstractmethod of `action_from_value` in the `RealNumberActionGenerator`.