### PR TITLE
Update Read the Docs config for new Ubuntu LTS build version

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -6,21 +6,9 @@ sphinx:
 build:
   os: ubuntu-lts-latest
   tools:
-    python: "3.12"
+    python: "3.14"
   apt_packages:
-    - libnss3
-    - libatk-bridge2.0-0
-    - libcups2
-    - libxcomposite1
-    - libxdamage1
-    - libxfixes3
-    - libxrandr2
-    - libgbm1
-    - libxkbcommon0
-    - libpango-1.0-0
-    - libcairo2
-    - libasound2
-    - graphviz
+    - libgvplugin-neato-layout8
   jobs:
     post_install:
       - kaleido_get_chrome


### PR DESCRIPTION
New release of read the docs yesterday moved from Ubuntu 22.04 to 26.04.