### PR TITLE
Ensure StateVector/StateVectors is used is combined measurement model

### DIFF
--- a/stonesoup/models/measurement/nonlinear.py
+++ b/stonesoup/models/measurement/nonlinear.py
@@ -54,9 +54,9 @@ class CombinedReversibleGaussianMeasurementModel(ReversibleModel, GaussianModel,
     def mapping(self):
         return [x for model in self.model_list for x in model.mapping]
 
-    def function(self, state, **kwargs) -> StateVector:
-        return np.vstack([model.function(state, **kwargs)
-                          for model in self.model_list]).view(StateVector)
+    def function(self, state, *args, **kwargs) -> StateVector:
+        state_vectors = [model.function(state, *args, **kwargs) for model in self.model_list]
+        return np.vstack(state_vectors).view(type(state_vectors[0]))
 
     def jacobian(self, state, **kwargs):
         return np.vstack([model.jacobian(state, **kwargs) for model in self.model_list])

--- a/stonesoup/models/measurement/tests/test_combined.py
+++ b/stonesoup/models/measurement/tests/test_combined.py
@@ -3,8 +3,7 @@ from pytest import approx
 import numpy as np
 
 from ....types.angle import Bearing
-from ....types.array import StateVector, CovarianceMatrix
-from ....types.detection import Detection
+from ....types.array import CovarianceMatrix, StateVector, StateVectors
 from ....types.state import State
 from ..linear import LinearGaussian
 from ..nonlinear import (
@@ -24,7 +23,7 @@ def test_non_linear(model):
     assert model.ndim_state == 5
 
     meas_vector = model.function(
-        Detection(StateVector([[0], [10], [10], [0], [-10]])))
+        State(StateVector([[0], [10], [10], [0], [-10]])))
 
     assert isinstance(meas_vector[0, 0], Bearing)
     assert not isinstance(meas_vector[1, 0], Bearing)
@@ -36,6 +35,24 @@ def test_non_linear(model):
                           np.array([[np.pi/2], [10], [-np.pi/2], [10]]))
 
     assert model.mapping == [0, 1, 3, 4]
+
+
+def test_non_linear_state_vectors(model):
+    meas_vector = model.function(
+        State(StateVectors([[0, 0], [10, -10], [10, 10], [0, 0], [-10, 10]])))
+
+    assert isinstance(meas_vector[0, 0], Bearing)
+    assert not isinstance(meas_vector[1, 0], Bearing)
+    assert isinstance(meas_vector[2, 0], Bearing)
+    assert not isinstance(meas_vector[3, 0], Bearing)
+    assert isinstance(meas_vector[0, 1], Bearing)
+    assert not isinstance(meas_vector[1, 1], Bearing)
+    assert isinstance(meas_vector[2, 1], Bearing)
+    assert not isinstance(meas_vector[3, 1], Bearing)
+    assert isinstance(meas_vector, StateVectors)
+
+    assert np.array_equal(meas_vector,
+                          np.array([[np.pi/2, -np.pi/2], [10, 10], [-np.pi/2, np.pi/2], [10, 10]]))
 
 
 def test_jacobian(model):


### PR DESCRIPTION
Currently always uses StateVector which causes issue (e.g. with UKF) when should be StateVectors.

Type is used from first model response, as logic on which to use would have already been done in each model