### PR TITLE
Fix error with attempting to plot empty measurements set

### DIFF
--- a/stonesoup/plotter.py
+++ b/stonesoup/plotter.py
@@ -366,8 +366,9 @@ class Plotter(_Plotter):
             self.legend_dict[name] = clutter_handle
 
         # Generate legend
-        artists.append(self.ax.legend(handles=self.legend_dict.values(),
-                                      labels=self.legend_dict.keys()))
+        if self.legend_dict:
+            artists.append(self.ax.legend(handles=self.legend_dict.values(),
+                                          labels=self.legend_dict.keys()))
         return artists
 
     def plot_tracks(self, tracks, mapping, uncertainty=False, particle=False, label="Tracks",

--- a/stonesoup/tests/test_plotter.py
+++ b/stonesoup/tests/test_plotter.py
@@ -454,9 +454,8 @@ def test_plotters_plot_measurements_empty_silent(plotter_class, _measurements, _
     "_measurements, _show_clutter",
     [(list(), True), (list(), False), (clutter_measurement_set, False)])
 def test_plotters_plot_measurements_empty_warn(_measurements, _show_clutter):
-    with pytest.warns(UserWarning, match="No artists with labels found to put in legend"):
-        plotter = Plotter()
-        plotter.plot_measurements(_measurements, [0, 2], show_clutter=_show_clutter)
+    plotter = Plotter()
+    plotter.plot_measurements(_measurements, [0, 2], show_clutter=_show_clutter)
 
 
 @pytest.mark.parametrize(
@@ -465,16 +464,15 @@ def test_plotters_plot_measurements_empty_warn(_measurements, _show_clutter):
      (true_measurements, False, len(true_measurements)),
      (all_measurements, False, len(true_measurements)),
      (clutter_measurements, False, None)])
-# Ignore this warning which occurs when there is no data to plot (e.g. last test case here)
-@pytest.mark.filterwarnings("ignore:.*No artists with labels found to put in legend.*:UserWarning")
 def test_plotters_plot_measurements_count_no_clutter(_measurements, _show_clutter,
                                                      expected_plot_truths_length):
     plotter = Plotter()
     artist_list = plotter.plot_measurements(_measurements, [0, 2], show_clutter=_show_clutter)
 
-    expected_number_of_artists = 1  # there is always a legend artist at the end
+    expected_number_of_artists = 0
     if expected_plot_truths_length is not None:
         expected_number_of_artists += 1
+        expected_number_of_artists += 1  # there is a legend artist at the end
     assert len(artist_list) == expected_number_of_artists
 
     if expected_plot_truths_length is not None:
@@ -495,11 +493,13 @@ def test_plotters_plot_measurements_count_with_clutter(_measurements, _show_clut
 
     truths_expected = expected_plot_truths_length is not None
     clutter_expected = expected_plot_clutter_length is not None
-    expected_number_of_artists = 1  # there is always a legend artist at the end
+    expected_number_of_artists = 0
     if truths_expected:
         expected_number_of_artists += 1
     if clutter_expected:
         expected_number_of_artists += 1
+    if truths_expected or clutter_expected:
+        expected_number_of_artists += 1  # there is a legend artist at the end
     assert len(artist_list) == expected_number_of_artists
 
     if truths_expected:
@@ -635,8 +635,6 @@ def test_plotter_plot_measurements_label(_measurements, expected_labels):
                                                     'Measurements\n(Clutter)'}),
                           (all_measurements, False, {'Measurements'})
                           ])
-@pytest.mark.filterwarnings("ignore:.*No artists with labels found to put in legend.*:UserWarning")
-# Ignore this warning which occurs when there is no data to plot
 def test_plotter_plot_measurements_label_adjust_clutter(_measurements,
                                                         _show_clutter,
                                                         expected_labels):


### PR DESCRIPTION
Change in matplotlib now raises an error if plotting an empty set, as invalid legend is attempted to be created.