### PR TITLE
Add PathBasedPlatform

### DIFF
--- a/stonesoup/platform/__init__.py
+++ b/stonesoup/platform/__init__.py
@@ -1,4 +1,5 @@
-from .base import Platform, MovingPlatform, FixedPlatform, MultiTransitionMovingPlatform
+from .base import Platform, MovingPlatform, FixedPlatform, MultiTransitionMovingPlatform, \
+    PathBasedPlatform
 
 __all__ = ['Platform', 'MovingPlatform', 'FixedPlatform', 'MultiTransitionMovingPlatform',
            'PathBasedPlatform']

--- a/stonesoup/platform/__init__.py
+++ b/stonesoup/platform/__init__.py
@@ -1,3 +1,4 @@
 from .base import Platform, MovingPlatform, FixedPlatform, MultiTransitionMovingPlatform
 
-__all__ = ['Platform', 'MovingPlatform', 'FixedPlatform', 'MultiTransitionMovingPlatform']
+__all__ = ['Platform', 'MovingPlatform', 'FixedPlatform', 'MultiTransitionMovingPlatform',
+           'PathBasedPlatform']

--- a/stonesoup/platform/base.py
+++ b/stonesoup/platform/base.py
@@ -1,7 +1,10 @@
 import uuid
 from collections.abc import MutableSequence
+from datetime import datetime
+
 
 from ..base import Property, Base
+from ..functions.interpolate import interpolate_state_mutable_sequence
 from ..movable import Movable, FixedMovable, MovingMovable, MultiTransitionMovable
 from ..sensor.sensor import Sensor
 from ..types.groundtruth import GroundTruthPath
@@ -189,3 +192,12 @@ class MovingPlatform(Platform):
 
 class MultiTransitionMovingPlatform(Platform):
     _default_movable_class = MultiTransitionMovable
+
+
+class PathBasedPlatform(MovingPlatform):
+    path: GroundTruthPath = Property(doc="Ground truth path used for the platform. "
+                                     "This is for use in cases when platform paths are imported "
+                                     "from external data, e.g., from a CSV file")
+
+    def move(self, timestamp: datetime):
+        self.states.append(interpolate_state_mutable_sequence(self.path, [timestamp]))

--- a/stonesoup/platform/base.py
+++ b/stonesoup/platform/base.py
@@ -202,6 +202,8 @@ class PathBasedPlatform(MovingPlatform):
     def __init__(self, *args, **kwargs):
         if "states" not in kwargs.keys() or kwargs["states"] is None:
             kwargs["states"] = [kwargs["path"][0]]
+        if "transition_model" not in kwargs.keys():
+            kwargs["transition_model"] = None
         super().__init__(*args, **kwargs)
 
     def move(self, timestamp: datetime):

--- a/stonesoup/platform/base.py
+++ b/stonesoup/platform/base.py
@@ -199,5 +199,10 @@ class PathBasedPlatform(MovingPlatform):
                                      "This is for use in cases when platform paths are imported "
                                      "from external data, e.g., from a CSV file")
 
+    def __init__(self, *args, **kwargs):
+        if "states" not in kwargs.keys() or kwargs["states"] is None:
+            kwargs["states"] = [kwargs["path"][0]]
+        super().__init__(*args, **kwargs)
+
     def move(self, timestamp: datetime):
         self.states.append(interpolate_state_mutable_sequence(self.path, [timestamp]))

--- a/stonesoup/platform/tests/test_platform_base.py
+++ b/stonesoup/platform/tests/test_platform_base.py
@@ -846,10 +846,9 @@ def test_path(states):
         gt[platform.states[-1].timestamp]
 
 
-def test_path_no_states():
+def test_path_no_states_no_tm():
     platform = PathBasedPlatform(path=gt,
-                                 position_mapping=[0],
-                                 transition_model=None)
+                                 position_mapping=[0])
     platform.move(timestamp=start_time + datetime.timedelta(seconds=1))
     assert len(platform.states) == 2
     assert np.allclose(platform.states[-1].state_vector, GroundTruthState([-0.5, 1]).state_vector)

--- a/stonesoup/platform/tests/test_platform_base.py
+++ b/stonesoup/platform/tests/test_platform_base.py
@@ -831,9 +831,23 @@ gt = GroundTruthPath(
      for i in range(2)])
 
 
-def test_path():
-    platform = PathBasedPlatform(path=GroundTruthPath(states=gt),
-                                 states=[gt[0]],
+@pytest.mark.parametrize("states", [None, [gt[0]]])
+def test_path(states):
+    platform = PathBasedPlatform(path=gt,
+                                 states=states,
+                                 position_mapping=[0],
+                                 transition_model=None)
+    platform.move(timestamp=start_time + datetime.timedelta(seconds=1))
+    assert len(platform.states) == 2
+    assert np.allclose(platform.states[-1].state_vector, GroundTruthState([-0.5, 1]).state_vector)
+
+    with pytest.raises(
+            IndexError, match="timestamp not found in states"):
+        gt[platform.states[-1].timestamp]
+
+
+def test_path_no_states():
+    platform = PathBasedPlatform(path=gt,
                                  position_mapping=[0],
                                  transition_model=None)
     platform.move(timestamp=start_time + datetime.timedelta(seconds=1))


### PR DESCRIPTION
This PR adds a `PathBasedPlatform` class. This class has the abiltiy to define a platform by a `GroundTruthPath` rather than a an individual `TransitionModel` or multiple.