### PR TITLE
Add TypeError when noise_diff_coeff is not float or int

### DIFF
--- a/stonesoup/models/transition/linear.py
+++ b/stonesoup/models/transition/linear.py
@@ -117,6 +117,16 @@ class ConstantNthDerivative(LinearGaussianTransitionModel, TimeVariantModel):
     noise_diff_coeff: float = Property(
         doc="The Nth derivative noise diffusion coefficient (Variance) :math:`q`")
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        # Check that the noise_diff_coeff is actually a float
+        if not (isinstance(self.noise_diff_coeff, self._properties['noise_diff_coeff'].cls) or
+                isinstance(self.noise_diff_coeff, int)):
+            raise TypeError("'noise_diff_coeff' should be a {} instance. Instead it "
+                            "is {}".format(self._properties['noise_diff_coeff'].cls,
+                                           type(self.noise_diff_coeff)))
+
     @property
     def ndim_state(self):
         return self.constant_derivative + 1
@@ -304,6 +314,14 @@ class NthDerivativeDecay(LinearGaussianTransitionModel, TimeVariantModel):
             "singer")
     noise_diff_coeff: float = Property(doc="The noise diffusion coefficient :math:`q`")
     damping_coeff: float = Property(doc="The Nth derivative damping coefficient :math:`K`")
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        # Check that the noise_diff_coeff is actually a float
+        if not isinstance(self.noise_diff_coeff, self._properties['noise_diff_coeff'].cls):
+            raise TypeError("'noise_diff_coeff' should be a {} instance. Instead it "
+                            "is {}".format(float, type(self.noise_diff_coeff)))
 
     @property
     def ndim_state(self):

--- a/stonesoup/models/transition/linear.py
+++ b/stonesoup/models/transition/linear.py
@@ -1,6 +1,6 @@
 import math
 from collections.abc import Sequence
-from abc import numbers
+from numbers import Real
 from functools import lru_cache
 
 import numpy as np
@@ -123,7 +123,7 @@ class ConstantNthDerivative(LinearGaussianTransitionModel, TimeVariantModel):
 
         # Check that the noise_diff_coeff is actually a float
         if not (isinstance(self.noise_diff_coeff, self._properties['noise_diff_coeff'].cls) or
-                isinstance(self.noise_diff_coeff, numbers.real)):
+                isinstance(self.noise_diff_coeff, Real)):
             raise TypeError("'noise_diff_coeff' should be a {} instance. Instead it "
                             "is {}".format(self._properties['noise_diff_coeff'].cls,
                                            type(self.noise_diff_coeff)))
@@ -321,7 +321,7 @@ class NthDerivativeDecay(LinearGaussianTransitionModel, TimeVariantModel):
 
         # Check that the noise_diff_coeff is actually a float
         if not (isinstance(self.noise_diff_coeff, self._properties['noise_diff_coeff'].cls) or
-                isinstance(self.noise_diff_coeff, numbers.real)):
+                isinstance(self.noise_diff_coeff, Real)):
             raise TypeError("'noise_diff_coeff' should be a {} instance. Instead it "
                             "is {}".format(float, type(self.noise_diff_coeff)))
 

--- a/stonesoup/models/transition/linear.py
+++ b/stonesoup/models/transition/linear.py
@@ -1,5 +1,6 @@
 import math
 from collections.abc import Sequence
+from abc import numbers
 from functools import lru_cache
 
 import numpy as np
@@ -122,7 +123,7 @@ class ConstantNthDerivative(LinearGaussianTransitionModel, TimeVariantModel):
 
         # Check that the noise_diff_coeff is actually a float
         if not (isinstance(self.noise_diff_coeff, self._properties['noise_diff_coeff'].cls) or
-                isinstance(self.noise_diff_coeff, int)):
+                isinstance(self.noise_diff_coeff, numbers.real)):
             raise TypeError("'noise_diff_coeff' should be a {} instance. Instead it "
                             "is {}".format(self._properties['noise_diff_coeff'].cls,
                                            type(self.noise_diff_coeff)))
@@ -319,7 +320,8 @@ class NthDerivativeDecay(LinearGaussianTransitionModel, TimeVariantModel):
         super().__init__(*args, **kwargs)
 
         # Check that the noise_diff_coeff is actually a float
-        if not isinstance(self.noise_diff_coeff, self._properties['noise_diff_coeff'].cls):
+        if not (isinstance(self.noise_diff_coeff, self._properties['noise_diff_coeff'].cls) or
+                isinstance(self.noise_diff_coeff, numbers.real)):
             raise TypeError("'noise_diff_coeff' should be a {} instance. Instead it "
                             "is {}".format(float, type(self.noise_diff_coeff)))
 

--- a/stonesoup/models/transition/tests/test_ca.py
+++ b/stonesoup/models/transition/tests/test_ca.py
@@ -35,7 +35,11 @@ def test_ca(ca_model_params, sign):
     # CombinedLinearGaussianTransitionModel object
     dim = len(state_vec) // 3  # pos, vel, acc for each dimension
     if dim == 1:
-        model_obj = ConstantAcceleration(noise_diff_coeff=noise_diff_coeffs[0])
+        model_obj = ConstantAcceleration(noise_diff_coeff=noise_diff_coeffs[0][0])
+        # Test non-float noise_diff_coeff error
+        with pytest.raises(TypeError, match="'noise_diff_coeff' should be a "
+                           "<class 'float'> instance. Instead it is <class 'list'>"):
+            ConstantAcceleration(noise_diff_coeff=[noise_diff_coeffs[0]])
     else:
         model_list = [ConstantAcceleration(
             noise_diff_coeff=noise_diff_coeffs[i]) for i in range(0, dim)]

--- a/stonesoup/models/transition/tests/test_cv.py
+++ b/stonesoup/models/transition/tests/test_cv.py
@@ -28,6 +28,11 @@ def test_cvmodel(sign):
                   [abs(timediff)**2 / 2,
                    abs(timediff)]]) * noise_diff_coeff
 
+    # Test non-float noise_diff_coeff error
+    with pytest.raises(TypeError, match="'noise_diff_coeff' should be a "
+                       "<class 'float'> instance. Instead it is <class 'list'>"):
+        ConstantVelocity(noise_diff_coeff=[noise_diff_coeff])
+
     # Create and a Constant Velocity model object
     cv = ConstantVelocity(noise_diff_coeff=noise_diff_coeff)
 

--- a/stonesoup/models/transition/tests/test_ou.py
+++ b/stonesoup/models/transition/tests/test_ou.py
@@ -40,6 +40,11 @@ def test_oumodel(sign):
     Q = np.array([[q11, q12],
                   [q12, q22]])
 
+    # Test non-float noise_diff_coeff error
+    with pytest.raises(TypeError, match="'noise_diff_coeff' should be a "
+                       "<class 'float'> instance. Instead it is <class 'list'>"):
+        OrnsteinUhlenbeck(noise_diff_coeff=[q], damping_coeff=k)
+
     # Create and a Constant Velocity model object
     ou = OrnsteinUhlenbeck(noise_diff_coeff=q, damping_coeff=k)
 

--- a/stonesoup/models/transition/tests/test_singer.py
+++ b/stonesoup/models/transition/tests/test_singer.py
@@ -39,6 +39,11 @@ def test_singer(singer_model_params, sign):
     # CombinedGaussianTransitionModel object
     dim = len(state_vec) // 3  # pos, vel, acc for each dimension
     if dim == 1:
+        # Test non-float noise_diff_coeff error
+        with pytest.raises(TypeError, match="'noise_diff_coeff' should be a "
+                           "<class 'float'> instance. Instead it is <class 'list'>"):
+            Singer(noise_diff_coeff=[noise_diff_coeffs[0]],
+                   damping_coeff=damping_coeffs[0])
         model_obj = Singer(noise_diff_coeff=noise_diff_coeffs[0],
                            damping_coeff=damping_coeffs[0])
     else:

--- a/stonesoup/regulariser/tests/test_particle.py
+++ b/stonesoup/regulariser/tests/test_particle.py
@@ -28,12 +28,12 @@ def dummy_constraint_function(particles):
     "transition_model, model_flag, constraint_func",
     [
         (
-            CombinedLinearGaussianTransitionModel([ConstantVelocity([0.05])]),  # transition_model
+            CombinedLinearGaussianTransitionModel([ConstantVelocity(0.05)]),  # transition_model
             False,  # model_flag
             None  # constraint_function
         ),
         (
-            CombinedLinearGaussianTransitionModel([ConstantVelocity([0.05])]),  # transition_model
+            CombinedLinearGaussianTransitionModel([ConstantVelocity(0.05)]),  # transition_model
             True,  # model_flag
             None  # constraint_function
         ),
@@ -43,7 +43,7 @@ def dummy_constraint_function(particles):
             None  # constraint_function
         ),
         (
-            CombinedLinearGaussianTransitionModel([ConstantVelocity([0.05])]),  # transition_model
+            CombinedLinearGaussianTransitionModel([ConstantVelocity(0.05)]),  # transition_model
             False,  # model_flag
             dummy_constraint_function  # constraint_function
         )

--- a/stonesoup/updater/tests/test_particle.py
+++ b/stonesoup/updater/tests/test_particle.py
@@ -211,11 +211,11 @@ def test_bernoulli_particle(constraint_func):
 
 @pytest.mark.parametrize("transition_model, model_flag", [
         (
-            CombinedLinearGaussianTransitionModel([ConstantVelocity([0.05])]),  # transition_model
+            CombinedLinearGaussianTransitionModel([ConstantVelocity(0.05)]),  # transition_model
             False  # model_flag
         ),
         (
-            CombinedLinearGaussianTransitionModel([ConstantVelocity([0.05])]),  # transition_model
+            CombinedLinearGaussianTransitionModel([ConstantVelocity(0.05)]),  # transition_model
             True  # model_flag
         )
     ], ids=["with_transition_model_init", "without_transition_model_init"]


### PR DESCRIPTION
This PR adds an error raise when a user attempts to input an array/list of `noise_diff_coeff` for `ConstantNthDerivative` and `NthDerivativeDecay` model types. Currently it is possible to input an array (or list) for `noise_diff_coeff` into (for example) `ConstantVelocity` as long as it contains 1 or 2 elements. For 2 elements, the result is row/column wise multiplication of the `noise_diff_coeff` array with the 2 x 2 matrix for calculating the covariance. The same is possible for `ConstantAcceleration` if the user inputs a 3 element array/list. The result of this is incorrect calculation of the covariance matrix, invalidating the model.