### PR TITLE
Update transition models to support backward prediction

### DIFF
--- a/stonesoup/models/transition/linear.py
+++ b/stonesoup/models/transition/linear.py
@@ -124,23 +124,23 @@ class ConstantNthDerivative(LinearGaussianTransitionModel, TimeVariantModel):
     def matrix(self, time_interval, **kwargs):
         time_interval_sec = time_interval.total_seconds()
         N = self.constant_derivative
-        Fmat = np.zeros((N + 1, N + 1))
+        Fmat = np.eye(N + 1)
         dt = time_interval_sec
         for i in range(0, N + 1):
-            for j in range(i, N + 1):
+            for j in range(i+1, N + 1):
                 Fmat[i, j] = (dt ** (j - i)) / math.factorial(j - i)
 
         return Fmat
 
     def covar(self, time_interval, **kwargs):
         time_interval_sec = time_interval.total_seconds()
-        dt = time_interval_sec
+        dt = abs(time_interval_sec)
         N = self.constant_derivative
         if N == 1:
             covar = np.array([[dt**3 / 3, dt**2 / 2],
                               [dt**2 / 2, dt]])
         else:
-            Fmat = self.matrix(time_interval, **kwargs)
+            Fmat = self.matrix(abs(time_interval), **kwargs)
             Q = np.zeros((N + 1, N + 1))
             Q[N, N] = 1
             igrand = Fmat @ Q @ Fmat.T
@@ -312,13 +312,13 @@ class NthDerivativeDecay(LinearGaussianTransitionModel, TimeVariantModel):
     @staticmethod
     @lru_cache()
     def _continoustransitionmatrix(t, N, K):
-        FCont = np.zeros((N + 1, N + 1))
+        FCont = np.eye(N + 1)
         for i in range(0, N + 1):
             FCont[i, N] = np.exp(-K * t) * (-1) ** (N - i) / K ** (N - i)
             for n in range(1, N - i + 1):
                 FCont[i, N] -= (-1) ** n * t ** (N - i - n) /\
                                (math.factorial(N - i - n) * K ** n)
-            for j in range(i, N):
+            for j in range(i+1, N):
                 FCont[i, j] = (t ** (j - i)) / math.factorial(j - i)
         return FCont
 
@@ -330,7 +330,7 @@ class NthDerivativeDecay(LinearGaussianTransitionModel, TimeVariantModel):
 
     @classmethod
     def _continouscovar(cls, t, N, K, k, l):  # noqa: E741
-        FcCont = cls._continoustransitionmatrix(t, N, K)
+        FcCont = abs(cls._continoustransitionmatrix(t, N, K))
         Q = np.zeros((N + 1, N + 1))
         Q[N, N] = 1
         CovarCont = FcCont @ Q @ FcCont.T
@@ -340,10 +340,13 @@ class NthDerivativeDecay(LinearGaussianTransitionModel, TimeVariantModel):
     @lru_cache()
     def _covardiscrete(cls, N, q, K, dt):
         covar = np.zeros((N + 1, N + 1))
+        if dt >= 0:
+            bounds = (0, dt)
+        else:
+            bounds = (dt, 0)
         for k in range(0, N + 1):
             for l in range(0, N + 1):  # noqa: E741
-                covar[k, l] = quad(cls._continouscovar, 0,
-                                   dt, args=(N, K, k, l))[0]
+                covar[k, l] = quad(cls._continouscovar, *bounds, args=(N, K, k, l))[0]
         return covar * q
 
     def covar(self, time_interval, **kwargs):
@@ -558,7 +561,7 @@ class SingerApproximate(Singer):
         """
 
         # time_interval_threshold is currently set arbitrarily.
-        time_interval_sec = time_interval.total_seconds()
+        time_interval_sec = abs(time_interval.total_seconds())
 
         # Only leading terms get calculated for speed.
         covar = np.array(
@@ -644,7 +647,7 @@ class KnownTurnRateSandwich(LinearGaussianTransitionModel, TimeVariantModel):
             The process noise covariance.
         """
         q1, q2 = self.turn_noise_diff_coeffs
-        dt = time_interval.total_seconds()
+        dt = abs(time_interval.total_seconds())
         covar_list = [model.covar(time_interval) for model in self.model_list]
         ctc1 = np.array([[q1*dt**3/3, q1*dt**2/2],
                          [q1*dt**2/2, q1*dt]])

--- a/stonesoup/models/transition/nonlinear.py
+++ b/stonesoup/models/transition/nonlinear.py
@@ -127,7 +127,7 @@ class ConstantTurn(GaussianTransitionModel, TimeVariantModel):
         """
         q_x, q_y = self.linear_noise_coeffs
         q = self.turn_noise_coeff
-        dt = time_interval.total_seconds()
+        dt = abs(time_interval.total_seconds())
 
         Q = np.array([[dt**3 / 3., dt**2 / 2.],
                       [dt**2 / 2., dt]])

--- a/stonesoup/models/transition/tests/conftest.py
+++ b/stonesoup/models/transition/tests/conftest.py
@@ -33,7 +33,7 @@ class CT_helper:
         """
         q_x, q_y = linear_noise_coeffs
         q = turn_noise_coeff
-        dt = time_interval.total_seconds()
+        dt = abs(time_interval.total_seconds())
 
         Q = np.array([[dt**3 / 3., dt**2 / 2.],
                       [dt**2 / 2., dt]])

--- a/stonesoup/models/transition/tests/test_ca.py
+++ b/stonesoup/models/transition/tests/test_ca.py
@@ -1,6 +1,7 @@
 import datetime
 
 from pytest import approx
+import pytest
 import numpy as np
 import scipy as sp
 from scipy.stats import multivariate_normal
@@ -10,33 +11,26 @@ from ..linear import ConstantAcceleration
 from ..base import CombinedGaussianTransitionModel
 
 
-def test_ca1dmodel():
-    """ ConstantAcceleration Transition Model test """
-    state_vec = np.array([[3.0], [1.0], [0.1]])
-    noise_diff_coeffs = np.array([[0.01]])
-    base(state_vec, noise_diff_coeffs)
+@pytest.fixture(params=[1, 2, 3])
+def ca_model_params(request):
+    if request.param == 1:
+        state_vec = np.array([[3.0], [1.0], [0.1]])
+        noise_diff_coeffs = np.array([[0.01]])
+    elif request.param == 2:
+        state_vec = np.array([[3.0], [1.0], [0.1],
+                              [2.0], [2.0], [0.2]])
+        noise_diff_coeffs = np.array([0.01, 0.02])
+    else:
+        state_vec = np.array([[3.0], [1.0], [0.1],
+                              [2.0], [2.0], [0.2],
+                              [4.0], [0.5], [0.05]])
+        noise_diff_coeffs = np.array([0.01, 0.02, 0.005])
+    return state_vec, noise_diff_coeffs
 
 
-def test_ca2dmodel():
-    """ ConstantAcceleration2D Transition Model test """
-    state_vec = np.array([[3.0], [1.0], [0.1],
-                          [2.0], [2.0], [0.2]])
-    noise_diff_coeffs = np.array([0.01, 0.02])
-    base(state_vec, noise_diff_coeffs)
-
-
-def test_ca3dmodel():
-    """ ConstantAcceleration3D Transition Model test """
-    state_vec = np.array([[3.0], [1.0], [0.1],
-                          [2.0], [2.0], [0.2],
-                          [4.0], [0.5], [0.05]])
-    noise_diff_coeffs = np.array([0.01, 0.02, 0.005])
-    base(state_vec, noise_diff_coeffs)
-
-
-def base(state_vec, noise_diff_coeffs):
-    """ Base test for n-dimensional ConstantAcceleration Transition Models """
-
+@pytest.mark.parametrize('sign', [1, -1])
+def test_ca(ca_model_params, sign):
+    state_vec, noise_diff_coeffs = ca_model_params
     # Create a 1D ConstantAcceleration or an n-dimensional
     # CombinedLinearGaussianTransitionModel object
     dim = len(state_vec) // 3  # pos, vel, acc for each dimension
@@ -48,9 +42,8 @@ def base(state_vec, noise_diff_coeffs):
         model_obj = CombinedGaussianTransitionModel(model_list)
 
     # State related variables
-    state_vec = state_vec
     old_timestamp = datetime.datetime.now()
-    timediff = 1  # 1sec
+    timediff = 1 * sign  # 1sec
     new_timestamp = old_timestamp + datetime.timedelta(seconds=timediff)
     time_interval = new_timestamp - old_timestamp
 
@@ -62,15 +55,15 @@ def base(state_vec, noise_diff_coeffs):
     mat_list = [base_mat for num in range(0, dim)]
     F = sp.linalg.block_diag(*mat_list)
 
-    base_covar = np.array([[timediff**5 / 20,
-                            timediff**4 / 8,
-                            timediff**3 / 6],
-                           [timediff**4 / 8,
-                            timediff**3 / 3,
-                            timediff**2 / 2],
-                           [timediff**3 / 6,
-                            timediff**2 / 2,
-                            timediff]])
+    base_covar = np.array([[abs(timediff)**5 / 20,
+                            abs(timediff)**4 / 8,
+                            abs(timediff)**3 / 6],
+                           [abs(timediff)**4 / 8,
+                            abs(timediff)**3 / 3,
+                            abs(timediff)**2 / 2],
+                           [abs(timediff)**3 / 6,
+                            abs(timediff)**2 / 2,
+                            abs(timediff)]])
     covar_list = [base_covar*noise_diff_coeffs[i]
                   for i in range(0, dim)]
     Q = sp.linalg.block_diag(*covar_list)
@@ -89,7 +82,7 @@ def base(state_vec, noise_diff_coeffs):
         State(state_vec),
         timestamp=new_timestamp,
         time_interval=time_interval)
-    assert np.array_equal(new_state_vec_wo_noise, F@state_vec)
+    assert np.allclose(new_state_vec_wo_noise, F@state_vec)
 
     # Evaluate the likelihood of the predicted state, given the prior
     # (without noise)
@@ -109,7 +102,7 @@ def base(state_vec, noise_diff_coeffs):
         noise=True,
         timestamp=new_timestamp,
         time_interval=time_interval)
-    assert not np.array_equal(new_state_vec_w_inoise, F@state_vec)
+    assert not np.allclose(new_state_vec_w_inoise, F@state_vec)
 
     # Evaluate the likelihood of the predicted state, given the prior
     # (with noise)
@@ -130,7 +123,7 @@ def base(state_vec, noise_diff_coeffs):
         timestamp=new_timestamp,
         time_interval=time_interval,
         noise=noise)
-    assert np.array_equal(new_state_vec_w_enoise, F@state_vec+noise)
+    assert np.allclose(new_state_vec_w_enoise, F@state_vec+noise)
 
     # Evaluate the likelihood of the predicted state, given the prior
     # (with noise)

--- a/stonesoup/models/transition/tests/test_combined.py
+++ b/stonesoup/models/transition/tests/test_combined.py
@@ -26,7 +26,7 @@ def test__linear_combined(comb_model):
 
     DIM = 9
 
-    combined_model = CombinedGaussianTransitionModel(
+    combined_model = comb_model(
         [model_1, model_2, model_3, model_4])
     t_delta = datetime.timedelta(0, 3)
 

--- a/stonesoup/models/transition/tests/test_ct.py
+++ b/stonesoup/models/transition/tests/test_ct.py
@@ -1,6 +1,7 @@
 import datetime
 
 from pytest import approx
+import pytest
 import numpy as np
 from scipy.stats import multivariate_normal
 
@@ -8,26 +9,19 @@ from ..linear import KnownTurnRate
 from ....types.state import State
 
 
-def test_ctmodel():
-    """ KnownTurnRate Transition Model test """
+@pytest.mark.parametrize('sign', [1, -1])
+def test_ctmodel(sign):
     state = State(np.array([[3.0], [1.0], [2.0], [1.0]]))
     turn_noise_diff_coeffs = np.array([0.01, 0.01])
     turn_rate = 0.1
-    base(KnownTurnRate, state, turn_noise_diff_coeffs, turn_rate)
-
-
-def base(model, state, turn_noise_diff_coeffs, turn_rate):
-    """ Base test for n-dimensional ConstantAcceleration Transition Models """
 
     # Create an KnownTurnRate model object
-    model = model
-    model_obj = model(turn_noise_diff_coeffs=turn_noise_diff_coeffs,
-                      turn_rate=turn_rate)
+    model_obj = KnownTurnRate(turn_noise_diff_coeffs=turn_noise_diff_coeffs, turn_rate=turn_rate)
 
     # State related variables
     state_vec = state.state_vector
     old_timestamp = datetime.datetime.now()
-    timediff = 1  # 1sec
+    timediff = 1 * sign  # 1sec
     new_timestamp = old_timestamp + datetime.timedelta(seconds=timediff)
     time_interval = new_timestamp - old_timestamp
 
@@ -47,22 +41,22 @@ def base(model, state, turn_noise_diff_coeffs, turn_rate):
 
     qx = turn_noise_diff_coeffs[0]
     qy = turn_noise_diff_coeffs[1]
-    Q = np.array([[qx * timediff**3 / 3,
-                   qx * timediff**2 / 2,
+    Q = np.array([[qx * abs(timediff)**3 / 3,
+                   qx * abs(timediff)**2 / 2,
                    0,
                    0],
-                  [qx * timediff**2 / 2,
-                   qx * timediff,
+                  [qx * abs(timediff)**2 / 2,
+                   qx * abs(timediff),
                    0,
                    0],
                   [0,
                    0,
-                   qy * timediff**3 / 3,
-                   qy * timediff**2 / 2],
+                   qy * abs(timediff)**3 / 3,
+                   qy * abs(timediff)**2 / 2],
                   [0,
                    0,
-                   qy * timediff**2 / 2,
-                   qy * timediff]])
+                   qy * abs(timediff)**2 / 2,
+                   qy * abs(timediff)]])
 
     # Ensure ```model_obj.transfer_function(time_interval)``` returns F
     assert np.array_equal(F, model_obj.jacobian(State(state_vec),

--- a/stonesoup/models/transition/tests/test_cv.py
+++ b/stonesoup/models/transition/tests/test_cv.py
@@ -1,6 +1,7 @@
 import datetime
 
 from pytest import approx
+import pytest
 import numpy as np
 from scipy.stats import multivariate_normal
 
@@ -8,23 +9,24 @@ from ..linear import ConstantVelocity
 from ....types.state import State
 
 
-def test_cvmodel():
+@pytest.mark.parametrize('sign', [1, -1])
+def test_cvmodel(sign):
     """ ConstanVelocity Transition Model test """
 
     # State related variables
     state = State(np.array([[3.0], [1.0]]))
     old_timestamp = datetime.datetime.now()
-    timediff = 1  # 1sec
+    timediff = 1 * sign  # 1sec
     new_timestamp = old_timestamp + datetime.timedelta(seconds=timediff)
     time_interval = new_timestamp - old_timestamp
 
     # Model-related components
     noise_diff_coeff = 0.001  # m/s^2
     F = np.array([[1, timediff], [0, 1]])
-    Q = np.array([[timediff**3 / 3,
-                   timediff**2 / 2],
-                  [timediff**2 / 2,
-                   timediff]]) * noise_diff_coeff
+    Q = np.array([[abs(timediff)**3 / 3,
+                   abs(timediff)**2 / 2],
+                  [abs(timediff)**2 / 2,
+                   abs(timediff)]]) * noise_diff_coeff
 
     # Create and a Constant Velocity model object
     cv = ConstantVelocity(noise_diff_coeff=noise_diff_coeff)

--- a/stonesoup/models/transition/tests/test_nlct.py
+++ b/stonesoup/models/transition/tests/test_nlct.py
@@ -1,29 +1,24 @@
 import datetime
 
+import pytest
 import numpy as np
+
 from ..nonlinear import ConstantTurn
 from ....types.state import State
 
 
-def test_ctmodel(CT_model):
-    """ ConstantTurn Transition Model test """
+@pytest.mark.parametrize('sign', [1, -1])
+def test_nlct(CT_model, sign):
     state = State(np.array([[3.0], [1.0], [2.0], [1.0], [-0.05]]))
     linear_noise_coeffs = np.array([0.1, 0.1])
     turn_noise_coeff = 0.01
-    base(CT_model, ConstantTurn, state, linear_noise_coeffs, turn_noise_coeff)
-
-
-def base(CT_model, model, state, linear_noise_coeffs, turn_noise_coeff):
-    """ Base test for n-dimensional ConstantAcceleration Transition Models """
-
     # Create an ConstantTurn model object
-    model = model
-    model_obj = model(linear_noise_coeffs=linear_noise_coeffs,
-                      turn_noise_coeff=turn_noise_coeff)
+    model_obj = ConstantTurn(linear_noise_coeffs=linear_noise_coeffs,
+                             turn_noise_coeff=turn_noise_coeff)
 
     # State related variables
     old_timestamp = datetime.datetime.now()
-    timediff = 1  # 1sec
+    timediff = 1 * sign  # 1sec
     new_timestamp = old_timestamp + datetime.timedelta(seconds=timediff)
     time_interval = datetime.timedelta(seconds=timediff)
 

--- a/stonesoup/models/transition/tests/test_nlcts.py
+++ b/stonesoup/models/transition/tests/test_nlcts.py
@@ -2,6 +2,7 @@ import datetime
 import copy
 
 import numpy as np
+import pytest
 
 from stonesoup.models.transition.nonlinear import ConstantTurnSandwich
 from stonesoup.models.transition.base import CombinedGaussianTransitionModel
@@ -9,17 +10,13 @@ from stonesoup.models.transition.linear import ConstantVelocity, ConstantAcceler
 from stonesoup.types.state import State
 
 
-def test_ctsmodel(CT_model):
-    """ ConstantTurn Transition Model test """
+@pytest.mark.parametrize('sign', [1, -1])
+def test_nlcts(CT_model, sign):
     state = State(np.array([[3.0], [1.0], [10.], [-1.], [-8.], [-1.], [0.5], [2.0], [1.0],
                             [-0.05]]))
     linear_noise_coeffs = np.array([0.1, 0.1])
     turn_noise_coeff = 0.01
-    base(CT_model, ConstantTurnSandwich, state, linear_noise_coeffs, turn_noise_coeff)
 
-
-def base(ct_model, model, state, linear_noise_coeffs, turn_noise_coeff):
-    """ Base test for n-dimensional ConstantAcceleration Transition Models """
     cv_coeff = 1.1
     ca_coeff = 0.4
 
@@ -29,9 +26,8 @@ def base(ct_model, model, state, linear_noise_coeffs, turn_noise_coeff):
     model_list = [cv_model, ca_model]
     comb_model = CombinedGaussianTransitionModel(model_list=model_list)
     # Create an ConstantTurnSandwich model object
-    model = model
-    model_obj = model(linear_noise_coeffs=linear_noise_coeffs,
-                      turn_noise_coeff=turn_noise_coeff, model_list=model_list)
+    model_obj = ConstantTurnSandwich(linear_noise_coeffs=linear_noise_coeffs,
+                                     turn_noise_coeff=turn_noise_coeff, model_list=model_list)
 
     # State related variables
     old_timestamp = datetime.datetime.now()
@@ -47,7 +43,7 @@ def base(ct_model, model, state, linear_noise_coeffs, turn_noise_coeff):
     idx.extend(list(range(tmp, tmp + 3)))
 
     state2.state_vector = state.state_vector[idx, :]
-    state_out1 = ct_model.function(state2, time_interval=time_interval)
+    state_out1 = CT_model.function(state2, time_interval=time_interval)
     state2.state_vector = state.state_vector[2:-3, :]
     state_out2 = comb_model.function(state2, time_interval=time_interval)
 
@@ -58,7 +54,7 @@ def base(ct_model, model, state, linear_noise_coeffs, turn_noise_coeff):
 
     # Ensure ```model_obj.covar(time_interval)``` returns Q
     # Only checking block diagonal components
-    Q1 = ct_model.covar(linear_noise_coeffs, turn_noise_coeff, time_interval)
+    Q1 = CT_model.covar(linear_noise_coeffs, turn_noise_coeff, time_interval)
     Q2 = comb_model.covar(timestamp=new_timestamp, time_interval=time_interval)
     model_Q = model_obj.covar(timestamp=new_timestamp, time_interval=time_interval)
     assert np.array_equal(model_Q[0:2, 0:2], Q1[0:2, 0:2])

--- a/stonesoup/models/transition/tests/test_ou.py
+++ b/stonesoup/models/transition/tests/test_ou.py
@@ -1,6 +1,7 @@
 import datetime
 
 from pytest import approx
+import pytest
 import numpy as np
 from scipy.stats import multivariate_normal
 
@@ -8,13 +9,14 @@ from stonesoup.models.transition.linear import OrnsteinUhlenbeck
 from ....types.state import State
 
 
-def test_oumodel():
+@pytest.mark.parametrize('sign', [1, -1])
+def test_oumodel(sign):
     """ OrnsteinUhlenbeck Transition Model test """
 
     # State related variables
     state = State(np.array([[3.0], [1.0]]))
     old_timestamp = datetime.datetime.now()
-    timediff = 1  # 1sec
+    timediff = 1 * sign  # 1sec
     new_timestamp = old_timestamp + datetime.timedelta(seconds=timediff)
     time_interval = new_timestamp - old_timestamp
 
@@ -30,10 +32,10 @@ def test_oumodel():
                   [0, exp_kdt]])
 
     q11 = q/k ** 2*(dt - 2/k*(1 - exp_kdt)
-                    + 1/(2*k)*(1 - exp_2kdt))
+                    + 1/(2*k)*(1 - exp_2kdt)) * sign
     q12 = q/k*((1 - exp_kdt)/k
                - 1/(2*k)*(1 - exp_2kdt))
-    q22 = q/(2*k)*(1 - exp_2kdt)
+    q22 = q/(2*k)*(1 - exp_2kdt) * sign
 
     Q = np.array([[q11, q12],
                   [q12, q22]])

--- a/stonesoup/models/transition/tests/test_rw.py
+++ b/stonesoup/models/transition/tests/test_rw.py
@@ -1,6 +1,7 @@
 import datetime
 
 from pytest import approx
+import pytest
 import numpy as np
 from scipy.stats import multivariate_normal
 
@@ -8,20 +9,21 @@ from ..linear import RandomWalk
 from ....types.state import State
 
 
-def test_rwodel():
+@pytest.mark.parametrize('sign', [1, -1])
+def test_rwodel(sign):
     """ RandomWalk Transition Model test """
 
     # State related variables
     state = State(np.array([[3.0]]))
     old_timestamp = datetime.datetime.now()
-    timediff = 1  # 1sec
+    timediff = 1 * sign  # 1sec
     new_timestamp = old_timestamp + datetime.timedelta(seconds=timediff)
     time_interval = new_timestamp - old_timestamp
 
     # Model-related components
     noise_diff_coeff = 0.001  # m/s^2
     F = np.array([[1]])
-    Q = np.array([[timediff]]) * noise_diff_coeff
+    Q = np.array([[abs(timediff)]]) * noise_diff_coeff
 
     # Create and a Random Walk model object
     rw = RandomWalk(noise_diff_coeff=noise_diff_coeff)

--- a/stonesoup/models/transition/tests/test_singer_approximate.py
+++ b/stonesoup/models/transition/tests/test_singer_approximate.py
@@ -1,43 +1,21 @@
 import datetime
 
 from pytest import approx
+import pytest
 import numpy as np
 import scipy as sp
 from scipy.stats import multivariate_normal
 
+from .test_singer import singer_model_params  # noqa: F401
 from ..linear import SingerApproximate
 from ..base import CombinedGaussianTransitionModel
 from ....types.state import State
 
 
-def test_singer1dmodel_approximate():
-    """ SingerApproximate 1D Transition Model test for small timediff """
-    state = State(np.array([[3.0], [1.0], [0.1]]))
-    noise_diff_coeffs = np.array([0.01])
-    damping_coeffs = np.array([0.1])
-    base(state, noise_diff_coeffs, damping_coeffs, timediff=0.4)
-
-
-def test_singer2dmodel_approximate():
-    """ SingerApproximate 2D Transition Model test for small timediff """
-    state = State(np.array([[3.0], [1.0], [0.1], [2.0], [2.0], [0.2]]))
-    noise_diff_coeffs = np.array([0.01, 0.02])
-    damping_coeffs = np.array([0.1, 0.1])
-
-    base(state, noise_diff_coeffs, damping_coeffs, timediff=0.4)
-
-
-def test_singer3dmodel_approximate():
-    """ SingerApproximate 3D Transition Model test for small timediff """
-    state = State(np.array([[3.0], [1.0], [0.1], [2.0], [2.0], [0.2], [4.0],
-                            [0.5], [0.05]]))
-    noise_diff_coeffs = np.array([0.01, 0.02, 0.005])
-    damping_coeffs = np.array([0.1, 0.1, 0.1])
-    base(state, noise_diff_coeffs, damping_coeffs, timediff=0.4)
-
-
-def base(state, noise_diff_coeffs, damping_coeffs, timediff=1.0):
-    """ Base test for n-dimensional ConstantAcceleration Transition Models """
+@pytest.mark.parametrize('sign', [1, -1])
+def test_singer_approximate(singer_model_params, sign):  # noqa: F811
+    state, noise_diff_coeffs, damping_coeffs = singer_model_params
+    timediff = 0.4 * sign
 
     state_vec = state.state_vector
 
@@ -85,15 +63,15 @@ def base(state, noise_diff_coeffs, damping_coeffs, timediff=1.0):
               np.exp(-damping_coeffdt)]]))
 
         covar_list.append(np.array(
-            [[timediff**5 / 20,
-              timediff**4 / 8,
-              timediff**3 / 6],
-             [timediff**4 / 8,
-              timediff**3 / 3,
-              timediff**2 / 2],
-             [timediff**3 / 6,
-              timediff**2 / 2,
-              timediff]]) * noise_diff_coeff)
+            [[abs(timediff)**5 / 20,
+              abs(timediff)**4 / 8,
+              abs(timediff)**3 / 6],
+             [abs(timediff)**4 / 8,
+              abs(timediff)**3 / 3,
+              abs(timediff)**2 / 2],
+             [abs(timediff)**3 / 6,
+              abs(timediff)**2 / 2,
+              abs(timediff)]]) * noise_diff_coeff)
 
     F = sp.linalg.block_diag(*mat_list)
     Q = sp.linalg.block_diag(*covar_list)


### PR DESCRIPTION
Models are updated to allow backwards prediction, which can be useful for dealing with track stitching, out of sequence measurements, etc.

In general many models supported this in their function, but not for covariance.