### PR TITLE
DetectorContext: Add support for dynamic prob_detection and clutter_spatial_density

### DIFF
--- a/docs/source/stonesoup.types.rst
+++ b/docs/source/stonesoup.types.rst
@@ -34,6 +34,12 @@ Detection Types
 .. automodule:: stonesoup.types.detection
     :show-inheritance:
 
+Detector Context Types
+----------------------
+
+.. automodule:: stonesoup.types.detector_context
+    :show-inheritance:
+
 Graph Types
 -----------
 .. automodule:: stonesoup.types.graph
@@ -126,5 +132,4 @@ Update Types
 
 .. automodule:: stonesoup.types.update
     :show-inheritance:
-
 

--- a/docs/tutorials/filters/DetectorContextTutorial.py
+++ b/docs/tutorials/filters/DetectorContextTutorial.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python
+
+"""
+=========================
+DetectorContext tutorial
+=========================
+"""
+
+# %%
+# Some probabilistic trackers use detection probability and clutter density in their hypothesis
+# weights. DetectorContext allows these quantities to depend on the current hypothesis or
+# detection while preserving the existing scalar configuration path.
+
+import datetime
+
+import numpy as np
+
+from stonesoup.hypothesiser.distance import DistanceHypothesiser
+from stonesoup.hypothesiser.gaussianmixture import GaussianMixtureHypothesiser
+from stonesoup.measures import Mahalanobis
+from stonesoup.mixturereducer.gaussianmixture import GaussianMixtureReducer
+from stonesoup.models.measurement.linear import LinearGaussian
+from stonesoup.models.transition.linear import ConstantVelocity
+from stonesoup.predictor.kalman import KalmanPredictor
+from stonesoup.tracker.pointprocess import PointProcessMultiTargetTracker
+from stonesoup.types.detection import Detection, DetectionSet
+from stonesoup.types.detector_context import SimpleDetectorContext
+from stonesoup.types.state import TaggedWeightedGaussianState
+from stonesoup.updater.kalman import KalmanUpdater
+from stonesoup.updater.pointprocess import PHDUpdater
+
+
+start_time = datetime.datetime(2026, 1, 1, 12)
+measurement_model = LinearGaussian(
+    ndim_state=2,
+    mapping=[0],
+    noise_covar=np.array([[0.2]]))
+
+
+def reader_with_context():
+    # Detection readers still yield ``(time, detections)``. When context is
+    # available, ``detections`` can be a DetectionSet.
+    for step in range(6):
+        time = start_time + datetime.timedelta(seconds=step)
+        detection = Detection(
+            state_vector=np.array([[float(step)]]),
+            timestamp=time,
+            measurement_model=measurement_model)
+
+        detector_context = SimpleDetectorContext(
+            prob_detection=lambda hypothesis:
+                0.9 if hypothesis.prediction.state_vector[0, 0] < 3 else 0.4,
+            clutter_spatial_density=lambda detection_:
+                1e-3 if detection_.state_vector[0, 0] < 3 else 1e-2)
+
+        yield time, DetectionSet({detection}, detector_context=detector_context)
+
+
+predictor = KalmanPredictor(transition_model=ConstantVelocity(noise_diff_coeff=0.05))
+updater = KalmanUpdater(measurement_model=measurement_model)
+hypothesiser = GaussianMixtureHypothesiser(
+    hypothesiser=DistanceHypothesiser(
+        predictor=predictor,
+        updater=updater,
+        measure=Mahalanobis(),
+        missed_distance=16),
+    order_by_detection=True)
+phd_updater = PHDUpdater(
+    updater=updater,
+    prob_detection=0.9,
+    clutter_spatial_density=1e-3)
+reducer = GaussianMixtureReducer(prune_threshold=1e-5, merge_threshold=4)
+birth_component = TaggedWeightedGaussianState(
+    state_vector=np.array([[0.0], [1.0]]),
+    covar=np.diag([1.0, 1.0]),
+    weight=0.25,
+    tag=TaggedWeightedGaussianState.BIRTH,
+    timestamp=start_time)
+
+# %%
+# The tracker extracts the context from each detection set and passes it to the
+# underlying components. Existing scalar
+# ``prob_detection`` and ``clutter_spatial_density`` values still provide the
+# fallback behaviour when no detector context is supplied.
+
+tracker = PointProcessMultiTargetTracker(
+    detector=reader_with_context(),
+    updater=phd_updater,
+    hypothesiser=hypothesiser,
+    reducer=reducer,
+    birth_component=birth_component)
+
+for time, tracks in tracker:
+    print(time, len(tracks), tracker.estimated_number_of_targets)

--- a/stonesoup/reader/base.py
+++ b/stonesoup/reader/base.py
@@ -32,7 +32,10 @@ class DetectionReader(Reader):
         : :class:`datetime.datetime`
             Datetime of current time step
         : set of :class:`~.Detection`
-            Detections generate in the time step
+            Detections generated in the time step. Readers should continue
+            to yield ``(timestamp, detections)``, where ``detections`` may
+            be a plain ``set`` or a :class:`~.DetectionSet` when detector
+            context is available.
         """
         raise NotImplementedError
 

--- a/stonesoup/tracker/pointprocess.py
+++ b/stonesoup/tracker/pointprocess.py
@@ -77,6 +77,7 @@ class PointProcessMultiTargetTracker(_TrackerMixInNext, Tracker):
 
     def __next__(self) -> tuple[datetime.datetime, set[Track]]:
         time, detections = next(self.detector_iter)
+        detector_context = getattr(detections, 'detector_context', None)
         # Add birth component
         self.birth_component.timestamp = time
         self.gaussian_mixture.append(self.birth_component)
@@ -84,10 +85,12 @@ class PointProcessMultiTargetTracker(_TrackerMixInNext, Tracker):
         hypotheses = self.hypothesiser.hypothesise(
                     self.gaussian_mixture.components,
                     detections,
-                    time
+                    time,
+                    detector_context=detector_context
                     )
         # Perform GM Update
-        self.gaussian_mixture = self.updater.update(hypotheses)
+        self.gaussian_mixture = self.updater.update(
+            hypotheses, detector_context=detector_context)
         # Reduce mixture - Pruning and Merging
         self.gaussian_mixture.components = \
             self.reducer.reduce(self.gaussian_mixture.components)

--- a/stonesoup/tracker/tests/test_pointprocess.py
+++ b/stonesoup/tracker/tests/test_pointprocess.py
@@ -10,6 +10,8 @@ from ...hypothesiser.gaussianmixture import GaussianMixtureHypothesiser
 from ...hypothesiser.distance import DistanceHypothesiser
 from ... import measures
 from ...models.measurement.linear import LinearGaussian
+from ...types.detection import DetectionSet
+from ...types.detector_context import SimpleDetectorContext
 from ...updater.kalman import KalmanUpdater
 
 
@@ -62,3 +64,61 @@ def test_point_process_multi_target_tracker_cycle(detector, predictor):
         assert (len(tracks) >= 1) & (len(tracks) <= 3)
         # All tracks should have unique IDs
         assert len(tracker.gaussian_mixture.component_tags) == len(tracker.gaussian_mixture)
+
+
+def test_point_process_multi_target_tracker_detector_context(detector, predictor):
+    detector_context = SimpleDetectorContext(prob_detection=0.8)
+    detector = (
+        (time, DetectionSet(detections, detector_context=detector_context))
+        for time, detections in detector)
+    timestamp = datetime.datetime.now()
+    birth_component = TaggedWeightedGaussianState(
+        np.array([[40]]),
+        np.array([[1000]]),
+        weight=0.3,
+        tag=TaggedWeightedGaussianState.BIRTH,
+        timestamp=timestamp)
+
+    measurement_model = LinearGaussian(ndim_state=1, mapping=[0],
+                                       noise_covar=np.array([[0.04]]))
+    updater = KalmanUpdater(measurement_model=measurement_model)
+    base_hypothesiser = DistanceHypothesiser(
+        predictor, updater, measure=measures.Mahalanobis(), missed_distance=16)
+    hypothesiser = GaussianMixtureHypothesiser(hypothesiser=base_hypothesiser,
+                                               order_by_detection=True)
+
+    class ContextHypothesiser:
+        def __init__(self, hypothesiser):
+            self.hypothesiser = hypothesiser
+            self.detector_contexts = []
+
+        def hypothesise(self, components, detections, timestamp, detector_context=None):
+            self.detector_contexts.append(detector_context)
+            return self.hypothesiser.hypothesise(components, detections, timestamp)
+
+    class ContextUpdater(PHDUpdater):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            self.detector_contexts = []
+
+        def update(self, hypotheses, detector_context=None, **kwargs):
+            self.detector_contexts.append(detector_context)
+            return super().update(hypotheses, detector_context=detector_context, **kwargs)
+
+    hypothesiser = ContextHypothesiser(hypothesiser)
+    reducer = GaussianMixtureReducer(prune_threshold=1e-5, merge_threshold=4)
+    phd_updater = ContextUpdater(updater=updater, prob_detection=0.1)
+
+    tracker = PointProcessMultiTargetTracker(
+        detector=detector,
+        updater=phd_updater,
+        hypothesiser=hypothesiser,
+        reducer=reducer,
+        birth_component=birth_component
+        )
+
+    time, tracks = next(iter(tracker))
+    assert time == datetime.datetime(2018, 1, 1, 14)
+    assert tracks
+    assert hypothesiser.detector_contexts == [detector_context]
+    assert phd_updater.detector_contexts == [detector_context]

--- a/stonesoup/types/detection.py
+++ b/stonesoup/types/detection.py
@@ -17,6 +17,18 @@ class Detection(State):
         default_factory=dict, doc='Dictionary of metadata items for Detections.')
 
 
+class DetectionSet(set):
+    """Set of detections with optional detector context.
+
+    Detection readers may return this in place of a plain ``set`` when
+    detector context is available for the time step.
+    """
+
+    def __init__(self, detections=(), detector_context=None):
+        super().__init__(detections)
+        self.detector_context = detector_context
+
+
 class GaussianDetection(Detection, GaussianState):
     """GaussianDetection type"""
 

--- a/stonesoup/types/detector_context.py
+++ b/stonesoup/types/detector_context.py
@@ -1,0 +1,42 @@
+from abc import ABC, abstractmethod
+from collections.abc import Callable
+
+from .detection import Detection
+from .hypothesis import SingleHypothesis
+from .numeric import Probability
+
+
+class DetectorContext(ABC):
+    """Detection probability and clutter intensity for a detector step."""
+
+    @abstractmethod
+    def prob_detection(self, hypothesis: SingleHypothesis) -> Probability:
+        """Return the detection probability for a hypothesis."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def clutter_spatial_density(self, detection: Detection) -> float:
+        """Return the clutter spatial density for a detection."""
+        raise NotImplementedError
+
+
+class SimpleDetectorContext(DetectorContext):
+    """Detector context backed by scalar values or callables."""
+
+    def __init__(
+            self,
+            prob_detection: Probability | float | Callable[[SingleHypothesis], Probability]
+            = Probability(1),
+            clutter_spatial_density: float | Callable[[Detection], float] = 1e-26):
+        self._prob_detection = prob_detection
+        self._clutter_spatial_density = clutter_spatial_density
+
+    def prob_detection(self, hypothesis):
+        if callable(self._prob_detection):
+            return self._prob_detection(hypothesis)
+        return Probability(self._prob_detection)
+
+    def clutter_spatial_density(self, detection):
+        if callable(self._clutter_spatial_density):
+            return self._clutter_spatial_density(detection)
+        return self._clutter_spatial_density

--- a/stonesoup/updater/pointprocess.py
+++ b/stonesoup/updater/pointprocess.py
@@ -8,6 +8,7 @@ from .kalman import KalmanUpdater
 from ..types.update import GaussianMixtureUpdate
 from ..types.state import TaggedWeightedGaussianState
 from ..types.numeric import Probability
+from ..types.detector_context import SimpleDetectorContext
 
 
 class PointProcessUpdater(Base):
@@ -35,7 +36,7 @@ class PointProcessUpdater(Base):
         default=1,
         doc="Probability of a target surviving until the next timestep")
 
-    def update(self, hypotheses):
+    def update(self, hypotheses, detector_context=None, **kwargs):
         """
         Updates the current components in a
         :class:`GaussianMixture` by applying the underlying \
@@ -55,6 +56,7 @@ class PointProcessUpdater(Base):
         """
         updated_components = list()
         weight_sum_list = list()
+        detector_context = self._detector_context(detector_context)
         # Loop over all measurements
         for multi_hypothesis in hypotheses[:-1]:
             updated_measurement_components = list()
@@ -74,7 +76,7 @@ class PointProcessUpdater(Base):
                     mean=measurement_prediction.mean.flatten(),
                     cov=measurement_prediction.covar
                 )
-                new_weight = self.prob_detection\
+                new_weight = detector_context.prob_detection(hypothesis)\
                     * prediction.weight * q
                 if prediction.tag != 'birth':
                     new_weight *= self.prob_survival
@@ -89,16 +91,16 @@ class PointProcessUpdater(Base):
                     timestamp=temp_updated_component.timestamp
                 )
                 # Add updated component to mixture
-                updated_measurement_components.append(updated_component)
+                updated_measurement_components.append((updated_component, hypothesis.measurement))
             weight_sum_list.append(weight_sum)
-            for component in updated_measurement_components:
+            for component, detection in updated_measurement_components:
                 if self.normalisation:
                     component.weight /= \
-                        (weight_sum + self.clutter_spatial_density)
+                        (weight_sum + detector_context.clutter_spatial_density(detection))
                 updated_components.append(component)
 
         # Calculate the correction terms
-        l1 = self._calculate_update_terms(weight_sum_list, hypotheses)
+        l1 = self._calculate_update_terms(weight_sum_list, hypotheses, detector_context)
 
         for missed_detected_hypotheses in hypotheses[-1]:
             # Add all active components except birth component back into
@@ -107,7 +109,8 @@ class PointProcessUpdater(Base):
                 component = TaggedWeightedGaussianState(
                     tag=missed_detected_hypotheses.prediction.tag,
                     weight=missed_detected_hypotheses.prediction.weight
-                    * (1-self.prob_detection) * l1 * self.prob_survival,
+                    * (1-detector_context.prob_detection(missed_detected_hypotheses))
+                    * l1 * self.prob_survival,
                     state_vector=missed_detected_hypotheses.prediction.mean,
                     covar=missed_detected_hypotheses.prediction.covar,
                     timestamp=missed_detected_hypotheses.prediction.timestamp)
@@ -123,8 +126,15 @@ class PointProcessUpdater(Base):
         return GaussianMixtureUpdate(hypothesis=hypotheses,
                                      components=updated_components)
 
+    def _detector_context(self, detector_context):
+        if detector_context is not None:
+            return detector_context
+        return SimpleDetectorContext(
+            prob_detection=self.prob_detection,
+            clutter_spatial_density=self.clutter_spatial_density)
+
     @abstractmethod
-    def _calculate_update_terms(self, updated_sum_list, hypotheses):
+    def _calculate_update_terms(self, updated_sum_list, hypotheses, detector_context):
         raise NotImplementedError
 
 
@@ -145,7 +155,7 @@ class PHDUpdater(PointProcessUpdater):
     https://ieeexplore.ieee.org/document/4086095.
     """
     @staticmethod
-    def _calculate_update_terms(updated_sum_list, hypotheses):
+    def _calculate_update_terms(updated_sum_list, hypotheses, detector_context):
         return 1
 
 
@@ -174,7 +184,7 @@ class LCCUpdater(PointProcessUpdater):
         super().__init__(*args, **kwargs)
         self.second_order_cumulant = 0
 
-    def _calculate_update_terms(self, updated_sum_list, hypotheses):
+    def _calculate_update_terms(self, updated_sum_list, hypotheses, detector_context):
         """
         Calculate the higher order terms used in the LCC Filter
         """
@@ -185,9 +195,13 @@ class LCCUpdater(PointProcessUpdater):
         # Second order predicted cumulant c(2)
         predicted_c2 = self.second_order_cumulant * self.prob_survival**2
         # Detected predicted weight mu_d
-        detected_weight_sum = self.prob_detection*predicted_weight_sum
+        detected_weight_sum = Probability.sum(
+            detector_context.prob_detection(hypothesis) * hypothesis.prediction.weight
+            for hypothesis in hypotheses[-1]) * self.prob_survival
         # Detected predicted weight mu_phi
-        misdetected_weight_sum = (1-self.prob_detection)*predicted_weight_sum
+        misdetected_weight_sum = Probability.sum(
+            (1-detector_context.prob_detection(hypothesis)) * hypothesis.prediction.weight
+            for hypothesis in hypotheses[-1]) * self.prob_survival
         # Calculate the alpha of the predicted Panjer process
         alpha_pred = ((predicted_weight_sum +
                        self.mean_number_of_false_alarms)**2)\
@@ -201,10 +215,10 @@ class LCCUpdater(PointProcessUpdater):
         l2 = numerator/(denominator**2)
         # Calculate updated c(2)
         detected_c2 = \
-            Probability.sum([weight_sum/((weight_sum +
-                             self.clutter_spatial_density)
-                             ** 2)
-                            for weight_sum in updated_sum_list])
+            Probability.sum(
+                weight_sum/((weight_sum + detector_context.clutter_spatial_density(
+                    multi_hypothesis[0].measurement)) ** 2)
+                for weight_sum, multi_hypothesis in zip(updated_sum_list, hypotheses[:-1]))
         misdetected_c2 = (misdetected_weight_sum**2)*l2
         self.second_order_cumulant = misdetected_c2 - detected_c2
         # Return the l1 correction factor for miss detected weight update

--- a/stonesoup/updater/tests/test_pointprocess.py
+++ b/stonesoup/updater/tests/test_pointprocess.py
@@ -8,6 +8,7 @@ from stonesoup.types.hypothesis import SingleHypothesis
 from stonesoup.types.multihypothesis import MultipleHypothesis
 from stonesoup.types.prediction import GaussianMeasurementPrediction
 from stonesoup.types.state import GaussianState
+from stonesoup.types.detector_context import SimpleDetectorContext
 from stonesoup.updater.kalman import (
     KalmanUpdater, ExtendedKalmanUpdater, UnscentedKalmanUpdater)
 from stonesoup.updater.pointprocess import PHDUpdater, LCCUpdater
@@ -97,6 +98,33 @@ def test_phd_single_component_update(UpdaterClass, measurement_model,
     assert miss_detected_component.timestamp == prediction.timestamp
     l1 = 1
     assert miss_detected_component.weight == prediction.weight * (1-prob_detection)*l1
+
+
+def test_phd_detector_context(measurement_model, prediction, measurement):
+    underlying_updater = KalmanUpdater(measurement_model=measurement_model)
+    measurement_prediction = underlying_updater.predict_measurement(prediction)
+    phd_updater = PHDUpdater(updater=underlying_updater)
+    detector_context = SimpleDetectorContext(
+        prob_detection=lambda hypothesis: 0.5,
+        clutter_spatial_density=lambda detection: 1e-3)
+
+    hypotheses = [MultipleHypothesis([SingleHypothesis(
+                                    prediction=prediction,
+                                    measurement=measurement)]),
+                  MultipleHypothesis([SingleHypothesis(
+                                    prediction=prediction,
+                                    measurement=None)])]
+
+    updated_mixture = phd_updater.update(hypotheses, detector_context=detector_context)
+
+    q = multivariate_normal.pdf(
+                    measurement.state_vector.flatten(),
+                    mean=measurement_prediction.mean.flatten(),
+                    cov=measurement_prediction.covar
+                )
+    new_weight = (0.5*prediction.weight*q) / ((0.5*prediction.weight*q)+1e-3)
+    assert updated_mixture[0].weight == new_weight
+    assert updated_mixture[1].weight == prediction.weight * 0.5
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This pull request implements the suggested `DetectorContext` abstraction proposed in [Context-Aware Sensor Modeling for Asynchronous Multi-Sensor Tracking in Stone Soup](https://arxiv.org/abs/2603.15137) (accepted to FUSION 2026).

The tl;dr is that we want to support cases where probability of detection is a function of the track/predicted state, and clutter intensity is a function of the detection/measurement state. This comes up in partially covered, asynchronous, or otherwise non-uniform sensing scenarios where single global `prob_detection` and `clutter_spatial_density` values are too restrictive.

The existing Stone Soup data-source flow is kept as:

```python
time, detections
```

The change is that `detections` may now be a `DetectionSet`, which is a small extension of the usual `set` of detections with an optional `detector_context` attribute. Plain `set` inputs are still supported.

The attached `DetectorContext` provides two query points:

- `prob_detection(hypothesis)`, for evaluating detection probability from the predicted track state and current detector context.
- `clutter_spatial_density(detection)`, for evaluating clutter intensity at a particular detection/measurement.

Trackers that can exploit this read `getattr(detections, "detector_context", None)` and pass it through to the relevant tracking components using the `detector_context` keyword. Components that use detection probability or clutter intensity can then query the context instead of treating those values as fixed scalars.

This initial PR wires the interface into the GM point-process path, including the existing `PointProcessMultiTargetTracker` and point-process updater classes. Existing scalar `prob_detection` and `clutter_spatial_density` configuration is preserved by falling back to a constant `SimpleDetectorContext` when no explicit context is supplied.

Readers, trackers, and the relevant tracking components need to be updated to make use of `DetectorContext`. The compatibility goal is that mixed old/new pipelines still run: plain `set` detections continue to work, `DetectionSet` remains set-like for existing trackers, and components that are not given an explicit context continue to use their existing scalar configuration. Such mixed pipelines may not exploit detector context end-to-end, but they should preserve existing behaviour.

The PR also includes a small filter tutorial showing the scalar path, a `DetectionSet` carrying detector context, and the same update using context-dependent detection probability and clutter intensity.

Some obvious follow-up work is deliberately left out to keep the first PR small: preserving detector context through feeders that rebuild detection sets, adding PDA/JPDA support, and extending the same pattern to SMC-PHD/particle tracker paths.