### PR TITLE
Fix issue with docs building with new kaleido release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,7 +94,7 @@ jobs:
   docs:
     resource_class: medium
     docker:
-      - image: cimg/python:3.12
+      - image: cimg/python:3.12-browsers
     steps:
       - checkout
       - restore_cache:
@@ -107,6 +107,7 @@ jobs:
             pip install --upgrade pip
             pip install -r docs/ci-requirements.txt
             pip install -e .[dev,orbital] opencv-python-headless joblib
+            kaleido_get_chrome
       - save_cache:
           paths:
             - ./venv

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -7,6 +7,22 @@ build:
   os: ubuntu-lts-latest
   tools:
     python: "3.12"
+  apt_packages:
+    - libnss3
+    - libatk-bridge2.0-0
+    - libcups2
+    - libxcomposite1
+    - libxdamage1
+    - libxfixes3
+    - libxrandr2
+    - libgbm1
+    - libxkbcommon0
+    - libpango-1.0-0
+    - libcairo2
+    - libasound2
+  jobs:
+    post_install:
+      - kaleido_get_chrome
 
 python:
   install:

--- a/docs/ci-requirements.txt
+++ b/docs/ci-requirements.txt
@@ -1,6 +1,6 @@
 # Additional requirement for CircleCI and Read The Docs
 # Needed to generate thumbnails in Sphinx-Gallery
-kaleido
+kaleido>=1.0.0
 # Additional requirement for EHM example [To fix the failing tests]
 pyehm
 # Additional requirement for ODE example

--- a/stonesoup/plotter.py
+++ b/stonesoup/plotter.py
@@ -1156,22 +1156,22 @@ class Plotterly(_Plotter):
             if self.dimension == 1:
                 self.fig.add_scatter(
                     x=[state.timestamp for state in truth],
-                    y=[state.state_vector[mapping[0]] for state in truth],
+                    y=[float(state.state_vector[mapping[0]]) for state in truth],
                     text=[self._format_state_text(state) for state in truth],
                     **scatter_kwargs)
 
             elif self.dimension == 2:
                 self.fig.add_scatter(
-                    x=[state.state_vector[mapping[0]] for state in truth],
-                    y=[state.state_vector[mapping[1]] for state in truth],
+                    x=[float(state.state_vector[mapping[0]]) for state in truth],
+                    y=[float(state.state_vector[mapping[1]]) for state in truth],
                     text=[self._format_state_text(state) for state in truth],
                     **scatter_kwargs)
 
             elif self.dimension == 3:
                 self.fig.add_scatter3d(
-                    x=[state.state_vector[mapping[0]] for state in truth],
-                    y=[state.state_vector[mapping[1]] for state in truth],
-                    z=[state.state_vector[mapping[2]] for state in truth],
+                    x=[float(state.state_vector[mapping[0]]) for state in truth],
+                    y=[float(state.state_vector[mapping[1]]) for state in truth],
+                    z=[float(state.state_vector[mapping[2]]) for state in truth],
                     text=[self._format_state_text(state) for state in truth],
                     **scatter_kwargs)
 


### PR DESCRIPTION
Due to changes with Kaleido, Chrome must be manually downloaded if not already installed (the case on CI/CD set up).

Also, new version doesn't like custom Bearing/Elevation types, so force these to floats (already done for tracks/measurements but not for truth).