### PR TITLE
Fix Incorrect DeprecationWarning from Orbital Classes

### DIFF
--- a/stonesoup/types/angle.py
+++ b/stonesoup/types/angle.py
@@ -250,6 +250,7 @@ class Latitude(Elevation):
     Multiplication or division produces a float object rather than Latitude.
     """
 
+
 class Inclination(Angle):
     """(Orbital) Inclination angle class.
 

--- a/stonesoup/types/orbitalstate.py
+++ b/stonesoup/types/orbitalstate.py
@@ -11,6 +11,7 @@ from ..functions.orbital import keplerian_to_rv, tru_anom_from_mean_anom
 from . import Type
 from .array import StateVector, StateVectors, Matrix
 from .state import State, GaussianState, ParticleState
+from .angle import Inclination, EclipticLongitude
 from ..reader.astronomical import TLEDictReader
 
 warnings.simplefilter("default")  # To show warnings to user
@@ -122,8 +123,8 @@ class Orbital(Type):
     .. [3] Broucke, R. A. & Cefola, P. J. 1972, Celestial Mechanics, Volume 5, Issue 3, pp. 303-310
 
     .. deprecated:: 1.9
-        This function will be removed in Stone Soup 1.10. Orbital functions have moved to the
-        astrodynamics plugin.
+        This function will be removed in Stone Soup 1.10. Orbital functions have moved to
+        the astrodynamics plugin.
     """
 
     coordinates: CoordinateSystem = Property(
@@ -753,8 +754,8 @@ class OrbitalState(Orbital, State):
            Aerospace Engineering Series
 
     .. deprecated:: 1.9
-        This function will be removed in Stone Soup 1.10. Orbital functions have moved to the
-        astrodynamics plugin.
+        This function will be removed in Stone Soup 1.10. Orbital functions have moved to
+        the astrodynamics plugin.
     """
 
 
@@ -766,8 +767,8 @@ class GaussianOrbitalState(Orbital, GaussianState):
     All methods provided by :class:`~.Orbital` are available.
 
     .. deprecated:: 1.9
-        This function will be removed in Stone Soup 1.10. Orbital functions have moved to the
-        astrodynamics plugin.
+        This function will be removed in Stone Soup 1.10. Orbital functions have moved to
+        the astrodynamics plugin.
     """
 
 
@@ -779,6 +780,6 @@ class ParticleOrbitalState(Orbital, ParticleState):
     All methods provided by :class:`~.Orbital` are available.
 
     .. deprecated:: 1.9
-        This function will be removed in Stone Soup 1.10. Orbital functions have moved to the
-        astrodynamics plugin.
+        This function will be removed in Stone Soup 1.10. Orbital functions have moved to
+        the astrodynamics plugin.
     """


### PR DESCRIPTION
As raised in #1258, DeprecationWarnings were being raised when importing Angle types that were not being deprecated. This PR moves orbital-specific angle classes into the orbitalstate.py file, to remove the warning for other Angle classes.