### PR TITLE
Iterated Kalman predictor

### DIFF
--- a/stonesoup/predictor/kalman.py
+++ b/stonesoup/predictor/kalman.py
@@ -1,3 +1,4 @@
+from copy import copy
 from functools import partial
 
 import numpy as np
@@ -683,3 +684,68 @@ class StochasticIntegrationPredictor(KalmanPredictor):
             transition_model=self.transition_model,
             prior=prior,
         )
+
+
+class IteratedKalmanPredictor(ExtendedKalmanPredictor):
+    r"""The simplest version of an iterated predictor. This recalculates the transition matrix at a
+    fixed (user-specified) number of equally-spaced intermediate points in between the prior and
+    the prediction. The hope/expectation is that that will produce a more accurate linearization of
+    the gradient of the function at that point, though that is not guaranteed and no checks on the
+    suitability of the solution are made. There are no convergence criteria, and no checks for
+    incremental improvement through the iteration are undertaken.
+
+    The transition matrix is calculated as the product of the intermediate steps,
+
+    .. math::
+
+        J(f)|_{k|k-1} = \prod_{i=0}^{n-1} J(f)|_{k-1 + i/n}
+
+    The default number of steps is 1, which reduces this to the standard extended Kalman predictor.
+    The option to include the end point in the iteration is provided. This allows the user to
+    specify whether the transition matrix is additionally calculated at the predicted state; the
+    default is to conclude the iteration at the last intermediate point.
+    """
+    nsteps: int = Property(default=1, doc="number of iterations")
+
+    include_end_point: bool = Property(default=False, 
+                                       doc="Whether to include the end point in the iteration. "
+                                       "Default is False.")
+
+    def _transition_matrix(self, prior, linearisation_point=None, time_interval=None, **kwargs):
+        r"""Returns the transition matrix as a product of Jacobians calculated at each
+        intermediate point.
+
+        Parameters
+        ----------
+        prior : :class:`~.State`
+            :math:`\mathbf{x}_{k-1}`
+        linearisation_point : :class:`~State`, optional
+            Initial state, first linearisation point. If default (`None`) prior will be used.
+        **kwargs : various, optional
+            These are passed to :meth:`~.TransitionModel.matrix` or
+            :meth:`~.TransitionModel.jacobian`
+
+        Returns
+        -------
+        : :class:`numpy.ndarray`
+            The output transition matrix is the product of the matrices calculated at each
+            intermediate point
+        """
+
+        if linearisation_point is None:
+            linearisation_point = prior
+        y = copy(linearisation_point)  # TODO: find a better copy-safe method of doing this
+
+        transition_matrix = np.eye(self.transition_model.ndim_state)
+
+        for i in range(self.nsteps):
+            J1 = self.transition_model.jacobian(y, time_interval=time_interval/float(self.nsteps))
+            y.state_vector = \
+                self.transition_model.function(y, time_interval=time_interval/float(self.nsteps))
+            transition_matrix = J1 @ transition_matrix
+
+        if self.include_end_point:
+            J1 = self.transition_model.jacobian(y, time_interval=time_interval/float(self.nsteps))
+            transition_matrix = J1 @ transition_matrix
+
+        return transition_matrix

--- a/stonesoup/predictor/kalman.py
+++ b/stonesoup/predictor/kalman.py
@@ -707,9 +707,9 @@ class IteratedKalmanPredictor(ExtendedKalmanPredictor):
     """
     nsteps: int = Property(default=1, doc="number of iterations")
 
-    include_end_point: bool = Property(default=False, 
-                                       doc="Whether to include the end point in the iteration. "
-                                       "Default is False.")
+    include_end_point: bool = Property(default=False,
+                                       doc="whether to include the end point in the iteration, "
+                                       "false by default")
 
     def _transition_matrix(self, prior, linearisation_point=None, time_interval=None, **kwargs):
         r"""Returns the transition matrix as a product of Jacobians calculated at each

--- a/stonesoup/predictor/kalman.py
+++ b/stonesoup/predictor/kalman.py
@@ -734,7 +734,7 @@ class IteratedKalmanPredictor(ExtendedKalmanPredictor):
 
         if linearisation_point is None:
             linearisation_point = prior
-        y = copy(linearisation_point)  # TODO: find a better copy-safe method of doing this
+        y = copy(linearisation_point)
 
         transition_matrix = np.eye(self.transition_model.ndim_state)
 

--- a/stonesoup/predictor/tests/test_kalman.py
+++ b/stonesoup/predictor/tests/test_kalman.py
@@ -162,8 +162,8 @@ def test_sqrt_kalman():
 
 
 def test_iterated():
-    # Test that the iterated kalman predictor returns same result as the EKF for number of 
-    # iterations = 1. And then doesn't for a larger number of iterations. 
+    # Test that the iterated kalman predictor returns same result as the EKF for number of
+    # iterations = 1. And then doesn't for a larger number of iterations.
 
     # Define time related variables
     timestamp = datetime.datetime.now()
@@ -202,7 +202,7 @@ def test_iterated():
 
     assert np.allclose(prediction.mean,
                        eval_prediction.mean, 0, atol=1.e-14)
-    # TODO: When the non-linear model is implemented change the following assertion to be False. 
+    # TODO: When the non-linear model is implemented change the following assertion to be False.
     # TODO: For now, it is True as the EKF and Iterated KF will return the same for a linear model.
     assert np.allclose(prediction.covar,
                        eval_prediction.covar, 0, atol=1.e-14)

--- a/stonesoup/predictor/tests/test_kalman.py
+++ b/stonesoup/predictor/tests/test_kalman.py
@@ -5,7 +5,9 @@ import numpy as np
 from ...models.transition.linear import ConstantVelocity
 from ...predictor.kalman import (
     KalmanPredictor, ExtendedKalmanPredictor, UnscentedKalmanPredictor,
-    SqrtKalmanPredictor, CubatureKalmanPredictor, StochasticIntegrationPredictor)
+    SqrtKalmanPredictor, CubatureKalmanPredictor, StochasticIntegrationPredictor,
+    IteratedKalmanPredictor
+    )
 from ...types.prediction import GaussianStatePrediction
 from ...types.state import GaussianState, SqrtGaussianState
 from ...types.track import Track
@@ -48,9 +50,16 @@ from ...types.track import Track
             np.array([[-6.45], [0.7]]),
             np.array([[4.1123, 0.0013],
                       [0.0013, 0.0365]])
+        ),
+        (   # Iterated
+            IteratedKalmanPredictor,
+            ConstantVelocity(noise_diff_coeff=0.1),
+            np.array([[-6.45], [0.7]]),
+            np.array([[4.1123, 0.0013],
+                      [0.0013, 0.0365]])
         )
     ],
-    ids=["standard", "extended", "unscented", "cubature", "stochasticIntegration"]
+    ids=["standard", "extended", "unscented", "cubature", "stochasticIntegration", "iterated"]
 )
 def test_kalman(PredictorClass, transition_model,
                 prior_mean, prior_covar):

--- a/stonesoup/predictor/tests/test_kalman.py
+++ b/stonesoup/predictor/tests/test_kalman.py
@@ -159,3 +159,51 @@ def test_sqrt_kalman():
                        atol=1.e-14)
     assert np.allclose(prediction.covar, sqrt_prediction.covar, 0, atol=1.e-14)
     assert prediction.timestamp == sqrt_prediction.timestamp
+
+
+def test_iterated():
+    # Test that the iterated kalman predictor returns same result as the EKF for number of 
+    # iterations = 1. And then doesn't for a larger number of iterations. 
+
+    # Define time related variables
+    timestamp = datetime.datetime.now()
+    timediff = 2  # 2sec
+    new_timestamp = timestamp + datetime.timedelta(seconds=timediff)
+    time_interval = new_timestamp - timestamp
+
+    # Define prior state
+    prior_mean = np.array([[-6.45], [0.7]])
+    prior_covar = np.array([[4.1123, 0.0013],
+                            [0.0013, 0.0365]])
+    prior = GaussianState(prior_mean,
+                          prior_covar,
+                          timestamp=timestamp)
+
+    # TODO: wait for suitable 1d non-linear model to be implemented. For now, just use a linear
+    # model.
+    transition_model = ConstantVelocity(noise_diff_coeff=0.1)
+
+    transition_model_matrix = transition_model.matrix(time_interval=time_interval)
+    transition_model_covar = transition_model.covar(time_interval=time_interval)
+
+    # Calculate evaluation variables
+    eval_prediction = GaussianStatePrediction(
+        transition_model_matrix @ prior.mean,
+        transition_model_matrix@prior.covar@transition_model_matrix.T + transition_model_covar)
+
+    # Initialise an iterated predictor
+    predictor = IteratedKalmanPredictor(transition_model=transition_model, nsteps=25)
+
+    # Perform and assert state prediction
+    prediction = predictor.predict(prior=prior, timestamp=new_timestamp)
+
+    # Assert presence of transition model
+    assert hasattr(prediction, 'transition_model')
+
+    assert np.allclose(prediction.mean,
+                       eval_prediction.mean, 0, atol=1.e-14)
+    # TODO: When the non-linear model is implemented change the following assertion to be False. 
+    # TODO: For now, it is True as the EKF and Iterated KF will return the same for a linear model.
+    assert np.allclose(prediction.covar,
+                       eval_prediction.covar, 0, atol=1.e-14)
+    assert prediction.timestamp == new_timestamp


### PR DESCRIPTION
Most straightforward version of an iterated predictor. Inherits from `ExtendedKalmanPredictor` and defaults to that (number of  iterations is 1 by default). Uses standard tests but may need an additional test to demonstrate its difference from `ExtendedKalmanPredictor`. TODO: should work out how not to use `copy.copy`.