### PR TITLE
Don't detect other platforms in PlatformDetectionSimulator

### DIFF
--- a/stonesoup/simulator/platform.py
+++ b/stonesoup/simulator/platform.py
@@ -18,6 +18,8 @@ class PlatformDetectionSimulator(DetectionSimulator):
         doc='Source of ground truth tracks used to generate detections for.')
     platforms: Sequence[Platform] = Property(
         doc='List of platforms in :class:`~.Platform` to generate sensor detections from.')
+    platforms_detectable: bool = Property(
+        default=True, doc='If sensor platforms are able to detect each other. Default ``True``')
 
     @BufferedGenerator.generator_method
     def detections_gen(self):
@@ -32,6 +34,9 @@ class PlatformDetectionSimulator(DetectionSimulator):
             # Make measurements from sensors
             for platform in self.platforms:
                 for sensor in platform.sensors:
-                    truths_to_be_measured = truths.union(self.platforms) - {platform}
+                    if self.platforms_detectable:
+                        truths_to_be_measured = truths.union(self.platforms) - {platform}
+                    else:
+                        truths_to_be_measured = truths
                     detections = sensor.measure(truths_to_be_measured)
                     yield time, detections

--- a/stonesoup/simulator/tests/test_platform.py
+++ b/stonesoup/simulator/tests/test_platform.py
@@ -2,6 +2,7 @@ import datetime
 from copy import deepcopy
 
 import numpy as np
+import pytest
 
 from stonesoup.platform.base import MovingPlatform
 from ...models.transition.linear import CombinedLinearGaussianTransitionModel, ConstantVelocity
@@ -22,9 +23,10 @@ def build_platform(sensors, x_velocity):
     return platform
 
 
+@pytest.mark.parametrize("platform_detectable", [True, False])
 def test_platform_detection_simulator(sensor_model1,
                                       sensor_model2,
-                                      transition_model1):
+                                      platform_detectable):
 
     platform1 = build_platform([sensor_model1], 1)
     platform2 = build_platform([sensor_model2], 2)
@@ -33,9 +35,13 @@ def test_platform_detection_simulator(sensor_model1,
                      datetime.timedelta(seconds=i),
                      set()) for i in range(10))
     detector = PlatformDetectionSimulator(ground_truth,
-                                          [platform1, platform2])
+                                          [platform1, platform2],
+                                          platform_detectable)
 
     for n, (time, detections) in enumerate(detector):
+        if not platform_detectable:
+            assert not detections
+            continue
 
         # Detection count at each step.
         assert len(detections) == 1


### PR DESCRIPTION
Useful in scenario where only want ground truth targets to be measured