### PR TITLE
Updated the Pandas DataFrame Example and a few other small tweaks

### DIFF
--- a/docs/examples/filters/Multi_Tracker_Example.py
+++ b/docs/examples/filters/Multi_Tracker_Example.py
@@ -241,7 +241,6 @@ init_transition_model = CombinedLinearGaussianTransitionModel(
     (ConstantVelocity(1), ConstantVelocity(1)))
 init_predictor_EKF = ExtendedKalmanPredictor(init_transition_model)
 init_predictor_UKF = UnscentedKalmanPredictor(init_transition_model)
-init_predictor_PF = ParticlePredictor(init_transition_model)
 
 # %%
 # The final step before running the trackers is to create the initiators:

--- a/docs/examples/metrics/Metrics.py
+++ b/docs/examples/metrics/Metrics.py
@@ -322,8 +322,6 @@ hypothesiser_PF = DistanceHypothesiser(predictor_PF, updater_PF,
                                        measure=Mahalanobis(), missed_distance=4)
 data_associator_PF = GNNWith2DAssignment(hypothesiser_PF)
 
-init_predictor_PF = ParticlePredictor(init_transition_model)
-
 from stonesoup.initiator.simple import GaussianParticleInitiator
 from stonesoup.types.state import GaussianState
 from stonesoup.initiator.simple import SimpleMeasurementInitiator

--- a/docs/examples/readers/Custom_Pandas_Dataloader.py
+++ b/docs/examples/readers/Custom_Pandas_Dataloader.py
@@ -1,10 +1,11 @@
 """
-Use of Custom Readers that support Pandas DataFrames
-====================================================
-This is a demonstration of using customised readers that
-support data contained within Pandas DataFrames, rather than
-loading directly from a .csv file using :class:`~.CSVGroundTruthReader` or
-:class:`~.CSVDetectionReader`.
+Creating a Custom Reader - Pandas DataFrame
+===========================================
+There are a number of Readers included within Stone Soup, allowing data to be loaded from a
+variety of files/formats. This example demonstrates how to create a customised Reader to
+support additional data formats. In this case, the new reader here supports data contained
+within Pandas DataFrames, rather than loading directly from a .csv file using
+:class:`~.CSVGroundTruthReader` or :class:`~.CSVDetectionReader`.
 
 The benefit is that this allows us to use the versatile data loading
 capabilities of pandas to read from many different data source types
@@ -12,6 +13,9 @@ as needed, including .csv, JSON, XML, Parquet, HDF5, .txt, .zip and more.
 The resulting DataFrame can then simply be fed into the defined
 `DataFrameGroundTruthReader` or `DataFrameDetectionReader` for further processing
 in Stone Soup as required.
+
+Notice: This is only an example. Stone Soup already includes Readers to load data from
+Pandas DataFrames.
 """
 
 # %%

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -88,9 +88,9 @@ sphinx_gallery_conf = {
 
 intersphinx_mapping = {
     'python': ('https://docs.python.org/{.major}'.format(sys.version_info), None),
-    'matplotlib': ('https://matplotlib.org/', None),
-    'numpy': ('https://docs.scipy.org/doc/numpy', None),
-    'scipy': ('https://docs.scipy.org/doc/scipy/reference', None),
+    'matplotlib': ('https://matplotlib.org/stable', None),
+    'numpy': ('https://numpy.org/doc/stable', None),
+    'scipy': ('https://docs.scipy.org/doc/scipy', None),
 }
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -44,6 +44,12 @@ following command::
 
     git clean -xf docs/source/auto_*
 
+Some examples may require additional packages beyond the dev installation.
+These are likely all located in the optional dependencies section of the
+top-level `pyproject.toml` file and can be installed through commands such as::
+
+    pip install .[ehm]
+
 Tests
 -----
 PyTest_ is used for testing in Stone Soup. As much effort should be put into

--- a/docs/source/stonesoup.reader.rst
+++ b/docs/source/stonesoup.reader.rst
@@ -55,3 +55,7 @@ Astronomical
 .. automodule:: stonesoup.reader.astronomical
     :show-inheritance:
 
+Pandas DataFrame
+----------------
+.. automodule:: stonesoup.reader.pandas_reader
+    :show-inheritance:

--- a/stonesoup/reader/pandas_reader.py
+++ b/stonesoup/reader/pandas_reader.py
@@ -62,10 +62,10 @@ class _DataFrameReader(Reader):
 class DataFrameGroundTruthReader(GroundTruthReader, _DataFrameReader):
     """A custom reader for pandas DataFrames containing truth data.
 
-    The DataFrame must have colums containing all fields needed to generate the
+    The DataFrame must have columns containing all fields needed to generate the
     ground truth state. Those states with the same ID will be put into
-    a :class:`~.GroundTruthPath` in sequence, and all paths that are updated at the same time
-    are yielded together, and such assumes file is in time order.
+    a :class:`~.GroundTruthPath` in sequence. All paths that are updated at the same time
+    are yielded together. Assume DataFrame is in time order.
 
     Parameters
     ----------
@@ -106,14 +106,13 @@ class DataFrameGroundTruthReader(GroundTruthReader, _DataFrameReader):
 class DataFrameDetectionReader(DetectionReader, _DataFrameReader):
     """A custom detection reader for DataFrames containing detections.
 
-    DataFrame must have headers with the appropriate fields needed to generate
-    the detection. Detections at the same time are yielded together, and such assume file is in
-    time order.
+    The DataFrame must have columns containing all fields needed to generate the detection.
+    Detections at the same time are yielded together. Assume DataFrame is in time order.
 
     Parameters
     ----------
     """
-    dataframe: pd.DataFrame = Property(doc="DataFrame containing the ground truth data.")
+    dataframe: pd.DataFrame = Property(doc="DataFrame containing the detections data.")
 
     @BufferedGenerator.generator_method
     def detections_gen(self):


### PR DESCRIPTION
Addresses #1146 

The main purpose of this PR is to clarify the Pandas DataFrame support in Stone Soup:
1. Mention the example is only for demonstration purposes (the support for reading pandas DFs is already included in Stone Soup). I was originally going to remove the `Reader` implementations from that example. But then I found #354 and #707 about it serving as a demonstration for how users can add custom Reader classes and figured it is worth keeping, along with a clarifying note.
2. Make the Pandas DataFrame Reader classes appear in the Stone Soup docs.

Along the way I found a few other tweaks to examples and documentation that seem like improvements (happy to discuss).
I also updated a few URLs in the sphinx document generation because the command output suggested to do so.