### PR TITLE
Drop deprecated Proposal names

### DIFF
--- a/stonesoup/proposal/simple.py
+++ b/stonesoup/proposal/simple.py
@@ -15,27 +15,6 @@ from stonesoup.predictor.base import Predictor
 from stonesoup.predictor.kalman import SqrtKalmanPredictor
 from stonesoup.types.hypothesis import SingleHypothesis
 
-import warnings
-
-__all__ = ["DynamicsProposal", "KalmanProposal"]
-
-DEPRECATED_NAMES = [("PriorAsProposal", "DynamicsProposal"), ("KFasProposal", "KalmanProposal")]
-
-
-def __getattr__(name):
-    for old_name, new_name in DEPRECATED_NAMES:
-        if name == old_name:
-            warnings.warn(f"The '{old_name}' class or function has renamed to '{new_name}' "
-                          f"and will be removed in a future release.",
-                          DeprecationWarning,
-                          stacklevel=2)
-            return globals()[new_name]
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
-
-
-def __dir__():
-    return sorted(__all__ + [names[0] for names in DEPRECATED_NAMES])
-
 
 class DynamicsProposal(Proposal):
     """Proposal that uses the dynamics model as the importance density.

--- a/stonesoup/proposal/tests/test_simple.py
+++ b/stonesoup/proposal/tests/test_simple.py
@@ -2,7 +2,6 @@ import itertools
 
 import datetime
 import numpy as np
-import pytest
 
 # Import the proposals
 from stonesoup.proposal.simple import DynamicsProposal, KalmanProposal
@@ -16,20 +15,6 @@ from stonesoup.predictor.particle import ParticlePredictor
 from stonesoup.types.detection import Detection
 from stonesoup.models.measurement.linear import LinearGaussian
 from stonesoup.types.hypothesis import SingleHypothesis
-
-
-def test_deprecated_names():
-    # Test handling of deprecated class names
-
-    # Test the deprecation warnings
-    with pytest.warns(DeprecationWarning):
-        from stonesoup.proposal.simple import PriorAsProposal
-    with pytest.warns(DeprecationWarning):
-        from stonesoup.proposal.simple import KFasProposal
-
-    # Ensure the deprecated names are still available and point to the new names
-    assert PriorAsProposal == DynamicsProposal
-    assert KFasProposal == KalmanProposal
 
 
 def test_prior_proposal():


### PR DESCRIPTION
Previously announced to be dropped after v1.6, but forgotten in v1.7. Drop now for v1.8.