### PR TITLE
Modify SquaredMahalanobis __call__ to accept a 2D state_vector in state2

### DIFF
--- a/stonesoup/measures/state.py
+++ b/stonesoup/measures/state.py
@@ -188,8 +188,8 @@ class SquaredMahalanobis(Measure):
 
         Parameters
         ----------
-        state1 : :class:`~.State` with shape (n, 1)
-        state2 : :class:`~.State` with shape (n, m)
+        state1 : :class:`~.State` whose `state_vector` has shape (n, 1)
+        state2 : :class:`~.State` whose `state_vector` has shape (n, m)
 
         Returns
         -------
@@ -219,8 +219,8 @@ class SquaredMahalanobis(Measure):
 
         delta = -(v.T-u)
 
-        # Return the diagonal elements with einsum
-        return np.einsum('ij,ji->i', np.dot(delta, vi), delta.T).squeeze()[()]
+        # Return the diagonal elements of A@B@A.T
+        return np.einsum('ij,jk,ik->i', delta, vi, delta).squeeze()[()]
 
     @staticmethod
     def _inv_cov(state, mapping=None):

--- a/stonesoup/measures/state.py
+++ b/stonesoup/measures/state.py
@@ -188,32 +188,39 @@ class SquaredMahalanobis(Measure):
 
         Parameters
         ----------
-        state1 : :class:`~.State`
-        state2 : :class:`~.State`
+        state1 : :class:`~.State` with shape (n, 1)
+        state2 : :class:`~.State` with shape (n, m)
 
         Returns
         -------
-        float
+        Union(float, np.ndarray)
             Squared Mahalanobis distance between a pair of input :class:`~.State`
-            objects
+            objects. Returns a 1D array if state2 has >1 length along axis 1.
 
         """
         state_vector1 = getattr(state1, 'mean', state1.state_vector)
         state_vector2 = getattr(state2, 'mean', state2.state_vector)
 
+        if len(state_vector1) != len(state_vector2):
+            raise ValueError(
+                f"Shape mismatch between state1 and state2 along axis 0, \
+                    {len(state_vector1)} != {len(state_vector2)}."
+            )
+
         if self.mapping is not None:
             u = state_vector1[self.mapping, 0]
-            v = state_vector2[self.mapping2, 0]
+            v = state_vector2[self.mapping2, :]
             # extract the mapped covariance data
             vi = self._inv_cov(state1, tuple(self.mapping))
         else:
             u = state_vector1[:, 0]
-            v = state_vector2[:, 0]
+            v = state_vector2[:, :]
             vi = self._inv_cov(state1)
 
-        delta = u - v
+        delta = -(v.T-u)
 
-        return np.dot(np.dot(delta, vi), delta)
+        # Return the diagonal elements with einsum
+        return np.einsum('ij,ji->i', np.dot(delta, vi), delta.T).squeeze()[()]
 
     @staticmethod
     def _inv_cov(state, mapping=None):

--- a/stonesoup/measures/tests/test_state.py
+++ b/stonesoup/measures/tests/test_state.py
@@ -48,9 +48,9 @@ def test_euclideanweighted():
 
 def test_mahalanobis():
     measure = measures.Mahalanobis()
-    assert measure(state_u, state_v) == distance.mahalanobis(u[:, 0],
-                                                             v[:, 0],
-                                                             np.linalg.inv(ui))
+    assert measure(state_u, state_v) == pytest.approx(distance.mahalanobis(u[:, 0],
+                                                                           v[:, 0],
+                                                                           np.linalg.inv(ui)))
 
 
 def test_hellinger():
@@ -141,13 +141,13 @@ def test_hellinger_partial_mapping(mapping_type):
 def test_mahalanobis_full_mapping(mapping_type):
     mapping = mapping_type(np.arange(len(u)))
     measure = measures.Mahalanobis(mapping=mapping)
-    assert measure(state_u, state_v) == distance.mahalanobis(u[:, 0],
-                                                             v[:, 0],
-                                                             np.linalg.inv(ui))
+    assert measure(state_u, state_v) == pytest.approx(distance.mahalanobis(u[:, 0],
+                                                                           v[:, 0],
+                                                                           np.linalg.inv(ui)))
     measure = measures.Mahalanobis(mapping=mapping, mapping2=mapping)
-    assert measure(state_u, state_v) == distance.mahalanobis(u[:, 0],
-                                                             v[:, 0],
-                                                             np.linalg.inv(ui))
+    assert measure(state_u, state_v) == pytest.approx(distance.mahalanobis(u[:, 0],
+                                                                           v[:, 0],
+                                                                           np.linalg.inv(ui)))
 
 
 def test_mahalanobis_partial_mapping(mapping_type):

--- a/stonesoup/measures/tests/test_state.py
+++ b/stonesoup/measures/tests/test_state.py
@@ -21,9 +21,11 @@ state_u = GaussianState(u, ui, timestamp=t)
 stateB_u = State(u, timestamp=t)
 
 v = StateVector([[11.], [10.], [100.], [2.]])
+vm = StateVectors(np.random.random((4, 10)))
 vi = CovarianceMatrix(np.diag([20., 3., 7., 10.]))
 
 state_v = GaussianState(v, vi, timestamp=t)
+state_vm = State(vm)
 stateB_v = State(v, timestamp=t)
 
 
@@ -51,7 +53,11 @@ def test_mahalanobis():
     assert measure(state_u, state_v) == pytest.approx(distance.mahalanobis(u[:, 0],
                                                                            v[:, 0],
                                                                            np.linalg.inv(ui)))
-
+    result_nm = measure(state_u, state_vm)
+    for i, vec in enumerate(vm):
+        assert result_nm[i] == pytest.approx(distance.mahalanobis(u[:, 0], 
+                                                                  vec[:, 0], 
+                                                                  np.linalg.inv(ui)))
 
 def test_hellinger():
     v = StateVector([[11.], [10.], [10.], [2.]])
@@ -144,10 +150,20 @@ def test_mahalanobis_full_mapping(mapping_type):
     assert measure(state_u, state_v) == pytest.approx(distance.mahalanobis(u[:, 0],
                                                                            v[:, 0],
                                                                            np.linalg.inv(ui)))
+    result_nm = measure(state_u, state_vm)
+    for i, vec in enumerate(vm):
+        assert result_nm[i] == pytest.approx(distance.mahalanobis(u[:, 0], 
+                                                                  vec[:, 0], 
+                                                                  np.linalg.inv(ui)))
     measure = measures.Mahalanobis(mapping=mapping, mapping2=mapping)
     assert measure(state_u, state_v) == pytest.approx(distance.mahalanobis(u[:, 0],
                                                                            v[:, 0],
                                                                            np.linalg.inv(ui)))
+    result_nm = measure(state_u, state_vm)
+    for i, vec in enumerate(vm):
+        assert result_nm[i] == pytest.approx(distance.mahalanobis(u[:, 0], 
+                                                                  vec[:, 0], 
+                                                                  np.linalg.inv(ui)))
 
 
 def test_mahalanobis_partial_mapping(mapping_type):
@@ -157,23 +173,43 @@ def test_mahalanobis_partial_mapping(mapping_type):
     assert measure(state_u, state_v) == \
         distance.mahalanobis([10, 1],
                              [11, 10], np.linalg.inv(reduced_ui))
+    result_nm = measure(state_u, state_vm)
+    for i, vec in enumerate(vm):
+        assert result_nm[i] == pytest.approx(distance.mahalanobis(u[mapping, 0], 
+                                                                  vec[mapping, 0], 
+                                                                  np.linalg.inv(reduced_ui)))
     mapping = np.array([0, 3])
     reduced_ui = CovarianceMatrix(np.diag([100, 10]))
     measure = measures.Mahalanobis(mapping=mapping)
     assert measure(state_u, state_v) == \
         distance.mahalanobis([10, 1],
                              [11, 2], np.linalg.inv(reduced_ui))
+    result_nm = measure(state_u, state_vm)
+    for i, vec in enumerate(vm):
+        assert result_nm[i] == pytest.approx(distance.mahalanobis(u[mapping, 0], 
+                                                                  vec[mapping, 0], 
+                                                                  np.linalg.inv(reduced_ui)))
 
     mapping = mapping_type([0, 1])
     measure = measures.Mahalanobis(mapping=mapping, mapping2=mapping)
     assert measure(state_u, state_v) == \
         distance.mahalanobis([10, 1],
                              [11, 10], np.linalg.inv(reduced_ui))
+    result_nm = measure(state_u, state_vm)
+    for i, vec in enumerate(vm):
+        assert result_nm[i] == pytest.approx(distance.mahalanobis(u[mapping, 0], 
+                                                                  vec[mapping, 0], 
+                                                                  np.linalg.inv(reduced_ui)))
     mapping = np.array([0, 3])
     measure = measures.Mahalanobis(mapping=mapping, mapping2=mapping)
     assert measure(state_u, state_v) == \
         distance.mahalanobis([10, 1],
                              [11, 2], np.linalg.inv(reduced_ui))
+    result_nm = measure(state_u, state_vm)
+    for i, vec in enumerate(vm):
+        assert result_nm[i] == pytest.approx(distance.mahalanobis(u[mapping, 0], 
+                                                                  vec[mapping, 0], 
+                                                                  np.linalg.inv(reduced_ui)))
 
     mapping = mapping_type([0, 1])
     mapping2 = np.array([0, 3])

--- a/stonesoup/measures/tests/test_state.py
+++ b/stonesoup/measures/tests/test_state.py
@@ -55,9 +55,10 @@ def test_mahalanobis():
                                                                            np.linalg.inv(ui)))
     result_nm = measure(state_u, state_vm)
     for i, vec in enumerate(vm):
-        assert result_nm[i] == pytest.approx(distance.mahalanobis(u[:, 0], 
-                                                                  vec[:, 0], 
+        assert result_nm[i] == pytest.approx(distance.mahalanobis(u[:, 0],
+                                                                  vec[:, 0],
                                                                   np.linalg.inv(ui)))
+
 
 def test_hellinger():
     v = StateVector([[11.], [10.], [10.], [2.]])
@@ -152,8 +153,8 @@ def test_mahalanobis_full_mapping(mapping_type):
                                                                            np.linalg.inv(ui)))
     result_nm = measure(state_u, state_vm)
     for i, vec in enumerate(vm):
-        assert result_nm[i] == pytest.approx(distance.mahalanobis(u[:, 0], 
-                                                                  vec[:, 0], 
+        assert result_nm[i] == pytest.approx(distance.mahalanobis(u[:, 0],
+                                                                  vec[:, 0],
                                                                   np.linalg.inv(ui)))
     measure = measures.Mahalanobis(mapping=mapping, mapping2=mapping)
     assert measure(state_u, state_v) == pytest.approx(distance.mahalanobis(u[:, 0],
@@ -161,8 +162,8 @@ def test_mahalanobis_full_mapping(mapping_type):
                                                                            np.linalg.inv(ui)))
     result_nm = measure(state_u, state_vm)
     for i, vec in enumerate(vm):
-        assert result_nm[i] == pytest.approx(distance.mahalanobis(u[:, 0], 
-                                                                  vec[:, 0], 
+        assert result_nm[i] == pytest.approx(distance.mahalanobis(u[:, 0],
+                                                                  vec[:, 0],
                                                                   np.linalg.inv(ui)))
 
 
@@ -175,8 +176,8 @@ def test_mahalanobis_partial_mapping(mapping_type):
                              [11, 10], np.linalg.inv(reduced_ui))
     result_nm = measure(state_u, state_vm)
     for i, vec in enumerate(vm):
-        assert result_nm[i] == pytest.approx(distance.mahalanobis(u[mapping, 0], 
-                                                                  vec[mapping, 0], 
+        assert result_nm[i] == pytest.approx(distance.mahalanobis(u[mapping, 0],
+                                                                  vec[mapping, 0],
                                                                   np.linalg.inv(reduced_ui)))
     mapping = np.array([0, 3])
     reduced_ui = CovarianceMatrix(np.diag([100, 10]))
@@ -186,8 +187,8 @@ def test_mahalanobis_partial_mapping(mapping_type):
                              [11, 2], np.linalg.inv(reduced_ui))
     result_nm = measure(state_u, state_vm)
     for i, vec in enumerate(vm):
-        assert result_nm[i] == pytest.approx(distance.mahalanobis(u[mapping, 0], 
-                                                                  vec[mapping, 0], 
+        assert result_nm[i] == pytest.approx(distance.mahalanobis(u[mapping, 0],
+                                                                  vec[mapping, 0],
                                                                   np.linalg.inv(reduced_ui)))
 
     mapping = mapping_type([0, 1])
@@ -197,8 +198,8 @@ def test_mahalanobis_partial_mapping(mapping_type):
                              [11, 10], np.linalg.inv(reduced_ui))
     result_nm = measure(state_u, state_vm)
     for i, vec in enumerate(vm):
-        assert result_nm[i] == pytest.approx(distance.mahalanobis(u[mapping, 0], 
-                                                                  vec[mapping, 0], 
+        assert result_nm[i] == pytest.approx(distance.mahalanobis(u[mapping, 0],
+                                                                  vec[mapping, 0],
                                                                   np.linalg.inv(reduced_ui)))
     mapping = np.array([0, 3])
     measure = measures.Mahalanobis(mapping=mapping, mapping2=mapping)
@@ -207,8 +208,8 @@ def test_mahalanobis_partial_mapping(mapping_type):
                              [11, 2], np.linalg.inv(reduced_ui))
     result_nm = measure(state_u, state_vm)
     for i, vec in enumerate(vm):
-        assert result_nm[i] == pytest.approx(distance.mahalanobis(u[mapping, 0], 
-                                                                  vec[mapping, 0], 
+        assert result_nm[i] == pytest.approx(distance.mahalanobis(u[mapping, 0],
+                                                                  vec[mapping, 0],
                                                                   np.linalg.inv(reduced_ui)))
 
     mapping = mapping_type([0, 1])


### PR DESCRIPTION
This PR is based on this exchange: https://github.com/dstl/Stone-Soup/discussions/1226#discussion-9023113

The idea is to expand SquaredMahalanobis to compute one-to-many distances instead of the original one-to-one distance.

Original interface:
- `state1.state_vector` has shape (n, 1)
- `state2.state_vector` has shape (n, 1)
- Returns the floating point squared Mahalanobis distance

New interface:
- `state1.state_vector` has shape (n, 1)
- `state2.state_vector` has shape (n, m)
- If m=1, returns the same floating point value as the original. If m>1, returns an np.ndarray of Mahalanobis distances of shape (m,), comparing the distance between state1 and all states in state2.

In the original exchange, @sdhiscocks said we should also consider an (n, m) + (n, m) case. This is a possibility, but I was not sure how to implement this given that a `GaussianState` cannot have its seconds axis >1 due to the limitations of `StateVector`. Please advise on this latter point.