### PR TITLE
Add fig and ax args to Plotter

### DIFF
--- a/stonesoup/plotter.py
+++ b/stonesoup/plotter.py
@@ -176,9 +176,7 @@ class Plotter(_Plotter):
         and labels as str
     """
 
-    def __init__(self, dimension=Dimension.TWO, **kwargs):
-        figure_kwargs = {"figsize": (10, 6)}
-        figure_kwargs.update(kwargs)
+    def __init__(self, dimension=Dimension.TWO, fig=None, ax=None, **kwargs):
         if isinstance(dimension, type(Dimension.TWO)):
             self.dimension = dimension
         elif isinstance(dimension, int):
@@ -187,12 +185,24 @@ class Plotter(_Plotter):
             raise TypeError("%s is an unsupported type for \'dimension\'; "
                             "expected type %s" % (type(dimension), type(Dimension.TWO)))
         # Generate plot axes
-        self.fig = plt.figure(**figure_kwargs)
+        if fig is not None:
+            self.fig = fig
+        else:
+            figure_kwargs = {"figsize": (10, 6)}
+            figure_kwargs.update(kwargs)
+            self.fig = plt.figure(**figure_kwargs)
+
         if self.dimension is Dimension.TWO:  # 2D axes
-            self.ax = self.fig.add_subplot(1, 1, 1)
+            if ax is not None:
+                self.ax = ax
+            else:
+                self.ax = self.fig.add_subplot(1, 1, 1)
             self.ax.axis('equal')
         else:  # 3D axes
-            self.ax = self.fig.add_subplot(111, projection='3d')
+            if ax is not None:
+                self.ax = ax
+            else:
+                self.ax = self.fig.add_subplot(111, projection='3d')
             self.ax.axis('auto')
             self.ax.set_zlabel("$z$")
         self.ax.set_xlabel("$x$")


### PR DESCRIPTION
Allow pyplot figure and axis types to be given to a Plotter so that plots can be natively placed within subplots 