### PR TITLE
Symmetrically remove prior covariance when initializing from measurement

### DIFF
--- a/stonesoup/initiator/simple.py
+++ b/stonesoup/initiator/simple.py
@@ -218,7 +218,8 @@ class SimpleMeasurementInitiator(GaussianInitiator):
             mapped_dimensions = measurement_model.mapping
 
             prior_state_vector[mapped_dimensions, :] = 0
-            prior_covar[mapped_dimensions, :] = 0
+            for dim in mapped_dimensions:
+                prior_covar[dim, :] = prior_covar[:, dim] = 0
             C0 = inv_model_matrix @ model_covar @ inv_model_matrix.T
             C0 = C0 + prior_covar + np.diag(np.array([self.diag_load] * C0.shape[0]))
             tracks.add(Track([Update.from_state(


### PR DESCRIPTION
Without this change, the covariance matrix generated by `SimpleMeasurementInitiatior` zeros only _rows_ of the prior covariance. This is a non-symmetric operation, and the resulting covariance matrix thus also becomes non-symmetric. I understand the logic here as "do not add prior covariance to observed dimensions", hence _prior_ covariances between observed dimensions and non-observed should also be removed.

Another option is to only remove prior covariance between observed dimensions, that would be
```
for dim in mapped_dimensions:
    prior_covar[dim, mapped_dimensions] = prior_covar[mapped_dimensions, dim] = 0
```