### PR TITLE
Drop support for Python 3.9

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,6 @@ workflows:
       - flake8
   test:
     jobs:
-      - test-39
       - test-310
       - test-311
       - test-312
@@ -15,9 +14,9 @@ workflows:
     jobs:
       - docs
 jobs:
-  test-39: &test-template
+  test-310: &test-template
     docker:
-      - image: cimg/python:3.9
+      - image: cimg/python:3.10
     steps:
       - checkout
       - restore_cache:
@@ -50,10 +49,6 @@ jobs:
               -f test-reports/coverage.xml \
               -F unittests \
               -n ${CIRCLE_BUILD_NUM}
-  test-310:
-    <<: *test-template
-    docker:
-      - image: cimg/python:3.10
   test-311:
     <<: *test-template
     docker:

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -5,6 +5,6 @@ coverage:
         threshold: 0.1%
 codecov:
   notify:
-    after_n_builds: 6
+    after_n_builds: 5
 comment:
-  after_n_builds: 6
+  after_n_builds: 5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
     "Programming Language :: Python :: 3 :: Only",
     "Topic :: Scientific/Engineering",
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
     "matplotlib",
     "numpy>=1.17",

--- a/stonesoup/dataassociator/clearmot.py
+++ b/stonesoup/dataassociator/clearmot.py
@@ -1,6 +1,5 @@
 import datetime
 import itertools
-import sys
 from collections import defaultdict
 from collections.abc import Generator, Iterable, MutableSequence
 from typing import Any
@@ -267,12 +266,4 @@ def pairwise(iterable: Iterable[Any]) -> Generator[Any, None, None]:
     """pairwise('ABCDEFG') → AB BC CD DE EF FG
     """
 
-    if sys.version_info >= (3, 10):
-        yield from itertools.pairwise(iterable)
-    else:
-        # Taken from https://docs.python.org/3/library/itertools.html#itertools.pairwise
-        iterator = iter(iterable)
-        a = next(iterator, None)
-        for b in iterator:
-            yield a, b
-            a = b
+    yield from itertools.pairwise(iterable)

--- a/stonesoup/functions/interpolate.py
+++ b/stonesoup/functions/interpolate.py
@@ -2,26 +2,13 @@ import copy
 import datetime
 import warnings
 from collections.abc import Iterable, Callable
+from itertools import pairwise
 from typing import Union
 
 import numpy as np
 
 from ..types.array import StateVectors
 from ..types.state import StateMutableSequence, State
-
-try:
-    # Available from python 3.10
-    from itertools import pairwise
-except ImportError:
-    try:
-        from more_itertools import pairwise
-    except ImportError:
-        from itertools import tee
-
-        def pairwise(iterable: Iterable):
-            a, b = tee(iterable)
-            next(b, None)
-            return zip(a, b)
 
 
 def time_range(start_time: datetime.datetime, end_time: datetime.datetime,

--- a/stonesoup/plugins.py
+++ b/stonesoup/plugins.py
@@ -31,15 +31,7 @@ import sys
 import warnings
 from importlib.metadata import entry_points
 
-try:
-    _plugin_points = entry_points(group='stonesoup.plugins')
-except TypeError:  # Older interface, doesn't accept group keyword
-    try:
-        _plugin_points = entry_points()['stonesoup.plugins']
-    except KeyError:  # pragma: no cover
-        _plugin_points = []
-
-for entry_point in _plugin_points:
+for entry_point in entry_points(group='stonesoup.plugins'):
     try:
         name = entry_point.name
         plugin_module = f'{__name__}.{name}'


### PR DESCRIPTION
3.9 is end of life soon, and currently tests on CircleCI are failing, so easier to drop a little earlier ready for the next release