### PR TITLE
Fixed typo in Animated Plotterly plot_tracks docstring

### DIFF
--- a/stonesoup/plotter.py
+++ b/stonesoup/plotter.py
@@ -2904,9 +2904,9 @@ class AnimatedPlotterly(_Plotter):
 
         Parameters
         ----------
-        tracks: Collection of :class '~Track'
+        tracks: Collection of :class:`~.Track`
             Collection of tracks which will be plotted. If not a collection, and instead a single
-            :class:'~Track' type, the argument is modified to be a set to allow for iteration
+            :class:`~.Track` type, the argument is modified to be a set to allow for iteration
 
         mapping: list
             List of items specifying the mapping of the position


### PR DESCRIPTION
Noticed a typo where the `Track` type wasn't linked in `AnimatedPlotterly`'s `plot_tracks` docstring. 

Built the html files to verify that these changed linked it correctly. 

This is my first ever PR so let me know if I messed anything up :).