### PR TITLE
Fix support for NumPy 2.5

### DIFF
--- a/docs/examples/dataassociation/MFA_example.py
+++ b/docs/examples/dataassociation/MFA_example.py
@@ -32,7 +32,7 @@ slide_window = 3  # Slide window; used by MFA data associator
 # present within the slide window.
 
 def plot_covar(state, ax, color=None):
-    w, v = np.linalg.eig(
+    w, v = np.linalg.eigh(
         measurement_model.matrix() @ state.covar @ measurement_model.matrix().T)
     max_ind = np.argmax(w)
     min_ind = np.argmin(w)

--- a/docs/tutorials/03_UnscentedKalmanFilterTutorial.py
+++ b/docs/tutorials/03_UnscentedKalmanFilterTutorial.py
@@ -270,7 +270,7 @@ ekf_pred_meas = extended_updater.predict_measurement(prediction)
 # Plot UKF's predicted measurement distribution
 from matplotlib.patches import Ellipse
 from stonesoup.plotter import Plotter
-w, v = np.linalg.eig(ukf_pred_meas.covar)
+w, v = np.linalg.eigh(ukf_pred_meas.covar)
 max_ind = np.argmax(w)
 min_ind = np.argmin(w)
 orient = np.arctan2(v[1, max_ind], v[0, max_ind])
@@ -283,7 +283,7 @@ ax.add_artist(ukf_ellipse)
 
 
 # Plot EKF's predicted measurement distribution
-w, v = np.linalg.eig(ekf_pred_meas.covar)
+w, v = np.linalg.eigh(ekf_pred_meas.covar)
 max_ind = np.argmax(w)
 min_ind = np.argmin(w)
 orient = np.arctan2(v[1, max_ind], v[0, max_ind])

--- a/stonesoup/functions/__init__.py
+++ b/stonesoup/functions/__init__.py
@@ -1182,7 +1182,7 @@ def find_nearest_positive_definite(matrix, max_iterations=20):
     matrix = (matrix + matrix.T) / 2
 
     # set negative eigenvalues to zero for positive semi definitife matrix
-    eigval, eigvec = np.linalg.eig(matrix)
+    eigval, eigvec = np.linalg.eigh(matrix)
     eigval[eigval < 0] = 0
 
     # matrix reconstruction

--- a/stonesoup/plotter.py
+++ b/stonesoup/plotter.py
@@ -479,11 +479,7 @@ class Plotter(_Plotter):
                         check += 1
                         if check % err_freq:
                             continue
-                        w, v = np.linalg.eig(HH @ state.covar @ HH.T)
-                        if np.iscomplexobj(w) or np.iscomplexobj(v):
-                            warnings.warn("Can not plot uncertainty for all states due to complex "
-                                          "eigenvalues or eigenvectors", UserWarning)
-                            continue
+                        w, v = np.linalg.eigh(HH @ state.covar @ HH.T)
                         max_ind = np.argmax(w)
                         min_ind = np.argmin(w)
                         orient = np.arctan2(v[1, max_ind], v[0, max_ind])
@@ -511,7 +507,7 @@ class Plotter(_Plotter):
                     check = err_freq
                     for state in track:
                         if not check % err_freq:
-                            w, v = np.linalg.eig(HH @ state.covar @ HH.T)
+                            w, v = np.linalg.eigh(HH @ state.covar @ HH.T)
 
                             xl = state.state_vector[mapping[0]]
                             yl = state.state_vector[mapping[1]]
@@ -1602,7 +1598,7 @@ class Plotterly(_Plotter):
     def _generate_ellipse_points(state, mapping, n_points=30):
         """Generate error ellipse points for given state and mapping"""
         HH = np.eye(state.ndim)[mapping, :]  # Get position mapping matrix
-        w, v = np.linalg.eig(HH @ state.covar @ HH.T)
+        w, v = np.linalg.eigh(HH @ state.covar @ HH.T)
         max_ind = np.argmax(w)
         min_ind = np.argmin(w)
         orient = np.arctan2(v[1, max_ind], v[0, max_ind])

--- a/stonesoup/tests/test_plotter.py
+++ b/stonesoup/tests/test_plotter.py
@@ -237,19 +237,6 @@ def test_plot_density_equal_x_y():
         plotter.plot_density({truth}, index=None)
 
 
-def test_plot_complex_uncertainty():
-    plotter = Plotter()
-    track = Track([
-        GaussianState(
-            state_vector=[0, 0],
-            covar=[[10, -1], [1, 10]])
-    ])
-    with pytest.warns(UserWarning, match="Can not plot uncertainty for all states due to complex "
-                                         "eigenvalues or eigenvectors"):
-
-        plotter.plot_tracks(track, mapping=[0, 1], uncertainty=True)
-
-
 def test_animation_plotter():
     animation_plotter = AnimationPlotter()
     animation_plotter.plot_ground_truths(truth, [0, 2])


### PR DESCRIPTION
`linalg.eig{,vals}` now only returns complex numbers, even if result is real. Change to use `eig{,vals}h` which returns real numbers