### PR TITLE
Add stabilization of Cholesky Factorization for Kalman Filter

### DIFF
--- a/stonesoup/functions/__init__.py
+++ b/stonesoup/functions/__init__.py
@@ -1192,12 +1192,14 @@ def find_nearest_positive_definite(matrix, max_iterations=20):
     # find the closest positive definite matrix
     eps = np.eye(matrix.shape[0]) * np.spacing(np.linalg.norm(matrix))
     k = 1
-    while not is_cholesky_decomposable(matrix):
+    while True:
         matrix += eps * k**2
-        k += 1
+        if is_cholesky_decomposable(matrix):
+            break
 
         if k == max_iterations:
             raise ValueError("Cannot find the nearest positive definite matrix.""")
+        k += 1
 
     return matrix
 

--- a/stonesoup/functions/__init__.py
+++ b/stonesoup/functions/__init__.py
@@ -1190,11 +1190,10 @@ def find_nearest_positive_definite(matrix, max_iterations=20):
     matrix = eigvec @ np.diag(eigval) @ eigvec.T
 
     # find the closest positive definite matrix
-    eps = np.spacing(np.linalg.norm(matrix))
-    eye = np.eye(matrix.shape[0])
-    k = 0
+    eps = np.eye(matrix.shape[0]) * np.spacing(np.linalg.norm(matrix))
+    k = 1
     while not is_cholesky_decomposable(matrix):
-        matrix += eye * (k**2 + eps)
+        matrix += eps * k**2
         k += 1
 
         if k == max_iterations:

--- a/stonesoup/updater/kalman.py
+++ b/stonesoup/updater/kalman.py
@@ -73,8 +73,8 @@ class KalmanUpdater(Updater):
             "geometric combination of the matrix and transpose. Default is False.")
     force_positive_definite_covariance: bool = Property(
         default=False,
-        doc="A flag to force the output covariance matrix to be symmetric by way of a simple "
-            "geometric combination of the matrix and transpose. Default is False.")
+        doc="A flag to force the output covariance matrix to be positive definite. "
+            "Default is False.")
     use_joseph_cov: bool = Property(
         default=False,
         doc="Bool dictating the method of covariance calculation. If use_joseph_cov is True then "

--- a/stonesoup/updater/kalman.py
+++ b/stonesoup/updater/kalman.py
@@ -13,7 +13,7 @@ from ..models.base import LinearModel
 from ..models.measurement.linear import LinearGaussian
 from ..models.measurement import MeasurementModel
 from ..functions import (gauss2sigma, unscented_transform, cubature_transform,
-                         cub_points_and_tf)
+                         cub_points_and_tf, find_nearest_positive_definite)
 from ..measures import Measure, Euclidean
 
 
@@ -68,6 +68,10 @@ class KalmanUpdater(Updater):
             "specified on construction, or in the measurement, then error "
             "will be thrown.")
     force_symmetric_covariance: bool = Property(
+        default=False,
+        doc="A flag to force the output covariance matrix to be symmetric by way of a simple "
+            "geometric combination of the matrix and transpose. Default is False.")
+    force_positive_definite_covariance: bool = Property(
         default=False,
         doc="A flag to force the output covariance matrix to be symmetric by way of a simple "
             "geometric combination of the matrix and transpose. Default is False.")
@@ -314,7 +318,9 @@ class KalmanUpdater(Updater):
                                               hypothesis.measurement,
                                               hypothesis.measurement_prediction)
 
-        if self.force_symmetric_covariance:
+        if self.force_positive_definite_covariance:
+            posterior_covariance = find_nearest_positive_definite(posterior_covariance)
+        elif self.force_symmetric_covariance:
             posterior_covariance = \
                 (posterior_covariance + posterior_covariance.T)/2
 


### PR DESCRIPTION
For some inputs, Unscented / Cubature Kalman Filter fail to compute compute unscented / cubature transform. This PR adds option to force covariance matrices to be positive definite so that transfroms can be successful.