### PR TITLE
Add default_factory for Property

### DIFF
--- a/stonesoup/architecture/__init__.py
+++ b/stonesoup/architecture/__init__.py
@@ -27,7 +27,7 @@ class Architecture(Base):
         doc="An Edges object containing all edges. For A to be connected to B we would have an "
             "Edge with edge_pair=(A, B) in this object.")
     current_time: datetime = Property(
-        default=None,
+        default_factory=datetime.now,
         doc="The time which the instance is at for the purpose of simulation. "
             "This is increased by the propagate method. This should be set to the earliest "
             "timestep from the ground truth")
@@ -51,8 +51,6 @@ class Architecture(Base):
         super().__init__(*args, **kwargs)
         if not self.name:
             self.name = type(self).__name__
-        if not self.current_time:
-            self.current_time = datetime.now()
 
         self.di_graph = nx.to_networkx_graph(self.edges.edge_list, create_using=nx.DiGraph)
         self._viz_graph = None

--- a/stonesoup/architecture/edge.py
+++ b/stonesoup/architecture/edge.py
@@ -252,12 +252,7 @@ class Edge(Base):
 
 class Edges(Base, Collection):
     """Container class for :class:`~.Edge`"""
-    edges: list[Edge] = Property(doc="List of Edge objects", default=None)
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        if self.edges is None:
-            self.edges = []
+    edges: list[Edge] = Property(doc="List of Edge objects", default_factory=list)
 
     def __iter__(self):
         return self.edges.__iter__()

--- a/stonesoup/architecture/generator.py
+++ b/stonesoup/architecture/generator.py
@@ -28,7 +28,7 @@ class InformationArchitectureGenerator(Base):
         default='decentralised')
     start_time: datetime = Property(
         doc="Start time of simulation to be passed to the Architecture class.",
-        default=datetime.now())
+        default_factory=datetime.now)
     node_ratio: tuple = Property(
         doc="Tuple containing the number of each type of node, in the order of (sensor nodes, "
             "sensor fusion nodes, fusion nodes).",

--- a/stonesoup/architecture/node.py
+++ b/stonesoup/architecture/node.py
@@ -129,7 +129,7 @@ class FusionNode(Node):
         default=None,
         doc="The queue from which this node draws data to be fused. Default is a standard "
             "FusionQueue")
-    tracks: set = Property(default=None,
+    tracks: set = Property(default_factory=set,
                            doc="Set of tracks tracked by the fusion node")
     colour: str = Property(
         default='#00b53d',
@@ -140,7 +140,6 @@ class FusionNode(Node):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.tracks = set()  # Set of tracks this Node has recorded
         if not self.fusion_queue:
             if self.tracker.detector:
                 self.fusion_queue = self.tracker.detector

--- a/stonesoup/dataassociator/clearmot.py
+++ b/stonesoup/dataassociator/clearmot.py
@@ -46,7 +46,7 @@ class ClearMotAssociator(TwoTrackToTrackAssociator):
         doc="Threshold distance measure which states must be within for an "
             "association to be recorded")
     measure: Measure = Property(
-        default=Euclidean(),
+        default_factory=Euclidean,
         doc="Distance measure to use. Default :class:`~.measures.Euclidean()`")
 
     def associate_tracks(self, tracks_set: set[Track], truth_set: set[GroundTruthPath])\

--- a/stonesoup/dataassociator/tracktotrack.py
+++ b/stonesoup/dataassociator/tracktotrack.py
@@ -233,7 +233,7 @@ class TrackToTruth(TwoTrackToTrackAssociator):
             "required to exceed a specified threshold in order for an "
             "association to be ended. Default is 2")
     measure: Measure = Property(
-        default=Euclidean(),
+        default_factory=Euclidean,
         doc="Distance measure to use. Default :class:`~.measures.Euclidean()`")
 
     def associate_tracks(self, tracks_set: set[Track], truth_set: set[GroundTruthPath]):

--- a/stonesoup/metricgenerator/ospametric.py
+++ b/stonesoup/metricgenerator/ospametric.py
@@ -70,7 +70,7 @@ class GOSPAMetric(MetricGenerator):
     c: float = Property(doc="c>0, cutoff distance.")
     switching_penalty: float = Property(doc="Penalty term for switching.", default=0.0)
     measure: Measure = Property(
-        default=Euclidean(),
+        default_factory=Euclidean,
         doc="Distance measure to use. Default :class:`~.measures.Euclidean()`")
     generator_name: str = Property(doc="Unique identifier to use when accessing generated metrics "
                                        "from MultiManager",

--- a/stonesoup/models/measurement/gas.py
+++ b/stonesoup/models/measurement/gas.py
@@ -93,7 +93,7 @@ class IsotropicPlume(GaussianModel, MeasurementModel):
     )
 
     translation_offset: StateVector = Property(
-        default=None,
+        default_factory=lambda: StateVector([[0.], [0.], [0.]]),
         doc="A 3x1 array specifying the Cartesian origin offset in terms of :math:`x,y,z` "
             "coordinates.")
 
@@ -106,15 +106,6 @@ class IsotropicPlume(GaussianModel, MeasurementModel):
         default=0.1,
         doc="Measurement threshold. Should be set high enough to minimise false detections."
     )
-
-    def __init__(self, *args, **kwargs):
-        """
-        Ensure that the translation offset is initiated
-        """
-        super().__init__(*args, **kwargs)
-        # Set values to defaults if not provided
-        if self.translation_offset is None:
-            self.translation_offset = StateVector([0.] * 3)
 
     def covar(self, **kwargs) -> CovarianceMatrix:
         raise NotImplementedError('Covariance for IsotropicPlume is dependant on the '

--- a/stonesoup/models/measurement/nonlinear.py
+++ b/stonesoup/models/measurement/nonlinear.py
@@ -106,7 +106,7 @@ class NonLinearGaussianMeasurement(MeasurementModel, GaussianModel, ABC):
     """
     noise_covar: CovarianceMatrix = Property(doc="Noise covariance")
     rotation_offset: StateVector = Property(
-        default=None,
+        default_factory=lambda: StateVector([[0.], [0.], [0.]]),
         doc="A 3x1 array of angles (rad), specifying the clockwise rotation "
             "around each Cartesian axis in the order :math:`x,y,z`. "
             "The rotation angles are positive if the rotation is in the "
@@ -114,13 +114,7 @@ class NonLinearGaussianMeasurement(MeasurementModel, GaussianModel, ABC):
             "along the respective rotation axis, towards the origin.")
 
     def __init__(self, *args, **kwargs):
-        """
-        Ensure that the rotation offset is initiated
-        """
         super().__init__(*args, **kwargs)
-        # Set values to defaults if not provided
-        if self.rotation_offset is None:
-            self.rotation_offset = StateVector([[0.], [0.], [0.]])
 
         if not isinstance(self.noise_covar, CovarianceMatrix):
             self.noise_covar = CovarianceMatrix(self.noise_covar)
@@ -243,18 +237,9 @@ class CartesianToElevationBearingRange(_AngleNonLinearGaussianMeasurement, Rever
     """  # noqa:E501
 
     translation_offset: StateVector = Property(
-        default=None,
+        default_factory=lambda: StateVector([[0.], [0.], [0.]]),
         doc="A 3x1 array specifying the Cartesian origin offset in terms of :math:`x,y,z` "
             "coordinates.")
-
-    def __init__(self, *args, **kwargs):
-        """
-        Ensure that the translation offset is initiated
-        """
-        super().__init__(*args, **kwargs)
-        # Set values to defaults if not provided
-        if self.translation_offset is None:
-            self.translation_offset = StateVector([0.] * 3)
 
     @property
     def ndim_meas(self) -> int:
@@ -486,17 +471,8 @@ class CartesianToElevationBearing(_AngleNonLinearGaussianMeasurement):
     """  # noqa:E501
 
     translation_offset: StateVector = Property(
-        default=None,
+        default_factory=lambda: StateVector([[0.], [0.], [0.]]),
         doc="A 3x1 array specifying the origin offset in terms of :math:`x,y,z` coordinates.")
-
-    def __init__(self, *args, **kwargs):
-        """
-        Ensure that the translation offset is initiated
-        """
-        super().__init__(*args, **kwargs)
-        # Set values to defaults if not provided
-        if self.translation_offset is None:
-            self.translation_offset = StateVector([0.] * 3)
 
     @property
     def ndim_meas(self) -> int:
@@ -562,17 +538,8 @@ class Cartesian2DToBearing(_AngleNonLinearGaussianMeasurement):
     """  # noqa:E501
 
     translation_offset: StateVector = Property(
-        default=None,
+        default_factory=lambda: StateVector([[0.], [0.]]),
         doc="A 2x1 array specifying the origin offset in terms of :math:`x,y` coordinates.")
-
-    def __init__(self, *args, **kwargs):
-        """
-        Ensure that the translation offset is initiated
-        """
-        super().__init__(*args, **kwargs)
-        # Set values to defaults if not provided
-        if self.translation_offset is None:
-            self.translation_offset = StateVector([0.] * 2)
 
     @property
     def ndim_meas(self):
@@ -673,26 +640,14 @@ class CartesianToBearingRangeRate(_AngleNonLinearGaussianMeasurement):
     """
 
     translation_offset: StateVector = Property(
-        default=None,
+        default_factory=lambda: StateVector([[0.], [0.], [0.]]),
         doc="A 3x1 array specifying the origin offset in terms of :math:`x,y` coordinates.")
     velocity_mapping: tuple[int, int, int] = Property(
         default=(1, 3, 5),
         doc="Mapping to the targets velocity within its state space")
     velocity: StateVector = Property(
-        default=None,
+        default_factory=lambda: StateVector([[0.], [0.], [0.]]),
         doc="A 3x1 array specifying the sensor velocity in terms of :math:`x,y,z` coordinates.")
-
-    def __init__(self, *args, **kwargs):
-        """
-        Ensure that the translation offset is initiated
-        """
-        super().__init__(*args, **kwargs)
-        # Set values to defaults if not provided
-        if self.translation_offset is None:
-            self.translation_offset = StateVector([0.] * 3)
-
-        if self.velocity is None:
-            self.velocity = StateVector([0.] * 3)
 
     @property
     def ndim_meas(self) -> int:
@@ -798,26 +753,14 @@ class CartesianToBearingRangeRate2D(_AngleNonLinearGaussianMeasurement):
     """
 
     translation_offset: StateVector = Property(
-        default=None,
+        default_factory=lambda: StateVector([[0.], [0.]]),
         doc="A 2x1 array specifying the origin offset in terms of :math:`x,y` coordinates.")
     velocity_mapping: tuple[int, int] = Property(
         default=(1, 3),
         doc="Mapping to the targets velocity within its state space")
     velocity: StateVector = Property(
-        default=None,
+        default_factory=lambda: StateVector([[0.], [0.]]),
         doc="A 2x1 array specifying the sensor velocity in terms of :math:`x,y` coordinates.")
-
-    def __init__(self, *args, **kwargs):
-        """
-        Ensure that the translation offset is initiated
-        """
-        super().__init__(*args, **kwargs)
-        # Set values to defaults if not provided
-        if self.translation_offset is None:
-            self.translation_offset = StateVector([0.] * 2)
-
-        if self.velocity is None:
-            self.velocity = StateVector([0.] * 2)
 
     @property
     def ndim_meas(self) -> int:
@@ -942,26 +885,14 @@ class CartesianToElevationBearingRangeRate(_AngleNonLinearGaussianMeasurement, R
     """
 
     translation_offset: StateVector = Property(
-        default=None,
+        default_factory=lambda: StateVector([[0.], [0.], [0.]]),
         doc="A 3x1 array specifying the origin offset in terms of :math:`x,y,z` coordinates.")
     velocity_mapping: tuple[int, int, int] = Property(
         default=(1, 3, 5),
         doc="Mapping to the targets velocity within its state space")
     velocity: StateVector = Property(
-        default=None,
+        default_factory=lambda: StateVector([[0.], [0.], [0.]]),
         doc="A 3x1 array specifying the sensor velocity in terms of :math:`x,y,z` coordinates.")
-
-    def __init__(self, *args, **kwargs):
-        """
-        Ensure that the translation offset is initiated
-        """
-        super().__init__(*args, **kwargs)
-        # Set values to defaults if not provided
-        if self.translation_offset is None:
-            self.translation_offset = StateVector([0.] * 3)
-
-        if self.velocity is None:
-            self.velocity = StateVector([0.] * 3)
 
     @property
     def ndim_meas(self) -> int:
@@ -1383,18 +1314,9 @@ class CartesianToAzimuthElevationRange(_AngleNonLinearGaussianMeasurement, Rever
     """  # noqa:E501
 
     translation_offset: StateVector = Property(
-        default=None,
+        default_factory=lambda: StateVector([[0.], [0.], [0.]]),
         doc="A 3x1 array specifying the Cartesian origin offset in terms of :math:`x,y,z` "
             "coordinates.")
-
-    def __init__(self, *args, **kwargs):
-        """
-        Ensure that the translation offset is initiated
-        """
-        super().__init__(*args, **kwargs)
-        # Set values to defaults if not provided
-        if self.translation_offset is None:
-            self.translation_offset = StateVector([0.] * 3)
 
     @property
     def ndim_meas(self) -> int:

--- a/stonesoup/movable/movable.py
+++ b/stonesoup/movable/movable.py
@@ -195,7 +195,7 @@ class FixedMovable(Movable):
         .. note:: Position and orientation are read/write properties in this class.
         """
     orientation: StateVector = Property(
-        default=None,
+        default_factory=lambda: StateVector([[0.], [0.], [0.]]),
         doc='A fixed orientation of the static platform. Defaults to the zero vector')
 
     def __init__(self, *args, **kwargs):
@@ -204,8 +204,6 @@ class FixedMovable(Movable):
             raise ValueError('Velocity mapping should not be set for a FixedMovable')
         super().__init__(*args, **kwargs)
         self.velocity_mapping = None
-        if self.orientation is None:
-            self.orientation = StateVector([0., 0., 0.])
 
     def _set_position(self, value: StateVector) -> None:
         self.state_vector[self.position_mapping, :] = value

--- a/stonesoup/platform/base.py
+++ b/stonesoup/platform/base.py
@@ -40,11 +40,10 @@ class Platform(Base):
             "it can be constructed transparently by passing Movable's constructor parameters to "
             "the Platform constructor.")
     sensors: MutableSequence[Sensor] = Property(
-        default=None, readonly=True,
+        default_factory=list, readonly=True,
         doc="A list of N mounted sensors. Defaults to an empty list.")
-
     id: str = Property(
-        default=None,
+        default_factory=lambda: str(uuid.uuid4()),
         doc="The unique platform ID. Default `None` where random UUID is generated.")
 
     _default_movable_class = None  # Will be overridden by subclasses
@@ -84,12 +83,8 @@ class Platform(Base):
         super().__init__(**platform_args)
         if self.movement_controller is None:
             self.movement_controller = self._default_movable_class(*args, **other_args)
-        if self.sensors is None:
-            self._property_sensors = []
         for sensor in self.sensors:
             sensor.movement_controller = self.movement_controller
-        if self.id is None:
-            self.id = str(uuid.uuid4())
 
     @staticmethod
     def _tuple_or_none(value):

--- a/stonesoup/predictor/kernel.py
+++ b/stonesoup/predictor/kernel.py
@@ -40,18 +40,12 @@ class AdaptiveKernelKalmanPredictor(KalmanPredictor):
     :math:`{V}_{k}` represents the finite matrix representation of the transition residual matrix.
     """
     kernel: Kernel = Property(
-        default=None,
+        default_factory=QuadraticKernel,
         doc="Default is None. If None, the default :class:`~QuadraticKernel` is used.")
     lambda_predictor: float = Property(
         default=1e-3,
         doc=r":math:`\lambda_{\tilde{K}}`. Regularisation parameter used to stabilise the inverse "
             r"Gram matrix. Range is :math:`\left[10^{-4}, 10^{-2}\right]`")
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
-        if self.kernel is None:
-            self.kernel = QuadraticKernel()
 
     @predict_lru_cache()
     def predict(self, prior, timestamp=None, proposal=None, **kwargs):

--- a/stonesoup/reader/generic.py
+++ b/stonesoup/reader/generic.py
@@ -97,7 +97,7 @@ class _DictionaryReader(_DictReader):
 
 class _CSVReader(_DictReader, TextFileReader):
     csv_options: Mapping = Property(
-        default={}, doc='Keyword arguments for the underlying csv reader')
+        default_factory=dict, doc='Keyword arguments for the underlying csv reader')
 
     @property
     def dict_reader(self) -> Iterator[dict]:

--- a/stonesoup/resampler/particle.py
+++ b/stonesoup/resampler/particle.py
@@ -74,7 +74,7 @@ class ESSResampler(Resampler):
                                 doc='Threshold compared with ESS to decide whether to resample. \
                                     Default is number of particles divided by 2, \
                                         set in resample method')
-    resampler: Resampler = Property(default=SystematicResampler(),
+    resampler: Resampler = Property(default_factory=SystematicResampler,
                                     doc='Resampler to wrap, which is called \
                                         when ESS below threshold')
 

--- a/stonesoup/sensor/radar/radar.py
+++ b/stonesoup/sensor/radar/radar.py
@@ -708,10 +708,10 @@ class AESARadar(Sensor):
     This model does not generate false alarms.
     """
     rotation_offset: StateVector = Property(
-        default=None,
+        default_factory=lambda: StateVector([[0.], [0.], [0.]]),
         doc="A 3x1 array of angles (rad), specifying the radar orientation in terms of the "
             "counter-clockwise rotation around the :math:`x,y,z` axis. i.e Roll, Pitch and Yaw. "
-            "Default is ``StateVector([0., 0., 0.])``")
+            "Default is ``None`` which sets rotation to ``StateVector([[0.], [0.], [0.]])``")
     position_mapping: tuple[int, int, int] = Property(
         default=(0, 1, 2),
         doc="Mapping between or positions and state "
@@ -753,11 +753,6 @@ class AESARadar(Sensor):
             "truth. Default `None`, where 'rcs' must be present on truth.")
     probability_false_alarm: Probability = Property(
         default=1e-6, doc="Probability of false alarm used in the North's approximation")
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        if self.rotation_offset is None:
-            self.rotation_offset = StateVector([0., 0., 0.])
 
     @measurement_model.getter
     def measurement_model(self):

--- a/stonesoup/sensormanager/action.py
+++ b/stonesoup/sensormanager/action.py
@@ -95,9 +95,11 @@ class ActionableProperty(Property):
     times."""
 
     def __init__(self, generator_cls, generator_kwargs_mapping=None,
-                 cls=None, *, default=inspect.Parameter.empty,
+                 cls=None, *,
+                 default=inspect.Parameter.empty, default_factory=inspect.Parameter.empty,
                  doc=None, readonly=False):
-        super().__init__(cls=cls, default=default, doc=doc, readonly=readonly)
+        super().__init__(cls=cls, default=default, default_factory=default_factory,
+                         doc=doc, readonly=readonly)
         self.generator_cls = generator_cls
         self.generator_kwargs_mapping = generator_kwargs_mapping
         if generator_kwargs_mapping is None:

--- a/stonesoup/sensormanager/base.py
+++ b/stonesoup/sensormanager/base.py
@@ -29,10 +29,10 @@ class SensorManager(Base, ABC):
 
     """
     sensors: set['Sensor'] = Property(
-        default=None, doc="The sensor(s) which the sensor manager is managing.")
+        default_factory=set, doc="The sensor(s) which the sensor manager is managing.")
 
     platforms: set['Platform'] = Property(
-        default=None, doc="The platform(s) which the sensor manager is managing.")
+        default_factory=set, doc="The platform(s) which the sensor manager is managing.")
 
     reward_function: Callable = Property(
         default=None, doc="A function or class designed to work out the reward associated with an "
@@ -48,14 +48,6 @@ class SensorManager(Base, ABC):
                           "Any sensors not added "
                           "will not be considered by the sensor manager or "
                           "reward function.")
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
-        if self.platforms is None:
-            self.platforms = set()
-        if self._property_sensors is None:
-            self._property_sensors = set()
 
     @sensors.getter
     def sensors(self):

--- a/stonesoup/simulator/simple.py
+++ b/stonesoup/simulator/simple.py
@@ -95,8 +95,8 @@ class MultiTargetGroundTruthSimulator(SingleTargetGroundTruthSimulator):
     seed: Optional[int] = Property(default=None, doc="Seed for random number generation."
                                                      " Default None")
     preexisting_states: Collection[StateVector] = Property(
-        default=list(), doc="State vectors at time 0 for "
-                            "groundtruths which should exist at the start of simulation.")
+        default_factory=list, doc="State vectors at time 0 for "
+                                  "groundtruths which should exist at the start of simulation.")
     initial_number_targets: int = Property(
         default=0, doc="Initial number of targets to be "
                        "simulated. These simulated targets will be made in addition to those "

--- a/stonesoup/tests/test_declarative.py
+++ b/stonesoup/tests/test_declarative.py
@@ -358,3 +358,31 @@ def test_type_hint_checking():
     class TestClass(Base):
         i = Property(Any, doc='Test')
     _ = TestClass(i=1)
+
+
+def test_default_factory():
+
+    class TestClass(Base):
+        i: Any = Property(default_factory=list)
+    inst = TestClass()
+    assert isinstance(inst.i, list)
+    assert len(inst.i) == 0
+    inst.i.append(1)
+
+    inst = TestClass(None)
+    assert isinstance(inst.i, list)
+    assert len(inst.i) == 0
+
+    class TestClass(Base):
+        i: Any = Property(default_factory=list, allow_none_with_factory=True)
+    inst = TestClass()
+    assert isinstance(inst.i, list)
+    assert len(inst.i) == 0
+    inst.i.append(1)
+
+    inst = TestClass(None)
+    assert inst.i is None
+
+    with pytest.raises(ValueError, match="Cannot have both default and default_factory"):
+        class TestClass(Base):
+            i: Any = Property(default="1", default_factory=lambda: "1")

--- a/stonesoup/types/association.py
+++ b/stonesoup/types/association.py
@@ -65,12 +65,11 @@ class AssociationSet(Type):
     associations.
     """
 
-    associations: set[Association] = Property(default=None, doc="set of independent associations.")
+    associations: set[Association] = Property(
+        default_factory=set, doc="set of independent associations.")
 
-    def __init__(self, associations=None, *args, **kwargs):
-        super().__init__(associations, *args, **kwargs)
-        if self.associations is None:
-            self.associations = set()
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         if not all(isinstance(member, Association) for member in self.associations):
             raise TypeError("Association set must contain only Association instances.")
         self._simplify()

--- a/stonesoup/types/detection.py
+++ b/stonesoup/types/detection.py
@@ -14,12 +14,7 @@ class Detection(State):
         doc="The measurement model used to generate the detection (the default is ``None``)")
 
     metadata: MutableMapping = Property(
-        default=None, doc='Dictionary of metadata items for Detections.')
-
-    def __init__(self, state_vector, *args, **kwargs):
-        super().__init__(state_vector, *args, **kwargs)
-        if self.metadata is None:
-            self.metadata = {}
+        default_factory=dict, doc='Dictionary of metadata items for Detections.')
 
 
 class GaussianDetection(Detection, GaussianState):

--- a/stonesoup/types/groundtruth.py
+++ b/stonesoup/types/groundtruth.py
@@ -8,12 +8,7 @@ from ..base import Property
 class GroundTruthState(State):
     """Ground Truth State type"""
     metadata: MutableMapping = Property(
-        default=None, doc='Dictionary of metadata items for Detections.')
-
-    def __init__(self, state_vector, *args, **kwargs):
-        super().__init__(state_vector, *args, **kwargs)
-        if self.metadata is None:
-            self.metadata = {}
+        default_factory=dict, doc='Dictionary of metadata items for Detections.')
 
 
 class CategoricalGroundTruthState(GroundTruthState, CategoricalState):
@@ -27,18 +22,13 @@ class GroundTruthPath(StateMutableSequence):
     """
 
     states: MutableSequence[GroundTruthState] = Property(
-        default=None,
+        default_factory=list,
         doc="List of groundtruth states to initialise path with. Default "
             "`None` which initialises with an empty list.")
     id: str = Property(
-        default=None,
+        default_factory=lambda: str(uuid.uuid4()),
         doc="The unique path ID. Default `None` where random UUID is "
             "generated.")
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        if self.id is None:
-            self.id = str(uuid.uuid4())
 
 
 class CompositeGroundTruthState(CompositeState):
@@ -51,9 +41,6 @@ class CompositeGroundTruthState(CompositeState):
     sub_states: Sequence[GroundTruthState] = Property(
         doc="Sequence of sub-states comprising the composite state. All sub-states must have "
             "matching timestamp and `metadata` attributes. Must not be empty.")
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
 
     @property
     def metadata(self):

--- a/stonesoup/types/hypothesis.py
+++ b/stonesoup/types/hypothesis.py
@@ -307,7 +307,7 @@ class CompositeProbabilityHypothesis(CompositeHypothesis, SingleProbabilityHypot
         doc="Probability that detection is true location of prediction. Default is `None`, "
             "whereby probability is calculated as the product of sub-hypotheses' probabilities")
     sub_hypotheses: Sequence[SingleProbabilityHypothesis] = Property(
-        default=None,
+        default_factory=list,
         doc="Sequence of probability-scored sub-hypotheses comprising the composite hypothesis."
     )
 

--- a/stonesoup/types/interval.py
+++ b/stonesoup/types/interval.py
@@ -165,15 +165,13 @@ class Intervals(Type):
     """
 
     intervals: MutableSequence[Interval] = Property(
-        default=None,
+        default_factory=list,
         doc="Container of :class:`Interval`")
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        if self.intervals is None:
-            self.intervals = list()
-        elif not isinstance(self.intervals, MutableSequence):
+        if not isinstance(self.intervals, MutableSequence):
             if isinstance(self.intervals, (Interval, tuple)):
                 self.intervals = [self.intervals]
             elif isinstance(self.intervals, Intervals):

--- a/stonesoup/types/mixture.py
+++ b/stonesoup/types/mixture.py
@@ -22,14 +22,12 @@ class GaussianMixture(Type, MutableSequence):
     """
 
     components: MutableSequence[WeightedGaussianState] = Property(
-        default=None,
+        default_factory=list,
         doc="""The initial list of :class:`WeightedGaussianState` components.
         Default `None` which initialises with empty list.""")
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        if self.components is None:
-            self.components = []
         if any(not isinstance(component, (WeightedGaussianState, TaggedWeightedGaussianState))
                 for component in self.components):
             raise ValueError("Cannot form GaussianMixtureState out of "

--- a/stonesoup/types/multihypothesis.py
+++ b/stonesoup/types/multihypothesis.py
@@ -16,7 +16,7 @@ class MultipleHypothesis(Type, Sequence):
     """
 
     single_hypotheses: Sequence[SingleHypothesis] = Property(
-        default=None,
+        default_factory=list,
         doc="The initial list of :class:`~.SingleHypothesis`. Default `None` "
             "which initialises with empty list.")
     normalise: bool = Property(
@@ -27,17 +27,13 @@ class MultipleHypothesis(Type, Sequence):
         default=1,
         doc="When normalising, weights will sum to this. Default is 1.")
 
-    def __init__(self, single_hypotheses=None, normalise=False, *args,
-                 **kwargs):
-        if single_hypotheses is None:
-            single_hypotheses = []
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
         if any(not isinstance(hypothesis, SingleHypothesis)
-               for hypothesis in single_hypotheses):
+               for hypothesis in self.single_hypotheses):
             raise ValueError("Cannot form MultipleHypothesis out of "
                              "non-SingleHypothesis inputs!")
-
-        super().__init__(single_hypotheses, normalise, *args, **kwargs)
 
         # normalise the weights of 'single_hypotheses', if indicated
         if self.normalise:
@@ -128,7 +124,7 @@ class MultipleCompositeHypothesis(Type, Sequence):
     """
 
     single_hypotheses: Sequence[CompositeHypothesis] = Property(
-        default=None,
+        default_factory=list,
         doc="The initial list of :class:`~.CompositeHypothesis`. Default `None` which initialises "
             "with empty list.")
     normalise: bool = Property(
@@ -138,17 +134,13 @@ class MultipleCompositeHypothesis(Type, Sequence):
         default=1,
         doc="When normalising, weights will sum to this. Default is 1.")
 
-    def __init__(self, single_hypotheses=None, normalise=False, *args,
-                 **kwargs):
-        if single_hypotheses is None:
-            single_hypotheses = []
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
         if not all(isinstance(hypothesis, CompositeHypothesis)
-                   for hypothesis in single_hypotheses):
+                   for hypothesis in self.single_hypotheses):
             raise ValueError("Cannot form MultipleHypothesis out of "
                              "non-CompositeHypothesis inputs!")
-
-        super().__init__(single_hypotheses, normalise, *args, **kwargs)
 
         # normalise the weights of 'single_hypotheses', if indicated
         if self.normalise:

--- a/stonesoup/types/state.py
+++ b/stonesoup/types/state.py
@@ -306,14 +306,12 @@ class StateMutableSequence(Type, MutableSequence):
     """
 
     states: MutableSequence[State] = Property(
-        default=None,
+        default_factory=list,
         doc="The initial list of states. Default `None` which initialises with empty list.")
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        if self.states is None:
-            self.states = []
-        elif not isinstance(self.states, Sequence):
+        if not isinstance(self.states, Sequence):
             # Ensure states is a list
             self.states = [self.states]
 
@@ -634,15 +632,11 @@ class TaggedWeightedGaussianState(WeightedGaussianState):
     Gaussian State object with an associated weight and tag. Used as components
     for a GaussianMixtureState.
     """
-    tag: str = Property(default=None, doc="Unique tag of the Gaussian State.")
+    tag: str = Property(
+        default_factory=lambda: str(uuid.uuid4()), doc="Unique tag of the Gaussian State.")
 
     BIRTH = 'birth'
     '''Tag value used to signify birth component'''
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        if self.tag is None:
-            self.tag = str(uuid.uuid4())
 
 
 class ASDWeightedGaussianState(ASDGaussianState):
@@ -660,15 +654,11 @@ class ASDTaggedWeightedGaussianState(ASDWeightedGaussianState):
     ASD Gaussian State object with an associated weight and tag. Used as components
     for a GaussianMixtureState.
     """
-    tag: str = Property(default=None, doc="Unique tag of the ASD Gaussian State.")
+    tag: str = Property(
+        default_factory=lambda: str(uuid.uuid4()), doc="Unique tag of the ASD Gaussian State.")
 
     BIRTH = 'birth'
     '''Tag value used to signify birth component'''
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        if self.tag is None:
-            self.tag = str(uuid.uuid4())
 
 TaggedWeightedGaussianState.register(ASDTaggedWeightedGaussianState)  # noqa: E305
 

--- a/stonesoup/types/tests/test_track.py
+++ b/stonesoup/types/tests/test_track.py
@@ -60,6 +60,9 @@ def test_track_id():
     assert isinstance(track.id, str)
     assert track.id == 'abc'
 
+    track = Track()
+    assert isinstance(track.id, str)
+
     track = Track(id=None)
     assert isinstance(track.id, str)
 

--- a/stonesoup/types/track.py
+++ b/stonesoup/types/track.py
@@ -22,23 +22,16 @@ class Track(StateMutableSequence):
     """
 
     states: MutableSequence[State] = Property(
-        default=None,
+        default_factory=list,
         doc="The initial states of the track. Default `None` which initialises with empty list.")
-
-    id: str = Property(default=None, doc="The unique track ID")
-
+    id: str = Property(default_factory=lambda: str(uuid.uuid4()), doc="The unique track ID")
     init_metadata: MutableMapping = Property(
-        default=None, doc="Initial dictionary of metadata items for track. Default `None` which "
-                          "initialises track metadata as an empty dictionary.")
+        default_factory=dict,
+        doc="Initial dictionary of metadata items for track. Default `None` which "
+            "initialises track metadata as an empty dictionary.")
 
     def __init__(self, *args, **kwargs):
-
         super().__init__(*args, **kwargs)
-
-        if self.id is None:
-            self.id = str(uuid.uuid4())
-        if self.init_metadata is None:
-            self.init_metadata = {}
 
         self.metadatas = list()
 

--- a/stonesoup/updater/iterated.py
+++ b/stonesoup/updater/iterated.py
@@ -42,7 +42,7 @@ class DynamicallyIteratedUpdater(Updater):
         default=1e-6,
         doc="The value of the difference in the measure used as a stopping criterion.")
     measure: Measure = Property(
-        default=KLDivergence(),
+        default_factory=KLDivergence,
         doc="The measure to use to test the iteration stopping criterion. Defaults to the "
             "Euclidean distance between current and prior posterior state estimate.")
     max_iterations: int = Property(

--- a/stonesoup/updater/kalman.py
+++ b/stonesoup/updater/kalman.py
@@ -636,7 +636,7 @@ class IteratedKalmanUpdater(ExtendedKalmanUpdater):
         default=1e-6,
         doc="The value of the difference in the measure used as a stopping criterion.")
     measure: Measure = Property(
-        default=Euclidean(),
+        default_factory=Euclidean,
         doc="The measure to use to test the iteration stopping criterion. Defaults to the "
             "Euclidean distance between current and prior posterior state estimate.")
     max_iterations: int = Property(

--- a/stonesoup/updater/kernel.py
+++ b/stonesoup/updater/kernel.py
@@ -18,19 +18,13 @@ class AdaptiveKernelKalmanUpdater(Updater):
      estimate.
     """
     kernel: Kernel = Property(
-        default=None,
+        default_factory=QuadraticKernel,
         doc="Default is None. If None, the default :class:`QuadraticKernel` is used.")
     lambda_updater: float = Property(
         default=1e-3,
         doc="Used to incorporate prior knowledge of the distribution. If the "
             "true distribution is Gaussian, the value of 2 is optimal. "
             "Default is 1e-3")
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
-        if self.kernel is None:
-            self.kernel = QuadraticKernel()
 
     @lru_cache()
     def predict_measurement(self, state_prediction, measurement_model=None,


### PR DESCRIPTION
Allows creation of mutable defaults more easily

Passing of `None` also uses default factory in order to maintain broad compatibility, but this can be disabled in order to allow None to be set instead of default. This provides alternative solution to #1087  