### PR TITLE
Modifications to architectures to handle set of detections/tracks

### DIFF
--- a/docs/tutorials/architecture/02_Information_and_Network_Architectures.py
+++ b/docs/tutorials/architecture/02_Information_and_Network_Architectures.py
@@ -223,7 +223,7 @@ for sn in network_arch.sensor_nodes:
     na_sensors.append(sn.sensor)
     for timestep in sn.data_held['created'].keys():
         for datapiece in sn.data_held['created'][timestep]:
-            na_dets.add(datapiece.data)
+            na_dets.update(datapiece.data)
 
 # %%
 # Plot
@@ -269,7 +269,7 @@ for sn in information_arch.sensor_nodes:
     ia_sensors.append(sn.sensor)
     for timestep in sn.data_held['created'].keys():
         for datapiece in sn.data_held['created'][timestep]:
-            ia_dets.add(datapiece.data)
+            ia_dets.update(datapiece.data)
 
 # %%
 plotter = Plotterly()

--- a/docs/tutorials/architecture/03_Avoiding_Data_Incest.py
+++ b/docs/tutorials/architecture/03_Avoiding_Data_Incest.py
@@ -278,7 +278,7 @@ for sn in NH_architecture.sensor_nodes:
     NH_sensors.append(sn.sensor)
     for timestep in sn.data_held['created'].keys():
         for datapiece in sn.data_held['created'][timestep]:
-            NH_dets.add(datapiece.data)
+            NH_dets.update(datapiece.data)
 
 # %%
 # Plot the tracks stored at Non-Hierarchical Node C
@@ -380,7 +380,7 @@ for sn in H_architecture.sensor_nodes:
     H_sensors.append(sn.sensor)
     for timestep in sn.data_held['created'].keys():
         for datapiece in sn.data_held['created'][timestep]:
-            H_dets.add(datapiece.data)
+            H_dets.update(datapiece.data)
 
 # %%
 # Plot the tracks stored at Hierarchical Node C

--- a/docs/tutorials/architecture/03_Avoiding_Data_Incest.py
+++ b/docs/tutorials/architecture/03_Avoiding_Data_Incest.py
@@ -255,8 +255,7 @@ NH_edges = Edges([Edge((sensornode1, fusion_node1), edge_latency=0),
 # sphinx_gallery_thumbnail_path = '_static/sphinx_gallery/ArchTutorial_3.png'
 
 
-NH_architecture = InformationArchitecture(NH_edges, current_time=start_time,
-                                          use_arrival_time=True)
+NH_architecture = InformationArchitecture(NH_edges, current_time=start_time)
 NH_architecture
 
 # %%
@@ -358,8 +357,7 @@ H_edges = Edges([Edge((sensornode1B, fusion_node1B), edge_latency=0),
 # the second route for information to travel from Sensor Node 1 to
 # Fusion Node 1.
 
-H_architecture = InformationArchitecture(H_edges, current_time=start_time,
-                                         use_arrival_time=True)
+H_architecture = InformationArchitecture(H_edges, current_time=start_time)
 H_architecture
 
 # %%

--- a/docs/tutorials/architecture/03_Avoiding_Data_Incest.py
+++ b/docs/tutorials/architecture/03_Avoiding_Data_Incest.py
@@ -71,7 +71,7 @@ mm = LinearGaussian(ndim_state=4,
 mm2 = LinearGaussian(ndim_state=4,
                      mapping=[0, 2],
                      noise_covar=CovarianceMatrix(np.diag([0.5, 0.5])),
-                     seed=6)
+                     seed=12)
 
 # %%
 from stonesoup.sensor.sensor import SimpleSensor
@@ -97,7 +97,7 @@ sensor1.clutter_model.distribution = sensor1.clutter_model.random_state.uniform
 sensor2 = DummySensor(measurement_model=mm2,
                       position=np.array([[10], [20]]),
                       clutter_model=ClutterModel(clutter_rate=5,
-                                                 dist_params=((-100, 100), (-50, 60)), seed=6))
+                                                 dist_params=((-100, 100), (-50, 60)), seed=12))
 sensor2.clutter_model.distribution = sensor2.clutter_model.random_state.uniform
 
 # %%

--- a/stonesoup/architecture/__init__.py
+++ b/stonesoup/architecture/__init__.py
@@ -514,11 +514,14 @@ class Architecture(Base):
             for detection in sensor_node.sensor.measure(current_ground_truths, noise, **kwargs):
                 all_detections[sensor_node].add(detection)
 
-            for data in all_detections[sensor_node]:
+            if all_detections[sensor_node]:
                 # The sensor acquires its own data instantly
-                sensor_node.update(data.timestamp, data.timestamp,
-                                   DataPiece(sensor_node, sensor_node, data, data.timestamp),
-                                   'created')
+                sensor_node.update(
+                    self.current_time, self.current_time,
+                    DataPiece(
+                        sensor_node, sensor_node, all_detections[sensor_node], self.current_time
+                    ),
+                    'created')
 
         return all_detections
 

--- a/stonesoup/architecture/__init__.py
+++ b/stonesoup/architecture/__init__.py
@@ -40,12 +40,6 @@ class Architecture(Base):
         doc="If True, the undirected version of the graph must be connected, ie. all nodes should "
             "be connected via some path. Set this to False to allow an unconnected architecture. "
             "Default is True")
-    use_arrival_time: bool = Property(
-        default=False,
-        doc="If True, the timestamp on data passed around the network will not be assigned when "
-            "it is opened by the fusing node - simulating an architecture where time of recording "
-            "is not registered by the sensor nodes"
-    )
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -575,12 +569,12 @@ class InformationArchitecture(Architecture):
             # TODO: Future work - Introduce failed edges functionality
 
             # Initial update of message categories
-            edge.update_messages(self.current_time, use_arrival_time=self.use_arrival_time)
+            edge.update_messages(self.current_time)
             for data_piece, time_pertaining in edge.unsent_data:
                 edge.send_message(data_piece, time_pertaining, data_piece.time_arrived)
 
             # Need to re-run update messages so that messages aren't left as 'pending'
-            edge.update_messages(self.current_time, use_arrival_time=self.use_arrival_time)
+            edge.update_messages(self.current_time)
 
         for fuse_node in self.fusion_nodes:
             fuse_node.fuse()
@@ -646,8 +640,7 @@ class NetworkArchitecture(Architecture):
             # Initial update of message categories
             edge.update_messages(
                 self.current_time,
-                to_network_node=to_network_node,
-                use_arrival_time=self.use_arrival_time)
+                to_network_node=to_network_node)
 
             # Send available messages from nodes to the edges
             if edge.sender in self.information_arch.all_nodes:
@@ -661,8 +654,7 @@ class NetworkArchitecture(Architecture):
             # Need to re-run update messages so that messages aren't left as 'pending'
             edge.update_messages(
                 self.current_time,
-                to_network_node=to_network_node,
-                use_arrival_time=self.use_arrival_time)
+                to_network_node=to_network_node)
 
         for fuse_node in self.fusion_nodes:
             fuse_node.fuse()

--- a/stonesoup/architecture/edge.py
+++ b/stonesoup/architecture/edge.py
@@ -226,7 +226,7 @@ class Edge(Base):
         """Data modified by the sender that has not been sent to the
         recipient."""
         unsent = []
-        if isinstance(type(self.sender.data_held), type(None)) or self.sender.data_held is None:
+        if self.sender.data_held is None:
             return unsent
         else:
             for status in ["fused", "created"]:

--- a/stonesoup/architecture/edge.py
+++ b/stonesoup/architecture/edge.py
@@ -133,7 +133,7 @@ class Edge(Base):
         # Message not opened by repeater node, remove node from 'sent_to'
         message_copy.data_piece.sent_to.add(self)
 
-    def update_messages(self, current_time, to_network_node=False, use_arrival_time=False):
+    def update_messages(self, current_time, to_network_node=False):
         """
         Updates the category of messages stored in edge.messages_held if latency time has passed.
         Adds messages that have 'arrived' at recipient to the relevant holding area of the node.
@@ -144,8 +144,6 @@ class Edge(Base):
             Current time in simulation.
         to_network_node : bool, optional
             True if recipient node is not in the information architecture (default is False).
-        use_arrival_time : bool, optional
-            True if arriving data should use arrival time as its timestamp (default is False).
         """
         # Check info type is what we expect
         to_remove = set()  # Needed as we can't change size of a set during iteration
@@ -168,15 +166,13 @@ class Edge(Base):
                         # Add data to recipient's data_held
                         self.recipient.update(message.time_pertaining,
                                               message.arrival_time,
-                                              message.data_piece, "unfused",
-                                              use_arrival_time=use_arrival_time)
+                                              message.data_piece, "unfused")
 
                     elif not to_network_node and self.recipient in message.destinations:
                         # Add data to recipient's data held, and message to messages_to_pass_on
                         self.recipient.update(message.time_pertaining,
                                               message.arrival_time,
-                                              message.data_piece, "unfused",
-                                              use_arrival_time=use_arrival_time)
+                                              message.data_piece, "unfused")
                         message.destinations = None
                         self.recipient.messages_to_pass_on.append(message)
 

--- a/stonesoup/architecture/node.py
+++ b/stonesoup/architecture/node.py
@@ -1,5 +1,6 @@
 import copy
 import threading
+from collections.abc import Iterable
 from datetime import datetime
 from queue import Queue, Empty
 
@@ -75,8 +76,9 @@ class Node(Base):
         if category not in self.data_held.keys():
             raise ValueError(f"category must be one of {self.data_held.keys()}")
         if not track:
-            if not isinstance(data_piece.data, Detection) and \
-                    not isinstance(data_piece.data, Track):
+            if (not isinstance(data_piece.data, Iterable) or (
+                    not isinstance(next(iter(data_piece.data), None), Detection)
+                    and not isinstance(next(iter(data_piece.data), None), Track))):
                 raise TypeError(f"Data provided without accompanying Track must be a Detection or "
                                 f"a Track, not a "
                                 f"{type(data_piece.data).__name__}")
@@ -92,9 +94,9 @@ class Node(Base):
 
         if (isinstance(self, FusionNode)
                 and category in ("created", "unfused")
-                and data_piece.data not in self.fusion_queue.received):
-            self.fusion_queue.received.add(data_piece.data)
-            self.fusion_queue.put((time_pertaining, {data_piece.data}))
+                and data_piece not in self.fusion_queue.received):
+            self.fusion_queue.received.add(data_piece)
+            self.fusion_queue.put((time_pertaining, data_piece.data))
 
         return added
 
@@ -159,6 +161,7 @@ class FusionNode(Node):
 
         added = False
         updated_tracks = set()
+        time = None
         while True:
             waiting_for_data = self.fusion_queue.waiting_for_data
             try:
@@ -167,14 +170,14 @@ class FusionNode(Node):
                 if not self._tracking_thread.is_alive() or waiting_for_data:
                     break
             else:
-                _, tracks = data
+                time, tracks = data
                 self.tracks.update(tracks)
                 updated_tracks = updated_tracks.union(tracks)
 
-        for track in updated_tracks:
-            data_piece = DataPiece(self, self, copy.copy(track), track.timestamp, True)
-            added, self.data_held['fused'] = _dict_set(
-                self.data_held['fused'], data_piece, track.timestamp)
+        if updated_tracks:
+            data_piece = DataPiece(
+                self, self, {copy.copy(track) for track in updated_tracks}, time, True)
+            added, self.data_held['fused'] = _dict_set(self.data_held['fused'], data_piece, time)
         return added
 
     @staticmethod

--- a/stonesoup/architecture/node.py
+++ b/stonesoup/architecture/node.py
@@ -45,8 +45,7 @@ class Node(Base):
         self.data_held = {"fused": {}, "created": {}, "unfused": {}}
         self.messages_to_pass_on = []
 
-    def update(self, time_pertaining, time_arrived, data_piece, category, track=None,
-               use_arrival_time=False):
+    def update(self, time_pertaining, time_arrived, data_piece, category, track=None):
         """
         Updates this Node's data_held using a new data piece.
 
@@ -63,8 +62,6 @@ class Node(Base):
         track : Track, optional
             Track to which the data piece is assigned, if it contains a Hypothesis
             (default is None).
-        use_arrival_time : bool, optional
-            If True, make `data.timestamp` equal to `time_arrived` (default is False).
 
         Returns
         -------
@@ -93,17 +90,9 @@ class Node(Base):
         added, self.data_held[category] = _dict_set(self.data_held[category],
                                                     new_data_piece, time_pertaining)
 
-        if use_arrival_time and isinstance(self, FusionNode) and \
-                category in ("created", "unfused"):
-            data = copy.copy(data_piece.data)
-            data.timestamp = time_arrived
-            if data not in self.fusion_queue.received:
-                self.fusion_queue.received.add(data)
-                self.fusion_queue.put((time_pertaining, {data}))
-
-        elif isinstance(self, FusionNode) and \
-                category in ("created", "unfused") and \
-                data_piece.data not in self.fusion_queue.received:
+        if (isinstance(self, FusionNode)
+                and category in ("created", "unfused")
+                and data_piece.data not in self.fusion_queue.received):
             self.fusion_queue.received.add(data_piece.data)
             self.fusion_queue.put((time_pertaining, {data_piece.data}))
 

--- a/stonesoup/architecture/tests/conftest.py
+++ b/stonesoup/architecture/tests/conftest.py
@@ -80,9 +80,9 @@ def nodes():
 @pytest.fixture
 def data_pieces(times, nodes):
     data_piece_a = DataPiece(node=nodes['a'], originator=nodes['a'],
-                             data=Track([]), time_arrived=times['a'])
+                             data={Track([])}, time_arrived=times['a'])
     data_piece_b = DataPiece(node=nodes['a'], originator=nodes['b'],
-                             data=Track([]), time_arrived=times['b'])
+                             data={Track([])}, time_arrived=times['b'])
     data_piece_fail = DataPiece(node=nodes['a'], originator=nodes['b'],
                                 data="Not a compatible data type", time_arrived=times['b'])
     data_piece_hyp = DataPiece(node=nodes['a'], originator=nodes['b'],

--- a/stonesoup/architecture/tests/test_architecture.py
+++ b/stonesoup/architecture/tests/test_architecture.py
@@ -512,8 +512,8 @@ def test_information_arch_measure(edge_lists, ground_truths, times):
             assert isinstance(detection, TrueDetection)
 
     for node in network.sensor_nodes:
-        # Check that each sensor node has data held for the detection of all 3 targets
-        assert len(node.data_held['created'][datetime.datetime(1306, 12, 25, 23, 47, 59)]) == 3
+        # Check that each sensor node has data held for the detection of all 1 targets
+        assert len(node.data_held['created'][network.current_time].pop().data) == 3
 
 
 def test_information_arch_measure_no_noise(edge_lists, ground_truths, times):
@@ -571,7 +571,7 @@ def test_fully_propagated(edge_lists, times, ground_truths):
     for node in network.sensor_nodes:
         # Check that each sensor node has data held for the detection of all 3 targets
         for key in node.data_held['created'].keys():
-            assert len(node.data_held['created'][key]) == 3
+            assert len(next(iter(node.data_held['created'][key])).data) == 3
 
     # Network should not be fully propagated
     assert network.fully_propagated is False
@@ -743,7 +743,7 @@ def test_net_arch_fully_propagated(generator_params, ground_truths):
     for node in arch.sensor_nodes:
         # Check that each sensor node has data held for the detection of all 3 targets
         for key in node.data_held['created'].keys():
-            assert len(node.data_held['created'][key]) == 3
+            assert len(next(iter(node.data_held['created'][key])).data) == 3
 
     edge = {edge for edge in arch.edges if
             isinstance(edge.nodes[0], RepeaterNode) and
@@ -756,8 +756,8 @@ def test_net_arch_fully_propagated(generator_params, ground_truths):
         DataPiece(
             edge.sender,
             edge.sender,
-            Track([GaussianState([1, 2, 3, 4], np.diag([1, 1, 1, 1]),
-                                 datetime.datetime(2016, 1, 2, 3, 4, 5))]),
+            {Track([GaussianState([1, 2, 3, 4], np.diag([1, 1, 1, 1]),
+                                  datetime.datetime(2016, 1, 2, 3, 4, 5))])},
             datetime.datetime(2016, 1, 2, 3, 4, 5),
         ),
     )

--- a/stonesoup/architecture/tests/test_edge.py
+++ b/stonesoup/architecture/tests/test_edge.py
@@ -14,7 +14,7 @@ def test_data_piece(nodes, times):
         _ = DataPiece()
 
     data_piece = DataPiece(node=nodes['a'], originator=nodes['a'],
-                           data=Track([]), time_arrived=times['a'])
+                           data={Track([])}, time_arrived=times['a'])
     assert data_piece.sent_to == set()
     assert data_piece.track is None
 
@@ -77,7 +77,7 @@ def test_update_messages():
 
     time_created = datetime.datetime.now()
     time_sent = time_created
-    data = DataPiece(A, A, Track([]), time_created)
+    data = DataPiece(A, A, {Track([])}, time_created)
 
     # Add message to edge
     edge.send_message(data, time_created, time_sent)
@@ -187,24 +187,24 @@ def test_message_destinations(times, radar_nodes):
 
     # Create a message without defining a destination
     message1 = Message(edge1, datetime.datetime(2016, 1, 2, 3, 4, 5), start_time,
-                       DataPiece(node1, node1, Track([]),
+                       DataPiece(node1, node1, {Track([])},
                                  datetime.datetime(2016, 1, 2, 3, 4, 5)))
 
     # Create a message with node 2 as a destination
     message2 = Message(edge1, datetime.datetime(2016, 1, 2, 3, 4, 5), start_time,
-                       DataPiece(node1, node1, Track([]),
+                       DataPiece(node1, node1, {Track([])},
                                  datetime.datetime(2016, 1, 2, 3, 4, 5)),
                        destinations={node2})
 
     # Create a message with as a defined destination that isn't node 2
     message3 = Message(edge1, datetime.datetime(2016, 1, 2, 3, 4, 5), start_time,
-                       DataPiece(node1, node1, Track([]),
+                       DataPiece(node1, node1, {Track([])},
                                  datetime.datetime(2016, 1, 2, 3, 4, 5)),
                        destinations={node3})
 
     # Create message that has node2 and node3 as a destination
     message4 = Message(edge1, datetime.datetime(2016, 1, 2, 3, 4, 5), start_time,
-                       DataPiece(node1, node1, Track([]),
+                       DataPiece(node1, node1, {Track([])},
                                  datetime.datetime(2016, 1, 2, 3, 4, 5)),
                        destinations={node2, node3})
 

--- a/stonesoup/architecture/tests/test_node.py
+++ b/stonesoup/architecture/tests/test_node.py
@@ -41,8 +41,7 @@ def test_node(data_pieces, times, nodes):
                     times['b'],
                     data_pieces['fail'],
                     "fused",
-                    track=Track([]),
-                    use_arrival_time=False)
+                    track=Track([]))
 
 
 def test_sensor_node(nodes):
@@ -163,18 +162,10 @@ def test_update(tracker):
     assert h_data.data == new_data_piece.data
     assert h_data.time_arrived == new_data_piece.time_arrived
 
-    # Test placing data into fusion queue - use_arrival_time=False
+    # Test placing data into fusion queue
     D = FusionNode(tracker=tracker)
-    D.update(dt1, dt1, d_data, 'created', use_arrival_time=False)
+    D.update(dt1, dt1, d_data, 'created')
     assert d_data.data in D.fusion_queue.received
-
-    # Test placing data into fusion queue - use_arrival_time=True
-    D = FusionNode(tracker=tracker)
-    D.update(dt1, dt1, d_data, 'created', use_arrival_time=True)
-    copied_data = D.fusion_queue.received.pop()
-    assert sum(copied_data.state_vector - d_data.data.state_vector) == 0
-    assert copied_data.measurement_model == d_data.data.measurement_model
-    assert copied_data.metadata == d_data.data.metadata
 
 
 def test_fuse(generator_params, ground_truths, timesteps):

--- a/stonesoup/architecture/tests/test_node.py
+++ b/stonesoup/architecture/tests/test_node.py
@@ -1,4 +1,5 @@
 import copy
+from collections.abc import Iterable
 from datetime import datetime
 
 import numpy as np
@@ -24,7 +25,9 @@ def test_node(data_pieces, times, nodes):
     node.update(times['a'], times['b'], data_pieces['a'], "fused")
     new_data_piece = node.data_held['fused'][times['a']].pop()
     assert new_data_piece.originator == nodes['a']
-    assert isinstance(new_data_piece.data, Track) and len(new_data_piece.data) == 0
+    assert isinstance(new_data_piece.data, Iterable)
+    assert isinstance(next(iter(new_data_piece.data), None), Track)
+    assert len(next(iter(new_data_piece.data))) == 0
     assert new_data_piece.time_arrived == times['b']
 
     with pytest.raises(TypeError):
@@ -113,9 +116,9 @@ def test_update(tracker):
     dt0 = "This ain't no datetime object"
     dt1 = datetime.now()
 
-    t_data = DataPiece(A, A, Track([]), dt1)
-    d_data = DataPiece(A, A, Detection(state_vector=StateVector(np.random.rand(4, 1)),
-                                       timestamp=dt1), dt1)
+    t_data = DataPiece(A, A, {Track([])}, dt1)
+    d_data = DataPiece(
+        A, A, {Detection(state_vector=StateVector(np.random.rand(4, 1)), timestamp=dt1)}, dt1)
     h_data = DataPiece(A, A, Hypothesis(), dt1)
 
     # Test invalid time inputs
@@ -165,7 +168,7 @@ def test_update(tracker):
     # Test placing data into fusion queue
     D = FusionNode(tracker=tracker)
     D.update(dt1, dt1, d_data, 'created')
-    assert d_data.data in D.fusion_queue.received
+    assert d_data in D.fusion_queue.received
 
 
 def test_fuse(generator_params, ground_truths, timesteps):


### PR DESCRIPTION
This modifies architectures to handle detections and tracks as a set to enable data to be moved in "scans" between nodes. The case of single detection/track at a time can be handle as a set of one detection/track e.g. by source generating data or by using feeder for manipulating the data.

This also removes arrival time feature, but again could be done with feeder.