### PR TITLE
Handle LinAlgError in Cubature Kalman Filter Cholesky decomposition

### DIFF
--- a/stonesoup/functions/__init__.py
+++ b/stonesoup/functions/__init__.py
@@ -218,7 +218,7 @@ def gauss2sigma(state, alpha=1.0, beta=2.0, kappa=None):
     if kappa is None:
         kappa = 3.0 - ndim_state
 
-    # Compute Square Root matrix via Colesky decomp.
+    # Compute Square Root matrix via Cholesky decomp.
     try:
         sqrt_sigma = np.linalg.cholesky(state.covar)
     except np.linalg.LinAlgError as e:
@@ -893,7 +893,12 @@ def gauss2cubature(state, alpha=1.0):
     """
     ndim_state = np.shape(state.state_vector)[0]
 
-    sqrt_covar = np.linalg.cholesky(state.covar)
+    try:
+        sqrt_covar = np.linalg.cholesky(state.covar)
+    except np.linalg.LinAlgError as e:
+        warnings.warn(repr(e))
+        sqrt_covar = cholesky_eps(state.covar)
+
     cuba_points = np.sqrt(alpha*ndim_state) * np.hstack((np.identity(ndim_state),
                                                          -np.identity(ndim_state)))
 

--- a/stonesoup/functions/tests/test_functions.py
+++ b/stonesoup/functions/tests/test_functions.py
@@ -242,6 +242,7 @@ def test_gauss2sigma_bad_covar(gauss2x):
     with pytest.warns(UserWarning, match="Matrix is not positive definite"):
         gauss2x(state)
 
+
 @pytest.mark.parametrize(
     "angle",
     [

--- a/stonesoup/functions/tests/test_functions.py
+++ b/stonesoup/functions/tests/test_functions.py
@@ -230,7 +230,8 @@ def test_gauss2sigma(mean):
         assert sigma_point_state_vector[0, 0] == approx(mean + n*covar**0.5)
 
 
-def test_gauss2sigma_bad_covar():
+@pytest.mark.parametrize("gauss2x", [(gauss2sigma), (gauss2cubature)])
+def test_gauss2sigma_bad_covar(gauss2x):
     covar = np.array(
         [[ 0.05201447,  0.02882126, -0.00569971, -0.00733617],  # noqa: E201
          [ 0.02882126,  0.01642966, -0.00862847, -0.00673035],  # noqa: E201
@@ -239,8 +240,7 @@ def test_gauss2sigma_bad_covar():
     state = GaussianState([[0], [0], [0], [0]], covar)
 
     with pytest.warns(UserWarning, match="Matrix is not positive definite"):
-        sigma_points_states, mean_weights, covar_weights = gauss2sigma(state, kappa=0)
-
+        gauss2x(state)
 
 @pytest.mark.parametrize(
     "angle",


### PR DESCRIPTION
use `cholesky_eps` when recieving a LinAlgError for Cholesky decomposition in the CKF. similar to #992 