### PR TITLE
Add sub_tracks and root_tracks properties to track type

### DIFF
--- a/stonesoup/tests/test_repr.py
+++ b/stonesoup/tests/test_repr.py
@@ -38,7 +38,8 @@ def test_repr():
                                                  [15. ]]),
                        timestamp=1)],
             id=1,
-            init_metadata={})''')
+            init_metadata={},
+            sub_tracks=set())''')
     act_repr2 = repr(track)
     assert exp_repr2 == act_repr2
     too_big = State([0] * 500000)  # This should not print in its entirety as it is far too large

--- a/stonesoup/types/track.py
+++ b/stonesoup/types/track.py
@@ -1,6 +1,7 @@
 import copy
 import uuid
 from collections.abc import MutableSequence, MutableMapping
+from typing import Collection
 
 from .multihypothesis import MultipleHypothesis
 from .state import State, StateMutableSequence
@@ -31,6 +32,10 @@ class Track(StateMutableSequence):
         default={}, doc="Initial dictionary of metadata items for track. Default `None` which "
                         "initialises track metadata as an empty dictionary.")
 
+    sub_tracks: set = Property(
+        default=None,
+        doc="The initial sub tracks of the track. Default ``None`` will initialise an empty set.")
+
     def __init__(self, *args, **kwargs):
 
         super().__init__(*args, **kwargs)
@@ -41,6 +46,13 @@ class Track(StateMutableSequence):
             self._update_metadata_from_state(state)
         if self.id is None:
             self.id = str(uuid.uuid4())
+
+        if self.sub_tracks is None:
+            self.sub_tracks = set()
+        elif isinstance(self.sub_tracks, Track):
+            self.sub_tracks = set([self.sub_tracks])
+        elif isinstance(self.sub_tracks, Collection):
+            self.sub_tracks = set(self.sub_tracks)
 
     def __setitem__(self, index, value):
         super().__setitem__(index, value)
@@ -140,3 +152,12 @@ class Track(StateMutableSequence):
                 hypothesis = state.hypothesis
                 if hypothesis and hypothesis.measurement.metadata is not None:
                     self.metadata.update(hypothesis.measurement.metadata)
+
+    @property
+    def root_tracks(self) -> set:
+        root_tracks = set()
+        for track in self.sub_tracks:
+            root_tracks.update(track.root_tracks)
+        if len(root_tracks) == 0:
+            root_tracks = set(self.sub_tracks)
+        return root_tracks

--- a/stonesoup/writer/tests/test_yaml.py
+++ b/stonesoup/writer/tests/test_yaml.py
@@ -108,6 +108,7 @@ def test_tracks_yaml(tracker, tmpdir):
                 - [1]
               - timestamp: *id001
           - id: '0'
+          - sub_tracks: !!set {}
           :
         ...
         """)


### PR DESCRIPTION
The `sub_tracks` property contains a set of tracks that are important to the formation of the track, e.g. in the case of track fusion this would be the set of tracks that were fused together to form this track.
The `root_tracks` property is the total set of `sub_tracks` including the `sub_tracks` of tracks that were used to form the top level track.