### PR TITLE
Computation performance with multi-sensor update wrappers

### DIFF
--- a/docs/source/stonesoup.updater.rst
+++ b/docs/source/stonesoup.updater.rst
@@ -95,3 +95,9 @@ Probabilistic
 
 .. automodule:: stonesoup.updater.probability
     :show-inheritance:
+
+Multi
+-----
+
+.. automodule:: stonesoup.updater.multi
+    :show-inheritance:

--- a/stonesoup/updater/multi.py
+++ b/stonesoup/updater/multi.py
@@ -1,0 +1,64 @@
+"""Updaters designed to wrap existing updaters that may offer a performance benefit
+in certain circumstances when dealing with many sensors
+"""
+import warnings
+
+import numpy as np
+
+from stonesoup.base import Property
+from stonesoup.models.measurement.nonlinear import CombinedReversibleGaussianMeasurementModel
+from stonesoup.types.detection import Detection
+from stonesoup.types.hypothesis import SingleHypothesis
+from stonesoup.types.multihypothesis import MultipleHypothesis
+from stonesoup.updater import Updater
+
+
+class CombineMeasurementUpdater(Updater):
+    """Combine measurement updater
+
+    This combines multiple measurements into a single measurement by combining their
+    state vectors and models.
+
+    All :class:`~.Detection` must have a measurement model associated with them,
+    and have the same associated prediction/timestamp.
+
+    In case where you have multiple measurements from many sensors at the
+    same timestamp, this may provide a computation performance increase over
+    sequential updates.
+    For linear case, this should provide equivalent update to sequential updates.
+    However, for a non-linear case will result in non-optimal update due to
+    linearisation differences.
+    """
+    measurement_model = None
+    updater: Updater = Property(doc="Base updater being wrapped")
+
+    def predict_measurement(self, *args, **kwargs):
+        return self.updater.predict_measurement(*args, **kwargs)
+
+    def update(self, hypothesis: MultipleHypothesis, **kwargs):
+        if len(hypothesis) == 1:  # No need to combine
+            return self.updater.update(hypothesis[0])
+
+        models = []
+        state_vectors = []
+        predictions = set()
+        for hyp in hypothesis:
+            state_vectors.append(hyp.measurement.state_vector)
+            models.append(hyp.measurement.measurement_model)
+            predictions.add(hyp.prediction)
+
+        if len(predictions) > 1:
+            warnings.warn("More than one prediction in combined update")
+        prediction = predictions.pop()
+
+        measurement = Detection(
+            state_vector=np.vstack(state_vectors),
+            timestamp=prediction.timestamp,
+            measurement_model=CombinedReversibleGaussianMeasurementModel(models)
+        )
+
+        update = self.updater.update(SingleHypothesis(prediction, measurement))
+
+        update.hypothesis = hypothesis
+
+        return update

--- a/stonesoup/updater/multi.py
+++ b/stonesoup/updater/multi.py
@@ -1,7 +1,10 @@
 """Updaters designed to wrap existing updaters that may offer a performance benefit
 in certain circumstances when dealing with many sensors
 """
+import copy
 import warnings
+from functools import partial
+from multiprocessing import Pool
 
 import numpy as np
 
@@ -10,7 +13,60 @@ from stonesoup.models.measurement.nonlinear import CombinedReversibleGaussianMea
 from stonesoup.types.detection import Detection
 from stonesoup.types.hypothesis import SingleHypothesis
 from stonesoup.types.multihypothesis import MultipleHypothesis
+from stonesoup.types.update import Update
 from stonesoup.updater import Updater
+from stonesoup.updater.kalman import KalmanUpdater
+
+
+class ParallelUpdater(Updater):
+    """Parallel Updater
+
+    All :class:`~.Detection` must have the same associated prediction/timestamp.
+
+    In case where you have multiple measurements from many sensors at the
+    same timestamp, this may provide a computation performance increase over
+    sequential updates with :attr:`multiprocessing` enabled.
+    For linear case, this should provide equivalent update to sequential updates.
+    However, for a non-linear case will result in non-optimal update due to
+    linearisation differences.
+    """
+    measurement_model = None
+    updater: KalmanUpdater = Property(doc="Base updater to be called in parallel")
+    multiprocessing: bool = Property(default=False, doc="Use multiprocessing Pool for updates")
+
+    def predict_measurement(self, *args, **kwargs):
+        return self.updater.predict_measurement(*args, **kwargs)
+
+    def update(self, hypothesis: MultipleHypothesis, **kwargs):
+        if len(hypothesis) == 1:  # No need for parallelism
+            return self.updater.update(hypothesis[0])
+
+        predictions = {hyp.prediction for hyp in hypothesis}
+        if len(predictions) > 1:
+            warnings.warn("More than one prediction in parallel update")
+        prediction = copy.copy(predictions.pop())
+        prediction.covar = prediction.covar * len(hypothesis)
+
+        # this can be computed in parallel
+        new_hypotheses = (SingleHypothesis(prediction, hyp.measurement) for hyp in hypothesis)
+        if self.multiprocessing:
+            with Pool() as p:
+                updates = p.map(partial(self.updater.update, **kwargs), new_hypotheses)
+        else:
+            updates = [self.updater.update(hyp, **kwargs) for hyp in new_hypotheses]
+
+        # here results are collected and fused
+        fused_covar = np.linalg.inv(
+            np.sum(np.array([np.linalg.inv(upd.covar) for upd in updates]), axis=0))
+        fused_state = fused_covar @ np.sum(
+            np.array([np.linalg.inv(upd.covar) @ upd.state_vector for upd in updates]), axis=0)
+
+        return Update.from_state(
+            prediction,
+            state_vector=fused_state,
+            covar=fused_covar,
+            hypothesis=hypothesis
+        )
 
 
 class CombineMeasurementUpdater(Updater):

--- a/stonesoup/updater/tests/test_multi.py
+++ b/stonesoup/updater/tests/test_multi.py
@@ -1,0 +1,86 @@
+import datetime
+
+import numpy as np
+import pytest
+
+from ..kalman import ExtendedKalmanUpdater
+from ..multi import ParallelUpdater, CombineMeasurementUpdater
+from ...types.detection import Detection
+from ...types.hypothesis import SingleHypothesis
+from ...types.prediction import GaussianStatePrediction
+from ...types.state import State
+from ...models.measurement.linear import LinearGaussian
+from ...models.measurement.nonlinear import CartesianToBearingRange
+
+
+@pytest.fixture(params=['linear', 'nonlinear'])
+def single_updater(request):
+    return request.param(None)
+
+
+@pytest.fixture(params=['combine', 'parallel', 'parallel_multip'])
+def multi_updater(request):
+    if request.param == 'combine':
+        return CombineMeasurementUpdater(ExtendedKalmanUpdater(None))
+    elif request.param.startswith('parallel'):
+        return ParallelUpdater(
+            ExtendedKalmanUpdater(None), multiprocessing=request.param.endswith('multip'))
+
+
+@pytest.fixture(params=['linear', 'nonlinear'])
+def models(request):
+    if request.param == 'linear':
+        return [
+            LinearGaussian(4, [0, 2], np.diag([1.5, 1.5])),
+            LinearGaussian(4, [0, 2], np.diag([0.5, 0.5]))
+        ]
+    elif request.param == 'nonlinear':
+        return [
+            CartesianToBearingRange(
+                4, [0, 2], np.diag([0.01, 1.5]), translation_offset=np.array([[10], [0]])),
+            CartesianToBearingRange(
+                4, [0, 2], np.diag([0.01, 0.5]), translation_offset=np.array([[0], [-5]]))
+        ]
+
+
+@pytest.mark.parametrize('n_dets', [1, 2])
+def test_multi_updater(multi_updater, models, n_dets):
+    timestamp = datetime.datetime(2025, 4, 3, 12)
+    gt = State([5, 0, 5, 0])
+
+    prediction = GaussianStatePrediction(
+        [4.6, 0.5, 5.6, -0.5],
+        np.diag([1., 0.25, 1., 0.25]),
+        timestamp
+        )
+
+    detections = [Detection(model.function(gt), timestamp, model) for model in models][:n_dets]
+
+    assert multi_updater.predict_measurement(prediction, models[0]) \
+        is multi_updater.updater.predict_measurement(prediction, models[0])
+    assert multi_updater.predict_measurement(prediction, models[1]) \
+        is multi_updater.updater.predict_measurement(prediction, models[1])
+
+    seq_post = prediction
+    for detection in detections:
+        seq_post = multi_updater.updater.update(SingleHypothesis(seq_post, detection))
+
+    mul_post = multi_updater.update(
+        [SingleHypothesis(prediction, detection) for detection in detections])
+
+    if isinstance(models[0], LinearGaussian):
+        rtol = 1e-9  # Linear should be identical...
+    else:
+        rtol = 1e-3  # Non-linear non-optimal due to linearisation
+
+    assert np.allclose(mul_post.state_vector, seq_post.state_vector, rtol=rtol)
+
+
+def test_multi_updater_multi_predictions(multi_updater):
+    model = LinearGaussian(1, [0], [[1]])
+    t = datetime.datetime(2025, 4, 3, 12)
+    with pytest.warns(match="More than one prediction"):
+        multi_updater.update([
+            SingleHypothesis(GaussianStatePrediction([[1]], [[2]], t), Detection([[0]], t, model)),
+            SingleHypothesis(GaussianStatePrediction([[1]], [[3]], t), Detection([[0]], t, model)),
+        ])


### PR DESCRIPTION
This PR includes two updater wrappers that may result in computation performance increases when dealing with large number of measurements at the same time from multiple sensors. This may be slower when only using small amount of data, and also can result in non-optimal results in case of non-linear measurement models.