### PR TITLE
Fix KnownTurnRate model not using 2nd noise parameter

### DIFF
--- a/stonesoup/models/transition/linear.py
+++ b/stonesoup/models/transition/linear.py
@@ -648,8 +648,8 @@ class KnownTurnRateSandwich(LinearGaussianTransitionModel, TimeVariantModel):
         covar_list = [model.covar(time_interval) for model in self.model_list]
         ctc1 = np.array([[q1*dt**3/3, q1*dt**2/2],
                          [q1*dt**2/2, q1*dt]])
-        ctc2 = np.array([[q1*dt**3/3, q1*dt**2/2],
-                         [q1*dt**2/2, q1*dt]])
+        ctc2 = np.array([[q2*dt**3/3, q2*dt**2/2],
+                         [q2*dt**2/2, q2*dt]])
         return CovarianceMatrix(block_diag(ctc1, *covar_list, ctc2))
 
 

--- a/stonesoup/models/transition/tests/test_ct.py
+++ b/stonesoup/models/transition/tests/test_ct.py
@@ -11,7 +11,7 @@ from ....types.state import State
 def test_ctmodel():
     """ KnownTurnRate Transition Model test """
     state = State(np.array([[3.0], [1.0], [2.0], [1.0]]))
-    turn_noise_diff_coeffs = np.array([0.01, 0.01])
+    turn_noise_diff_coeffs = np.array([0.01, 0.02])
     turn_rate = 0.1
     base(KnownTurnRate, state, turn_noise_diff_coeffs, turn_rate)
 


### PR DESCRIPTION
Both dimensions were using the same (first dimension's) noise parameter.