### PR TITLE
Create generic sensor models

### DIFF
--- a/stonesoup/sensor/action/base.py
+++ b/stonesoup/sensor/action/base.py
@@ -73,6 +73,9 @@ class AngleActionsGenerator(RealNumberActionGenerator):
     rpm: float = Property(default=60,
                           doc="The number of rotations per minute (RPM).")
 
+    max_angle: float = Property(default=np.inf)
+    min_angle: float = Property(default=-np.inf)
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.epsilon = Angle(np.radians(1e-6))
@@ -114,11 +117,11 @@ class AngleActionsGenerator(RealNumberActionGenerator):
 
     @property
     def min(self):
-        return Angle(self.initial_value - self.angle_delta)
+        return max(Angle(self.initial_value - self.angle_delta), self.min_angle)
 
     @property
     def max(self):
-        return Angle(self.initial_value + self.angle_delta)
+        return min(Angle(self.initial_value + self.angle_delta), self.max_angle)
 
     def __contains__(self, item):
 

--- a/stonesoup/sensor/action/dwell_action.py
+++ b/stonesoup/sensor/action/dwell_action.py
@@ -80,3 +80,17 @@ class DwellActionsGenerator(AngleActionsGenerator):
                                  end_time=self.end_time,
                                  target_value=angle_action.target_value,
                                  increasing_angle=angle_action.increasing_angle)
+
+
+class StationaryDwellActionsGenerator(DwellActionsGenerator):
+    """
+    :class:`~.DwellActionsGenerator` with a default action of staying still instead of rotating
+    """
+
+    @property
+    def default_action(self):
+        return ChangeDwellAction(rotation_end_time=self.end_time,
+                                 generator=self,
+                                 end_time=self.end_time,
+                                 target_value=self.initial_value,
+                                 increasing_angle=None)

--- a/stonesoup/sensor/action/tests/test_tilt_action.py
+++ b/stonesoup/sensor/action/tests/test_tilt_action.py
@@ -15,8 +15,8 @@ class DummyTiltActionable(Actionable):
                                                   generator_kwargs_mapping={'rpm': 'rpm'})
     timestamp: datetime = Property(doc="Current time that actionable exists at.")
     rpm: float = Property(doc="Rotations per minute.")
-    min_tilt = np.radians(-90)
-    max_tilt = np.radians(90)
+    min_angle = np.radians(-90)
+    max_angle = np.radians(90)
 
     def validate_timestamp(self):
         if self.timestamp:
@@ -62,8 +62,8 @@ def test_tilt_action(initial_tilt_deg):
     assert generator.min == max(actionable.tilt_centre[0, 0] - np.radians(60), -np.radians(90))
 
     for angle in np.linspace(0, np.radians(60), 10):
-        tilt1 = min(actionable.tilt_centre[0, 0] + angle, actionable.max_tilt)
-        tilt2 = max(actionable.tilt_centre[0, 0] - angle, actionable.min_tilt)
+        tilt1 = min(actionable.tilt_centre[0, 0] + angle, actionable.max_angle)
+        tilt2 = max(actionable.tilt_centre[0, 0] - angle, actionable.min_angle)
 
         assert tilt1 in generator
         assert float(tilt1) in generator
@@ -94,26 +94,26 @@ def test_tilt_action(initial_tilt_deg):
             assert increasing1 is None
             assert increasing2 is None
             assert tilt_end1 == tilt_end2 == start
-        elif actionable.tilt_centre[0, 0] == actionable.min_tilt:
+        elif actionable.tilt_centre[0, 0] == actionable.min_angle:
             assert increasing1
             assert increasing2 is None
-        elif actionable.tilt_centre[0, 0] == actionable.max_tilt:
+        elif actionable.tilt_centre[0, 0] == actionable.max_angle:
             assert increasing1 is None
             assert not increasing2
         else:
             assert increasing1
             assert not increasing2
 
-        if tilt1 == actionable.max_tilt:
-            new_tilt_time = ((actionable.max_tilt - actionable.tilt_centre[0, 0]) /
+        if tilt1 == actionable.max_angle:
+            new_tilt_time = ((actionable.max_angle - actionable.tilt_centre[0, 0]) /
                              np.radians(60) * (end-start))
             new_tilt_end = start + new_tilt_time
             assert tilt_end1 == new_tilt_end
         else:
             assert tilt_end1 == tilt_end
 
-        if tilt2 == actionable.min_tilt:
-            new_tilt_time = ((actionable.tilt_centre[0, 0] - actionable.min_tilt) /
+        if tilt2 == actionable.min_angle:
+            new_tilt_time = ((actionable.tilt_centre[0, 0] - actionable.min_angle) /
                              np.radians(60) * (end-start))
             new_tilt_end = start + new_tilt_time
             assert tilt_end2 == new_tilt_end
@@ -121,20 +121,20 @@ def test_tilt_action(initial_tilt_deg):
             assert tilt_end2 == tilt_end
 
     actions = [action for action in generator]
-    if (actionable.min_tilt + np.radians(60) <= actionable.tilt_centre[0, 0] <=
-            actionable.max_tilt - np.radians(60)):
+    if (actionable.min_angle + np.radians(60) <= actionable.tilt_centre[0, 0] <=
+            actionable.max_angle - np.radians(60)):
         assert len(actions) == 5
         target_tilts = np.array([-60, -30, 0, 30, 60])
-    elif (actionable.min_tilt + np.radians(30) <= actionable.tilt_centre[0, 0] <=
-            actionable.max_tilt - np.radians(30)):
+    elif (actionable.min_angle + np.radians(30) <= actionable.tilt_centre[0, 0] <=
+            actionable.max_angle - np.radians(30)):
         assert len(actions) == 4
-        if actionable.tilt_centre[0, 0] < (actionable.max_tilt + actionable.min_tilt) / 2:
+        if actionable.tilt_centre[0, 0] < (actionable.max_angle + actionable.min_angle) / 2:
             target_tilts = np.array([-30, 0, 30, 60])
         else:
             target_tilts = np.array([-60, -30, 0, 30])
     else:
         assert len(actions) == 3
-        if actionable.tilt_centre[0, 0] < (actionable.max_tilt + actionable.min_tilt) / 2:
+        if actionable.tilt_centre[0, 0] < (actionable.max_angle + actionable.min_angle) / 2:
             target_tilts = np.array([0, 30, 60])
         else:
             target_tilts = np.array([-60, -30, 0])
@@ -147,22 +147,22 @@ def test_tilt_action(initial_tilt_deg):
 
     generator(np.radians(1))
     for angle in np.arange(0, 181, 1):
-        tilt1 = min(actionable.tilt_centre[0, 0] + np.radians(angle), actionable.max_tilt)
-        tilt2 = max(actionable.tilt_centre[0, 0] - np.radians(angle), actionable.min_tilt)
+        tilt1 = min(actionable.tilt_centre[0, 0] + np.radians(angle), actionable.max_angle)
+        tilt2 = max(actionable.tilt_centre[0, 0] - np.radians(angle), actionable.min_angle)
         action1 = generator.action_from_value(tilt1)
         action2 = generator.action_from_value(tilt2)
-        if (angle > 60 and (actionable.min_tilt + np.radians(60) + generator.epsilon <
+        if (angle > 60 and (actionable.min_angle + np.radians(60) + generator.epsilon <
                             actionable.tilt_centre[0, 0] <
-                            actionable.max_tilt - np.radians(60) - generator.epsilon)):
+                            actionable.max_angle - np.radians(60) - generator.epsilon)):
             assert action1 is None
             assert action2 is None
         elif angle > 60 and (actionable.tilt_centre[0, 0] <=
-                             actionable.min_tilt + np.radians(60) + generator.epsilon):
+                             actionable.min_angle + np.radians(60) + generator.epsilon):
             assert action1 is None
             assert isinstance(action2, ChangeTiltAction)
             assert pytest.approx(action2.target_value) == tilt2
         elif angle > 60 and (actionable.tilt_centre[0, 0] >=
-                             actionable.max_tilt - np.radians(60) - generator.epsilon):
+                             actionable.max_angle - np.radians(60) - generator.epsilon):
             assert isinstance(action1, ChangeTiltAction)
             assert pytest.approx(action1.target_value) == tilt1
             assert action2 is None

--- a/stonesoup/sensor/action/tilt_action.py
+++ b/stonesoup/sensor/action/tilt_action.py
@@ -3,7 +3,7 @@ from collections.abc import Iterator
 import numpy as np
 
 from ...base import Property
-from ...types.angle import Angle, Elevation
+from ...types.angle import Elevation
 from ...functions import mod_elevation
 from .base import ChangeAngleAction, AngleActionsGenerator
 
@@ -38,8 +38,8 @@ class TiltActionsGenerator(AngleActionsGenerator):
     """Generates possible actions for changing the tilt centre of a sensor in a given
     time period."""
 
-    max_tilt: float = Property(default=np.radians(90))
-    min_tilt: float = Property(default=np.radians(-90))
+    max_angle: float = Property(default=np.radians(90))
+    min_angle: float = Property(default=np.radians(-90))
 
     @property
     def default_action(self):
@@ -49,20 +49,12 @@ class TiltActionsGenerator(AngleActionsGenerator):
                                 target_value=self.initial_value,
                                 increasing_angle=None)
 
-    @property
-    def min(self):
-        return max(Angle(self.initial_value - self.angle_delta), self.min_tilt)
-
-    @property
-    def max(self):
-        return min(Angle(self.initial_value + self.angle_delta), self.max_tilt)
-
     def __iter__(self) -> Iterator[ChangeTiltAction]:
         """Returns ChangeTiltAction types, where the value is a possible value of the [0, 0]
         element of the tilt centre's state vector."""
 
         current_angle = self.initial_value
-        while current_angle - self.resolution >= max(self.min_tilt, self.min-self.epsilon):
+        while current_angle - self.resolution >= max(self.min_angle, self.min-self.epsilon):
             current_angle -= self.resolution
         while current_angle <= self.max + self.epsilon:
             rot_end_time, increasing = self._end_time_direction(current_angle)

--- a/stonesoup/sensor/base.py
+++ b/stonesoup/sensor/base.py
@@ -149,4 +149,6 @@ class PlatformMountable(Base, ABC):
 
             It is settable if, and only if, the sensor holds its own internal movement_controller
             which is a :class:`~.MovingMovable`."""
+        if self.movement_controller is None:
+            return None
         return self.movement_controller.velocity

--- a/stonesoup/sensor/detection_probability.py
+++ b/stonesoup/sensor/detection_probability.py
@@ -1,0 +1,56 @@
+from abc import abstractmethod
+import numpy as np
+
+from stonesoup.base import Base, Property
+from stonesoup.types.array import StateVector
+
+
+class DetectionProbability(Base):
+    """Base class to define sensor detection probability"""
+    @abstractmethod
+    def __call__(self, state_vector: StateVector) -> float:
+        """
+        Method to determine the probability of detection based on the location of the target in
+        bearing, range space. Note for a 2D sensor the state vector will be [bearing, range] and
+        for a 3D sensor the state vector will be [elevation, bearing, range]
+
+        Parameters
+        ----------
+        state_vector : StateVector
+            location of the target in bearing range space
+
+        Returns
+        -------
+        float
+            The resulting probability of detection
+        """
+
+
+class ConstantDetectionProbability(DetectionProbability):
+    """:class:`.DetectionProbability` class to implement a constant probability of detection"""
+    p_d: float = Property(default=1., doc="The probaiblity of detection")
+
+    def __call__(self, *args, **kwargs) -> float:
+        return self.p_d
+
+
+class ExponentialDecayDetectionProbability(DetectionProbability):
+    """:class:`.DetectionProbability` class to implement a probability of detection of decays as
+    the range to the target increases"""
+    decay_rate: float = Property(default=np.inf, doc="The characteristic range of the "
+                                                     "exponential decay")
+
+    def __call__(self, state_vector, *args, **kwargs) -> float:
+        range = state_vector[-1, :].astype(float)
+        return np.exp(-range / self.decay_rate)
+
+
+class SigmoidDetectionProbability(DetectionProbability):
+    """:class:`.DetectionProbability` class to implement a probability of detection which observes
+    a sigmoid function"""
+    decay_rate: float = Property(doc="The rate at which the Sigmoid function decays")
+    midpoint: float = Property(doc="The range at which the probability of detection is 50%")
+
+    def __call__(self, state_vector, *args, **kwargs):
+        range = state_vector[-1, :].astype(float)
+        return 1 - 1/(1 + np.exp(-(range-self.midpoint)/self.decay_rate))

--- a/stonesoup/sensor/radar/radar.py
+++ b/stonesoup/sensor/radar/radar.py
@@ -15,18 +15,15 @@ from ...models.measurement.nonlinear import \
      CartesianToBearingRangeRate, CartesianToElevationBearingRangeRate,
      Cartesian2DToBearing, CartesianToBearingRangeRate2D)
 from ...sensor.action.dwell_action import DwellActionsGenerator
-from ...sensor.action.tilt_action import TiltActionsGenerator
 from ...sensormanager.action import ActionableProperty
-from ...sensor.sensor import Sensor, VisibilityInformed2DSensor
-from ...types.array import CovarianceMatrix
-from ...types.angle import Angle
+from ...sensor.sensor import Sensor, Generic2DSensor, Generic3DSensor
 from ...types.detection import TrueDetection, Detection
 from ...types.groundtruth import GroundTruthState
 from ...types.numeric import Probability
 from ...types.state import StateVector
 
 
-class RadarBearingRange(VisibilityInformed2DSensor):
+class RadarBearingRange(Generic2DSensor):
     """A simple radar sensor that generates measurements of targets, using a
     :class:`~.CartesianToBearingRange` model, relative to its position.
 
@@ -36,38 +33,9 @@ class RadarBearingRange(VisibilityInformed2DSensor):
 
     """
 
-    ndim_state: int = Property(
-        default=2,
-        doc="Number of state dimensions. This is utilised by (and follows in format) "
-            "the underlying :class:`~.CartesianToBearingRange` model")
-    position_mapping: tuple[int, int] = Property(
-        doc="Mapping between the target's state space and the sensor's "
-            "measurement capability")
-    noise_covar: CovarianceMatrix = Property(
-        doc="The sensor noise covariance matrix. This is utilised by "
-            "(and follows in format) the underlying "
-            ":class:`~.CartesianToBearingRange` model")
-    max_range: float = Property(
-        default=np.inf,
-        doc="The maximum detection range of the radar (in meters)")
-
-    @property
-    def measurement_model(self):
-        return CartesianToBearingRange(
-            ndim_state=self.ndim_state,
-            mapping=self.position_mapping,
-            noise_covar=self.noise_covar,
-            translation_offset=self.position,
-            rotation_offset=self.orientation)
-
-    def is_detectable(self, state: GroundTruthState, measurement_model=None) -> bool:
-        if measurement_model is None:
-            measurement_model = self.measurement_model
-        measurement_vector = measurement_model.function(state, noise=False)
-        true_range = measurement_vector[1, 0]  # Bearing(0), Range(1)
-        detectable = true_range <= self.max_range
-        visible = self.is_visible(state)
-        return detectable & visible
+    measurement_model_class = CartesianToBearingRange
+    dwell_centre: StateVector = Property(default=StateVector([0.]))
+    rpm = 0
 
     def is_clutter_detectable(self, state: Detection) -> bool:
         clutter_cart = self.measurement_model.inverse_function(state)
@@ -76,7 +44,7 @@ class RadarBearingRange(VisibilityInformed2DSensor):
         return detectable and visible
 
 
-class RadarBearing(VisibilityInformed2DSensor):
+class RadarBearing(Generic2DSensor):
     """A simple radar sensor that generates measurements of targets, using a
     :class:`~.Cartesian2DToBearing` model, relative to its position.
 
@@ -86,58 +54,15 @@ class RadarBearing(VisibilityInformed2DSensor):
 
     """
 
-    ndim_state: int = Property(
-        default=2,
-        doc="Number of state dimensions. This is utilised by (and follows in format) "
-            "the underlying :class:`~.Cartesian2DToBearing` model")
-    position_mapping: tuple[int, int] = Property(
-        doc="Mapping between the target's state space and the sensor's "
-            "measurement capability")
-    noise_covar: CovarianceMatrix = Property(
-        doc="The sensor noise covariance matrix. This is utilised by "
-            "(and follows in format) the underlying "
-            ":class:`~.Cartesian2DToBearing` model")
-    max_range: float = Property(
-        default=np.inf,
-        doc="The maximum detection range of the radar (in meters)")
-
-    @property
-    def measurement_model(self):
-        return Cartesian2DToBearing(
-            ndim_state=self.ndim_state,
-            mapping=self.position_mapping,
-            noise_covar=self.noise_covar,
-            translation_offset=self.position,
-            rotation_offset=self.orientation)
-
-    def is_detectable(self, state: GroundTruthState, measurement_model=None) -> bool:
-        if measurement_model is None:
-            tmp_meas_model = CartesianToBearingRange(
-                ndim_state=self.ndim_state,
-                mapping=self.position_mapping,
-                noise_covar=self.noise_covar,
-                translation_offset=self.position,
-                rotation_offset=self.orientation
-            )
-        else:
-            tmp_meas_model = CartesianToBearingRange(
-                ndim_state=measurement_model.ndim_state,
-                mapping=measurement_model.mapping,
-                noise_covar=measurement_model.noise_covar,
-                translation_offset=measurement_model.translation_offset,
-                rotation_offset=measurement_model.rotation_offset
-            )
-        measurement_vector = tmp_meas_model.function(state, noise=False)
-        true_range = measurement_vector[1, :]  # Bearing(0), Range(1)
-        detectable = true_range <= self.max_range
-        visible = self.is_visible(state)
-        return detectable & visible
+    measurement_model_class = Cartesian2DToBearing
+    dwell_centre: StateVector = Property(default=StateVector([0.]))
+    rpm = 0
 
     def is_clutter_detectable(self, state: Detection) -> bool:
         return True
 
 
-class RadarRotatingBearingRange(RadarBearingRange):
+class RadarRotatingBearingRange(Generic2DSensor):
     """A simple rotating radar, with set field-of-view (FOV) angle, range and\
      rotations per minute (RPM), that generates measurements of targets, using\
      a :class:`~.CartesianToBearingRange` model, relative to its\
@@ -149,6 +74,7 @@ class RadarRotatingBearingRange(RadarBearingRange):
 
     """
 
+    measurement_model_class = CartesianToBearingRange
     dwell_centre: StateVector = ActionableProperty(
         doc="A `state_vector` property that describes the rotation angle of the centre of the "
             "sensor's current FOV (i.e. the dwell centre) relative to the positive x-axis of the "
@@ -156,65 +82,8 @@ class RadarRotatingBearingRange(RadarBearingRange):
             "counter-clockwise direction when viewed by an observer looking down the z-axis of "
             "the sensor frame, towards the origin. Angle units are in radians",
         generator_cls=DwellActionsGenerator,
-        generator_kwargs_mapping={'rpm': 'rpm', 'resolution': 'resolution'})
-    rpm: float = Property(
-        doc="The number of antenna rotations per minute (RPM)")
-    resolution: Angle = Property(
-        default=Angle(np.radians(1)),
-        doc="Resolution of the dwell_centre. Used by the :class:`~.DwellActionsGenerator` "
-            "during sensor management.")
-    max_range: float = Property(
-        default=np.inf,
-        doc="The maximum detection range of the radar (in meters)")
-    fov_angle: float = Property(
-        doc="The radar field of view (FOV) angle (in radians).")
-
-    @property
-    def measurement_model(self):
-        antenna_heading = self.orientation[2, 0] + self.dwell_centre[0, 0]
-        # Set rotation offset of underlying measurement model
-        rot_offset = \
-            StateVector(
-                [[self.orientation[0, 0]],
-                 [self.orientation[1, 0]],
-                 [antenna_heading]])
-
-        return CartesianToBearingRange(
-            ndim_state=self.ndim_state,
-            mapping=self.position_mapping,
-            noise_covar=self.noise_covar,
-            translation_offset=self.position,
-            rotation_offset=rot_offset)
-
-    def measure(self, ground_truths: set[GroundTruthState], noise: Union[np.ndarray, bool] = True,
-                **kwargs) -> set[TrueDetection]:
-
-        if self.timestamp is None:
-            # Read timestamp from ground truth
-            try:
-                self.timestamp = next(iter(ground_truths)).timestamp
-            except StopIteration:
-                # No ground truths to get timestamp from
-                return set()
-
-        return super().measure(ground_truths, noise, **kwargs)
-
-    def is_detectable(self, state: GroundTruthState, measurement_model=None) -> bool:
-        if measurement_model is None:
-            measurement_model = self.measurement_model
-        measurement_vector = measurement_model.function(state, noise=False)
-
-        # Check if state falls within sensor's FOV
-        fov_min = -self.fov_angle / 2
-        fov_max = +self.fov_angle / 2
-        bearing_t = measurement_vector[0, :]
-        true_range = measurement_vector[1, :]
-
-        detectable = np.logical_and(fov_min <= bearing_t, bearing_t <= fov_max) & \
-            (true_range <= self.max_range)
-        visible = self.is_visible(state)
-
-        return detectable & visible
+        generator_kwargs_mapping={'rpm': 'rpm', 'resolution': 'resolution',
+                                  "min_angle": "min_dwell", "max_angle": "max_dwell"})
 
     def is_clutter_detectable(self, state: Detection) -> bool:
         measurement_vector = state.state_vector
@@ -232,7 +101,7 @@ class RadarRotatingBearingRange(RadarBearingRange):
         return detectable and visible
 
 
-class RadarRotatingBearing(RadarBearing):
+class RadarRotatingBearing(Generic2DSensor):
     """A simple rotating radar, with set field-of-view (FOV) angle, range and\
      rotations per minute (RPM), that generates measurements of targets, using\
      a :class:`~.Cartesian2DToBearing` model, relative to its\
@@ -244,6 +113,7 @@ class RadarRotatingBearing(RadarBearing):
 
     """
 
+    measurement_model_class = Cartesian2DToBearing
     dwell_centre: StateVector = ActionableProperty(
         doc="A `state_vector` property that describes the rotation angle of the centre of the "
             "sensor's current FOV (i.e. the dwell centre) relative to the positive x-axis of the "
@@ -251,88 +121,14 @@ class RadarRotatingBearing(RadarBearing):
             "counter-clockwise direction when viewed by an observer looking down the z-axis of "
             "the sensor frame, towards the origin. Angle units are in radians",
         generator_cls=DwellActionsGenerator,
-        generator_kwargs_mapping={'rpm': 'rpm', 'resolution': 'resolution'})
-    rpm: float = Property(
-        doc="The number of antenna rotations per minute (RPM)")
-    resolution: Angle = Property(
-        default=Angle(np.radians(1)),
-        doc="Resolution of the dwell_centre. Used by the :class:`~.DwellActionsGenerator` "
-            "during sensor management.")
-    max_range: float = Property(
-        default=np.inf,
-        doc="The maximum detection range of the radar (in meters)")
-    fov_angle: float = Property(
-        doc="The radar field of view (FOV) angle (in radians).")
+        generator_kwargs_mapping={'rpm': 'rpm', 'resolution': 'resolution',
+                                  "min_angle": "min_dwell", "max_angle": "max_dwell"})
 
-    @property
-    def measurement_model(self):
-        antenna_heading = self.orientation[2, 0] + self.dwell_centre[0, 0]
-        # Set rotation offset of underlying measurement model
-        rot_offset = \
-            StateVector(
-                [[self.orientation[0, 0]],
-                 [self.orientation[1, 0]],
-                 [antenna_heading]])
-
-        return Cartesian2DToBearing(
-            ndim_state=self.ndim_state,
-            mapping=self.position_mapping,
-            noise_covar=self.noise_covar,
-            translation_offset=self.position,
-            rotation_offset=rot_offset)
-
-    def measure(self, ground_truths: set[GroundTruthState], noise: Union[np.ndarray, bool] = True,
-                **kwargs) -> set[TrueDetection]:
-
-        if self.timestamp is None:
-            # Read timestamp from ground truth
-            try:
-                self.timestamp = next(iter(ground_truths)).timestamp
-            except StopIteration:
-                # No ground truths to get timestamp from
-                return set()
-
-        return super().measure(ground_truths, noise, **kwargs)
-
-    def is_detectable(self, state: GroundTruthState, measurement_model=None) -> bool:
-        if measurement_model is None:
-            antenna_heading = self.orientation[2, 0] + self.dwell_centre[0, 0]
-            # Set rotation offset of underlying measurement model
-            rot_offset = \
-                StateVector(
-                    [[self.orientation[0, 0]],
-                     [self.orientation[1, 0]],
-                     [antenna_heading]])
-            tmp_meas_model = CartesianToBearingRange(
-                ndim_state=self.ndim_state,
-                mapping=self.position_mapping,
-                noise_covar=self.noise_covar,
-                translation_offset=self.position,
-                rotation_offset=rot_offset
-            )
-        else:
-            tmp_meas_model = CartesianToBearingRange(
-                ndim_state=measurement_model.ndim_state,
-                mapping=measurement_model.mapping,
-                noise_covar=measurement_model.noise_covar,
-                translation_offset=measurement_model.translation_offset,
-                rotation_offset=measurement_model.rotation_offset
-            )
-        measurement_vector = tmp_meas_model.function(state, noise=False)
-
-        # Check if state falls within sensor's FOV
-        fov_min = -self.fov_angle / 2
-        fov_max = +self.fov_angle / 2
-        bearing_t = measurement_vector[0, :]
-        true_range = measurement_vector[1, :]
-        detectable = np.logical_and(fov_min <= bearing_t, bearing_t <= fov_max) & \
-            (true_range <= self.max_range)
-        visible = self.is_visible(state)
-
-        return detectable & visible
+    def is_clutter_detectable(self, state: Detection) -> bool:
+        return True
 
 
-class RadarElevationBearingRange(RadarBearingRange):
+class RadarElevationBearingRange(Generic3DSensor):
     """A  radar sensor that generates measurements of targets, using a
     :class:`~.CartesianToElevationBearingRange` model, relative to its position.
 
@@ -342,36 +138,13 @@ class RadarElevationBearingRange(RadarBearingRange):
 
     """
 
-    ndim_state: int = Property(
-        default=3,
-        doc="Number of state dimensions. This is utilised by (and follows in format) "
-            "the underlying :class:`~.CartesianToBearingRange` model")
-    noise_covar: CovarianceMatrix = Property(
-        doc="The sensor noise covariance matrix. This is utilised by "
-            "(and follows in format) the underlying "
-            ":class:`~.CartesianToElevationBearingRange` model")
-    max_range: float = Property(
-        default=np.inf,
-        doc="The maximum detection range of the radar (in meters)")
-
-    @property
-    def measurement_model(self):
-        return CartesianToElevationBearingRange(
-            ndim_state=self.ndim_state,
-            mapping=self.position_mapping,
-            noise_covar=self.noise_covar,
-            translation_offset=self.position,
-            rotation_offset=self.orientation)
-
-    def is_detectable(self, state: GroundTruthState, measurement_model=None) -> bool:
-        if measurement_model is None:
-            measurement_model = self.measurement_model
-        measurement_vector = measurement_model.function(state, noise=False)
-        true_range = measurement_vector[2, 0]  # Elevation(0), Bearing(1), Range(2)
-        return true_range <= self.max_range
+    measurement_model_class = CartesianToElevationBearingRange
+    dwell_centre: StateVector = Property(default=StateVector([0.]))
+    tilt_centre: StateVector = Property(default=StateVector([0.]))
+    rpm = 0
 
 
-class RadarRotatingElevationBearingRange(RadarElevationBearingRange):
+class RadarRotatingElevationBearingRange(Generic3DSensor):
     """
     A rotating radar, with set field-of-view (FOV) angle, range and rotations per minute (RPM),
     that generates measurements of targets, using a :class:`~.CartesianToElevationBearingRange`
@@ -389,92 +162,11 @@ class RadarRotatingElevationBearingRange(RadarElevationBearingRange):
             "counter-clockwise direction when viewed by an observer looking down the z-axis of "
             "the sensor frame, towards the origin. Angle units are in radians",
         generator_cls=DwellActionsGenerator,
-        generator_kwargs_mapping={'rpm': 'rpm', 'resolution': 'resolution'})
-    tilt_centre: StateVector = ActionableProperty(
-        doc="A `state_vector` property that describes the tilting angle of the centre of the "
-            "sensor's current FOV (i.e. the tilt centre) relative to the x-y plane of the sensor "
-            "frame/orientation. The angle is positive if the tilt is towards the positive z "
-            "direction when viewed by an observer looking down the x-axis of the sensor frame, "
-            "towards the origin. Angle units are in radians",
-        generator_cls=TiltActionsGenerator,
-        generator_kwargs_mapping={'rpm': 'rpm', 'resolution': 'resolution'})
-    rpm: float = Property(
-        doc="The number of antenna rotations per minute (RPM)")
-    resolution: Angle = Property(
-        default=Angle(np.radians(1)),
-        doc="Resolution of the dwell_centre. Used by the :class:`~.DwellActionsGenerator` "
-            "during sensor management.")
-    fov_angle: float = Property(
-        doc="The radar horizontal field of view (FOV) angle (in radians).")
-    vertical_extent: float = Property(
-        doc="The radar vertical field of view (FOV) angle (in radians).")
-
-    @property
-    def measurement_model(self):
-        # Set rotation offset of underlying measurement model
-        rot_offset = StateVector([[self.orientation[0, 0]],
-                                  [self.orientation[1, 0] + self.tilt_centre[0, 0]],
-                                  [self.orientation[2, 0] + self.dwell_centre[0, 0]]])
-
-        return CartesianToElevationBearingRange(
-            ndim_state=self.ndim_state,
-            mapping=self.position_mapping,
-            noise_covar=self.noise_covar,
-            translation_offset=self.position,
-            rotation_offset=rot_offset)
-
-    def measure(self, ground_truths: set[GroundTruthState], noise: Union[np.ndarray, bool] = True,
-                **kwargs) -> set[TrueDetection]:
-
-        if self.timestamp is None:
-            # Read timestamp from ground truth
-            try:
-                self.timestamp = next(iter(ground_truths)).timestamp
-            except StopIteration:
-                # No ground truths to get timestamp from
-                return set()
-
-        return super().measure(ground_truths, noise, **kwargs)
-
-    def is_detectable(self, state: GroundTruthState, measurement_model=None) -> bool:
-        if measurement_model is None:
-            measurement_model = self.measurement_model
-        measurement_vector = measurement_model.function(state, noise=False)
-
-        # Check if state falls within sensor's FOV
-        ver_min = -self.vertical_extent / 2
-        ver_max = +self.vertical_extent / 2
-
-        fov_min = -self.fov_angle / 2
-        fov_max = +self.fov_angle / 2
-
-        elevation_t = measurement_vector[0, 0]
-        bearing_t = measurement_vector[1, 0]
-        true_range = measurement_vector[2, 0]
-        return (ver_min <= elevation_t <= ver_max and
-                fov_min <= bearing_t <= fov_max and
-                true_range <= self.max_range)
-
-    def is_clutter_detectable(self, state: Detection) -> bool:
-        measurement_vector = state.state_vector
-
-        # Check if state falls within sensor's FOV
-        ver_min = -self.vertical_extent / 2
-        ver_max = +self.vertical_extent / 2
-
-        fov_min = -self.fov_angle / 2
-        fov_max = +self.fov_angle / 2
-
-        elevation_t = measurement_vector[0, 0]
-        bearing_t = measurement_vector[1, 0]
-        true_range = measurement_vector[2, 0]
-
-        return (ver_min <= elevation_t <= ver_max and
-                fov_min <= bearing_t <= fov_max and
-                true_range <= self.max_range)
+        generator_kwargs_mapping={'rpm': 'rpm', 'resolution': 'resolution',
+                                  "min_angle": "min_dwell", "max_angle": "max_dwell"})
 
 
-class RadarBearingRangeRate(RadarBearingRange):
+class RadarBearingRangeRate(RadarElevationBearingRange):
     """ A radar sensor that generates measurements of targets, using a
     :class:`~.CartesianToBearingRangeRate` model, relative to its position
     and velocity.
@@ -486,6 +178,7 @@ class RadarBearingRangeRate(RadarBearingRange):
 
     """
 
+    measurement_model_class = CartesianToBearingRangeRate
     velocity_mapping: tuple[int, int, int] = Property(
         default=(1, 3, 5),
         doc="Mapping to the target's velocity information within its state space")
@@ -493,28 +186,6 @@ class RadarBearingRangeRate(RadarBearingRange):
         default=6,
         doc="Number of state dimensions. This is utilised by (and follows in format) "
             "the underlying :class:`~.CartesianToBearingRangeRate` model")
-    noise_covar: CovarianceMatrix = Property(
-        doc="The sensor noise covariance matrix. This is utilised by "
-            "(and follows in format) the underlying "
-            ":class:`~.CartesianToBearingRangeRate` model")
-
-    @property
-    def measurement_model(self):
-        return CartesianToBearingRangeRate(
-            ndim_state=self.ndim_state,
-            mapping=self.position_mapping,
-            velocity_mapping=self.velocity_mapping,
-            noise_covar=self.noise_covar,
-            translation_offset=self.position,
-            velocity=self.velocity,
-            rotation_offset=self.orientation)
-
-    def is_detectable(self, state: GroundTruthState, measurement_model=None) -> bool:
-        if measurement_model is None:
-            measurement_model = self.measurement_model
-        measurement_vector = measurement_model.function(state, noise=False)
-        true_range = measurement_vector[1, 0]  # Bearing(0), Range(1), Range-Rate(2)
-        return true_range <= self.max_range
 
 
 class RadarBearingRangeRate2D(RadarBearingRange):
@@ -529,6 +200,7 @@ class RadarBearingRangeRate2D(RadarBearingRange):
 
     """
 
+    measurement_model_class = CartesianToBearingRangeRate2D
     velocity_mapping: tuple[int, int] = Property(
         default=(1, 3),
         doc="Mapping to the target's velocity information within its state space")
@@ -536,28 +208,6 @@ class RadarBearingRangeRate2D(RadarBearingRange):
         default=4,
         doc="Number of state dimensions. This is utilised by (and follows in format) "
             "the underlying :class:`~.CartesianToBearingRangeRate2D` model")
-    noise_covar: CovarianceMatrix = Property(
-        doc="The sensor noise covariance matrix. This is utilised by "
-            "(and follows in format) the underlying "
-            ":class:`~.CartesianToBearingRangeRate2D` model")
-
-    @property
-    def measurement_model(self):
-        return CartesianToBearingRangeRate2D(
-            ndim_state=self.ndim_state,
-            mapping=self.position_mapping,
-            velocity_mapping=self.velocity_mapping,
-            noise_covar=self.noise_covar,
-            translation_offset=self.position,
-            velocity=self.velocity,
-            rotation_offset=self.orientation)
-
-    def is_detectable(self, state: GroundTruthState, measurement_model=None) -> bool:
-        if measurement_model is None:
-            measurement_model = self.measurement_model
-        measurement_vector = measurement_model.function(state, noise=False)
-        true_range = measurement_vector[1, 0]  # Bearing(0), Range(1), Range-Rate(2)
-        return true_range <= self.max_range
 
 
 class RadarElevationBearingRangeRate(RadarBearingRangeRate):
@@ -571,35 +221,7 @@ class RadarElevationBearingRangeRate(RadarBearingRangeRate):
 
     """
 
-    velocity_mapping: tuple[int, int, int] = Property(
-        default=(1, 3, 5),
-        doc="Mapping to the target's velocity information within its state space")
-    ndim_state: int = Property(
-        default=6,
-        doc="Number of state dimensions. This is utilised by (and follows in format) "
-            "the underlying :class:`~.CartesianToElevationBearingRangeRate` model")
-    noise_covar: CovarianceMatrix = Property(
-        doc="The sensor noise covariance matrix. This is utilised by "
-            "(and follows in format) the underlying "
-            ":class:`~.CartesianToElevationBearingRangeRate` model")
-
-    @property
-    def measurement_model(self):
-        return CartesianToElevationBearingRangeRate(
-            ndim_state=self.ndim_state,
-            mapping=self.position_mapping,
-            velocity_mapping=self.velocity_mapping,
-            noise_covar=self.noise_covar,
-            translation_offset=self.position,
-            velocity=self.velocity,
-            rotation_offset=self.orientation)
-
-    def is_detectable(self, state: GroundTruthState, measurement_model=None) -> bool:
-        if measurement_model is None:
-            measurement_model = self.measurement_model
-        measurement_vector = measurement_model.function(state, noise=False)
-        true_range = measurement_vector[2, 0]  # Elevation(0), Bearing(1), Range(2), Range-Rate(3)
-        return true_range <= self.max_range
+    measurement_model_class = CartesianToElevationBearingRangeRate
 
 
 class RadarRasterScanBearingRange(RadarRotatingBearingRange):

--- a/stonesoup/sensor/radar/radar.py
+++ b/stonesoup/sensor/radar/radar.py
@@ -16,14 +16,15 @@ from ...models.measurement.nonlinear import \
      Cartesian2DToBearing, CartesianToBearingRangeRate2D)
 from ...sensor.action.dwell_action import DwellActionsGenerator
 from ...sensormanager.action import ActionableProperty
-from ...sensor.sensor import Sensor, Generic2DSensor, Generic3DSensor
+from ...sensor.sensor import (Sensor, VisibilityInformed2DSensor, Rotating2DSensor,
+                              Generic3DSensor, Rotating3DSensor)
 from ...types.detection import TrueDetection, Detection
 from ...types.groundtruth import GroundTruthState
 from ...types.numeric import Probability
 from ...types.state import StateVector
 
 
-class RadarBearingRange(Generic2DSensor):
+class RadarBearingRange(VisibilityInformed2DSensor):
     """A simple radar sensor that generates measurements of targets, using a
     :class:`~.CartesianToBearingRange` model, relative to its position.
 
@@ -44,7 +45,7 @@ class RadarBearingRange(Generic2DSensor):
         return detectable and visible
 
 
-class RadarBearing(Generic2DSensor):
+class RadarBearing(VisibilityInformed2DSensor):
     """A simple radar sensor that generates measurements of targets, using a
     :class:`~.Cartesian2DToBearing` model, relative to its position.
 
@@ -62,7 +63,7 @@ class RadarBearing(Generic2DSensor):
         return True
 
 
-class RadarRotatingBearingRange(Generic2DSensor):
+class RadarRotatingBearingRange(VisibilityInformed2DSensor, Rotating2DSensor):
     """A simple rotating radar, with set field-of-view (FOV) angle, range and\
      rotations per minute (RPM), that generates measurements of targets, using\
      a :class:`~.CartesianToBearingRange` model, relative to its\
@@ -101,7 +102,7 @@ class RadarRotatingBearingRange(Generic2DSensor):
         return detectable and visible
 
 
-class RadarRotatingBearing(Generic2DSensor):
+class RadarRotatingBearing(VisibilityInformed2DSensor, Rotating2DSensor):
     """A simple rotating radar, with set field-of-view (FOV) angle, range and\
      rotations per minute (RPM), that generates measurements of targets, using\
      a :class:`~.Cartesian2DToBearing` model, relative to its\
@@ -144,7 +145,7 @@ class RadarElevationBearingRange(Generic3DSensor):
     rpm = 0
 
 
-class RadarRotatingElevationBearingRange(Generic3DSensor):
+class RadarRotatingElevationBearingRange(Rotating3DSensor):
     """
     A rotating radar, with set field-of-view (FOV) angle, range and rotations per minute (RPM),
     that generates measurements of targets, using a :class:`~.CartesianToElevationBearingRange`

--- a/stonesoup/sensor/sensor.py
+++ b/stonesoup/sensor/sensor.py
@@ -13,9 +13,17 @@ except ImportError:
 import numpy as np
 
 from .base import PlatformMountable
-from ..sensormanager.action import Actionable
+from .action.dwell_action import StationaryDwellActionsGenerator
+from .action.tilt_action import TiltActionsGenerator
 from ..base import Property
 from ..models.clutter.clutter import ClutterModel
+from ..models.measurement import MeasurementModel
+from ..models.measurement.nonlinear import (CartesianToBearingRange,
+                                            CartesianToElevationBearingRange)
+from ..models.measurement.linear import LinearGaussian
+from ..sensormanager.action import Actionable, ActionableProperty
+from ..types.angle import Angle
+from ..types.array import CovarianceMatrix
 from ..types.detection import TrueDetection, Detection
 from ..types.groundtruth import GroundTruthState
 from ..types.state import ParticleState, State, StateVector
@@ -439,3 +447,245 @@ class VisibilityInformed2DSensor(SimpleSensor):
                                                          beta <= 1))
 
         return intersections
+
+
+class Generic2DSensor(VisibilityInformed2DSensor):
+    """
+    Generic :class:`~.SimpleSensor` implementation which takes a 2D input truth state and produces
+    measurements using a desired measurement model.
+    """
+    measurement_model_class: MeasurementModel = Property(
+        default=CartesianToBearingRange,
+        doc="The :class:`stonesoup.models.measurement.MeasurementModel` desired to make"
+            "measurements")
+    ndim_state: int = Property(
+        default=2,
+        doc="Number of state dimensions. This is utilised by (and follows in format) "
+            "the underlying measurement model")
+    position_mapping: tuple[int, int] = Property(
+        doc="Mapping between the target's state space and the sensor's "
+            "measurement capability")
+    velocity_mapping: tuple[int, int] = Property(default=None)
+    noise_covar: CovarianceMatrix = Property(
+        doc="The sensor noise covariance matrix. This is utilised by "
+            "(and follows in format) the underlying measurement model")
+
+    min_range: float = Property(default=0,
+                                doc="The minimum detection range of the radar (in meters)")
+    max_range: float = Property(default=np.inf,
+                                doc="The maximum detection range of the radar (in meters)")
+    fov_angle: float = Property(default=2*np.pi)
+
+    dwell_centre: StateVector = ActionableProperty(
+        doc="A `state_vector` property that describes the rotation angle of the centre of the "
+            "sensor's current FOV (i.e. the dwell centre) relative to the positive x-axis of the "
+            "sensor frame/orientation. The angle is positive if the rotation is in the "
+            "counter-clockwise direction when viewed by an observer looking down the z-axis of "
+            "the sensor frame, towards the origin. Angle units are in radians",
+        generator_cls=StationaryDwellActionsGenerator,
+        generator_kwargs_mapping={"rpm": "rpm", "resolution": "resolution",
+                                  "min_angle": "min_dwell", "max_angle": "max_dwell"})
+    min_dwell: float = Property(default=-np.inf)
+    max_dwell: float = Property(default=np.inf)
+
+    rpm: float = Property(
+        doc="The number of antenna rotations per minute (RPM)")
+    resolution: Angle = Property(
+        default=Angle(np.radians(1)),
+        doc="Resolution of the dwell_centre. Used by the :class:`~.DwellActionsGenerator` "
+            "during sensor management.")
+
+    def create_measurement_model(self, measurement_model=None, check_visibility=False
+                                 ) -> MeasurementModel:
+        """Method to generate a measurement model using the sensor's attributes
+
+        Parameters
+        ----------
+        measurement_model : MeasurementModel, optional
+            Measurement model to produce new model from, by default None
+        check_visibility : bool, optional
+            Boolean dictating whether this model is being used to check visibility,
+            by default False
+
+        Returns
+        -------
+        MeasurementModel
+        """
+
+        if measurement_model is None:
+            model_class = self.measurement_model_class
+            ndim_state = self.ndim_state
+            mapping = self.position_mapping
+            noise_covar = self.noise_covar
+            translation_offset = self.position
+            orientation = self.orientation
+            if orientation is None:
+                orientation = StateVector([0, 0, 0])
+            rotation_offset = StateVector([[orientation[0, 0]],
+                                           [orientation[1, 0]],
+                                           [orientation[2, 0] + self.dwell_centre[0, 0]]])
+            velocity_mapping = self.velocity_mapping
+            velocity = self.velocity
+        else:
+            model_class = type(measurement_model)
+            ndim_state = measurement_model.ndim_state
+            mapping = measurement_model.mapping
+            noise_covar = measurement_model.noise_covar
+            translation_offset = getattr(measurement_model, "translation_offset", None)
+            rotation_offset = getattr(measurement_model, "rotation_offset", None)
+            velocity_mapping = getattr(measurement_model, "velocity_mapping", None)
+            velocity = getattr(measurement_model, "velocity", None)
+
+        if check_visibility:
+            model_class = CartesianToBearingRange
+        if isinstance(model_class, LinearGaussian):
+            if self.velocity_mapping is not None and measurement_model is None:
+                mapping = tuple(*self.position_mapping, *self.velocity_mapping)
+            return LinearGaussian(ndim_state=ndim_state,
+                                  mapping=mapping,
+                                  noise_covar=self.noise_covar)
+        model = model_class(ndim_state=ndim_state,
+                            mapping=mapping,
+                            noise_covar=noise_covar,
+                            translation_offset=translation_offset,
+                            rotation_offset=rotation_offset)
+        model.velocity_mapping = velocity_mapping
+        model.velocity = velocity
+        return model
+
+    @property
+    def measurement_model(self):
+        return self.create_measurement_model()
+
+    def measure(self, ground_truths: set[GroundTruthState], noise: Union[np.ndarray, bool] = True,
+                **kwargs) -> set[TrueDetection]:
+
+        if self.timestamp is None:
+            # Read timestamp from ground truth
+            try:
+                self.timestamp = next(iter(ground_truths)).timestamp
+            except StopIteration:
+                # No ground truths to get timestamp from
+                return set()
+
+        return super().measure(ground_truths, noise, **kwargs)
+
+    def is_detectable(self, state, measurement_model=None):
+        measurement_model = self.create_measurement_model(measurement_model=measurement_model,
+                                                          check_visibility=True)
+        measurement_vector = measurement_model.function(state, noise=False)
+        return self._is_detectable(measurement_vector) & self.is_visible(state)
+
+    # TODO: Need way of making this method generic.
+    # Clutter is in measurement model state space and therefore the indices of e, b and r are not set
+    def is_clutter_detectable(self, state: Detection) -> bool:
+        measurement_vector = state.state_vector
+        return self._is_detectable(measurement_vector)
+
+    def _is_detectable(self, measurement_vector: StateVector) -> bool:
+        fov_min = -self.fov_angle / 2
+        fov_max = +self.fov_angle / 2
+
+        bearing_t = measurement_vector[0, :]
+        true_range = measurement_vector[1, :]
+        return (np.logical_and(fov_min <= bearing_t, bearing_t <= fov_max) &
+                np.logical_and(self.min_range <= true_range, true_range <= self.max_range))
+
+
+class Generic3DSensor(Generic2DSensor):
+    """
+    Generic :class:`~.SimpleSensor` implementation which takes a 3D input truth state and produces
+    measurements using a desired measurement model.
+    """
+    measurement_model_class: MeasurementModel = Property(default=CartesianToElevationBearingRange)
+    ndim_state: int = Property(
+        default=3
+    )
+    position_mapping: tuple[int, int, int] = Property()
+    velocity_mapping: tuple[int, int, int] = Property(default=None)
+
+    vertical_extent: float = Property(default=np.pi)
+    tilt_centre: StateVector = ActionableProperty(
+        generator_cls=TiltActionsGenerator,
+        generator_kwargs_mapping={"rpm": "rpm", "resolution": "resolution",
+                                  "min_angle": "min_tilt", "max_angle": "max_tilt"}
+    )
+    min_tilt: float = Property(default=-np.pi/2)
+    max_tilt: float = Property(default=np.pi/2)
+
+    def create_measurement_model(self, measurement_model=None, check_visibility=False):
+        """Method to generate a measurement model using the sensor's attributes
+
+        Parameters
+        ----------
+        measurement_model : MeasurementModel, optional
+            Measurement model to produce new model from, by default None
+        check_visibility : bool, optional
+            Boolean dictating whether this model is being used to check visibility,
+            by default False
+
+        Returns
+        -------
+        MeasurementModel
+        """
+        if measurement_model is None:
+            model_class = self.measurement_model_class
+            ndim_state = self.ndim_state
+            mapping = self.position_mapping
+            noise_covar = self.noise_covar
+            translation_offset = self.position
+            orientation = self.orientation
+            if orientation is None:
+                orientation = StateVector([0, 0, 0])
+            rotation_offset = StateVector([[orientation[0, 0]],
+                                           [orientation[1, 0] + self.tilt_centre[0, 0]],
+                                           [orientation[2, 0] + self.dwell_centre[0, 0]]])
+            velocity_mapping = self.velocity_mapping
+            velocity = self.velocity
+        else:
+            model_class = type(measurement_model)
+            ndim_state = measurement_model.ndim_state
+            mapping = measurement_model.mapping
+            noise_covar = measurement_model.noise_covar
+            translation_offset = getattr(measurement_model, "translation_offset", None)
+            rotation_offset = getattr(measurement_model, "rotation_offset", None)
+            velocity_mapping = getattr(measurement_model, "velocity_mapping", None)
+            velocity = getattr(measurement_model, "velocity", None)
+
+        if check_visibility:
+            model_class = CartesianToElevationBearingRange
+        if isinstance(model_class, LinearGaussian):
+            mapping = self.position_mapping
+            if self.velocity_mapping is not None and measurement_model is None:
+                mapping = tuple(*self.position_mapping, *self.velocity_mapping)
+            return LinearGaussian(ndim_state=self.ndim_state,
+                                  mapping=mapping,
+                                  noise_covar=self.noise_covar)
+        model = model_class(ndim_state=ndim_state,
+                            mapping=mapping,
+                            noise_covar=noise_covar,
+                            translation_offset=translation_offset,
+                            rotation_offset=rotation_offset)
+        model.velocity_mapping = velocity_mapping
+        model.velocity = velocity
+        return model
+
+    def is_detectable(self, state, measurement_model=None):
+        measurement_model = self.create_measurement_model(measurement_model=measurement_model,
+                                                          check_visibility=True)
+        measurement_vector = measurement_model.function(state, noise=False)
+        return self._is_detectable(measurement_vector)
+
+    def _is_detectable(self, measurement_vector: StateVector) -> bool:
+        ver_min = -self.vertical_extent / 2
+        ver_max = +self.vertical_extent / 2
+
+        fov_min = -self.fov_angle / 2
+        fov_max = +self.fov_angle / 2
+
+        elevation_t = measurement_vector[0, :]
+        bearing_t = measurement_vector[1, :]
+        true_range = measurement_vector[2, :]
+        return (np.logical_and(ver_min <= elevation_t, elevation_t <= ver_max) &
+                np.logical_and(fov_min <= bearing_t, bearing_t <= fov_max) &
+                np.logical_and(self.min_range <= true_range, true_range <= self.max_range))

--- a/stonesoup/sensor/sensor.py
+++ b/stonesoup/sensor/sensor.py
@@ -210,7 +210,163 @@ class SensorSuite(Sensor):
         raise NotImplementedError
 
 
-class VisibilityInformed2DSensor(SimpleSensor):
+class Generic2DSensor(SimpleSensor):
+    """
+    Generic :class:`~.SimpleSensor` implementation which takes a 2D input truth state and produces
+    measurements using a desired measurement model.
+    """
+    measurement_model_class: MeasurementModel = Property(
+        default=CartesianToBearingRange,
+        doc="The :class:`stonesoup.models.measurement.MeasurementModel` desired to make"
+            "measurements")
+    ndim_state: int = Property(
+        default=2,
+        doc="Number of state dimensions. This is utilised by (and follows in format) "
+            "the underlying measurement model")
+    position_mapping: tuple[int, int] = Property(
+        doc="Mapping between the target's state space and the sensor's "
+            "measurement capability")
+    velocity_mapping: tuple[int, int] = Property(default=None)
+    noise_covar: CovarianceMatrix = Property(
+        doc="The sensor noise covariance matrix. This is utilised by "
+            "(and follows in format) the underlying measurement model")
+
+    min_range: float = Property(default=0,
+                                doc="The minimum detection range of the radar (in meters)")
+    max_range: float = Property(default=np.inf,
+                                doc="The maximum detection range of the radar (in meters)")
+    fov_angle: float = Property(default=2*np.pi)
+
+    @property
+    def _rotation_offset(self):
+        orientation = self.orientation
+        if orientation is None:
+            orientation = StateVector([0, 0, 0])
+        return orientation
+
+    def create_measurement_model(self, measurement_model=None, check_visibility=False
+                                 ) -> MeasurementModel:
+        """Method to generate a measurement model using the sensor's attributes
+
+        Parameters
+        ----------
+        measurement_model : MeasurementModel, optional
+            Measurement model to produce new model from, by default None
+        check_visibility : bool, optional
+            Boolean dictating whether this model is being used to check visibility,
+            by default False
+
+        Returns
+        -------
+        MeasurementModel
+        """
+
+        if measurement_model is None:
+            model_class = self.measurement_model_class
+            ndim_state = self.ndim_state
+            mapping = self.position_mapping
+            noise_covar = self.noise_covar
+            translation_offset = self.position
+            rotation_offset = self._rotation_offset
+            velocity_mapping = self.velocity_mapping
+            velocity = self.velocity
+        else:
+            model_class = type(measurement_model)
+            ndim_state = measurement_model.ndim_state
+            mapping = measurement_model.mapping
+            noise_covar = measurement_model.noise_covar
+            translation_offset = getattr(measurement_model, "translation_offset",
+                                         StateVector([0, 0, 0]))
+            rotation_offset = getattr(measurement_model, "rotation_offset", StateVector([0, 0, 0]))
+            velocity_mapping = getattr(measurement_model, "velocity_mapping", None)
+            velocity = getattr(measurement_model, "velocity", None)
+
+        if check_visibility:
+            model_class = CartesianToBearingRange
+        if isinstance(model_class, LinearGaussian):
+            if self.velocity_mapping is not None and measurement_model is None:
+                mapping = tuple(*self.position_mapping, *self.velocity_mapping)
+            return LinearGaussian(ndim_state=ndim_state,
+                                  mapping=mapping,
+                                  noise_covar=self.noise_covar)
+        model = model_class(ndim_state=ndim_state,
+                            mapping=mapping,
+                            noise_covar=noise_covar,
+                            translation_offset=translation_offset,
+                            rotation_offset=rotation_offset)
+        model.velocity_mapping = velocity_mapping
+        model.velocity = velocity
+        return model
+
+    @property
+    def measurement_model(self):
+        return self.create_measurement_model()
+
+    def measure(self, ground_truths: set[GroundTruthState], noise: Union[np.ndarray, bool] = True,
+                **kwargs) -> set[TrueDetection]:
+
+        if self.timestamp is None:
+            # Read timestamp from ground truth
+            try:
+                self.timestamp = next(iter(ground_truths)).timestamp
+            except StopIteration:
+                # No ground truths to get timestamp from
+                return set()
+
+        return super().measure(ground_truths, noise, **kwargs)
+
+    def is_detectable(self, state, measurement_model=None):
+        measurement_model = self.create_measurement_model(measurement_model=measurement_model,
+                                                          check_visibility=True)
+        measurement_vector = measurement_model.function(state, noise=False)
+        return self._is_detectable(measurement_vector) & self.is_visible(state)
+
+    # TODO: Need way of making this method generic.
+    # Clutter is in measurement model state space and therefore
+    # the indices of e, b and r are not set
+    def is_clutter_detectable(self, state: Detection) -> bool:
+        measurement_vector = state.state_vector
+        return self._is_detectable(measurement_vector)
+
+    def _is_detectable(self, measurement_vector: StateVector) -> bool:
+        fov_min = -self.fov_angle / 2
+        fov_max = +self.fov_angle / 2
+
+        bearing_t = measurement_vector[0, :]
+        true_range = measurement_vector[1, :]
+        return (np.logical_and(fov_min <= bearing_t, bearing_t <= fov_max) &
+                np.logical_and(self.min_range <= true_range, true_range <= self.max_range))
+
+
+class Rotating2DSensor(Generic2DSensor):
+    dwell_centre: StateVector = ActionableProperty(
+        doc="A `state_vector` property that describes the rotation angle of the centre of the "
+            "sensor's current FOV (i.e. the dwell centre) relative to the positive x-axis of the "
+            "sensor frame/orientation. The angle is positive if the rotation is in the "
+            "counter-clockwise direction when viewed by an observer looking down the z-axis of "
+            "the sensor frame, towards the origin. Angle units are in radians",
+        generator_cls=StationaryDwellActionsGenerator,
+        generator_kwargs_mapping={"rpm": "rpm", "resolution": "resolution",
+                                  "min_angle": "min_dwell", "max_angle": "max_dwell"})
+    min_dwell: float = Property(default=-np.inf)
+    max_dwell: float = Property(default=np.inf)
+
+    rpm: float = Property(
+        doc="The number of antenna rotations per minute (RPM)")
+    resolution: Angle = Property(
+        default=Angle(np.radians(1)),
+        doc="Resolution of the dwell_centre. Used by the :class:`~.DwellActionsGenerator` "
+            "during sensor management.")
+
+    @property
+    def _rotation_offset(self):
+        orientation = self.orientation
+        if orientation is None:
+            orientation = StateVector([0, 0, 0])
+        return orientation + StateVector([0, 0, self.dwell_centre[0, 0]])
+
+
+class VisibilityInformed2DSensor(Generic2DSensor):
     """The base class of 2D sensors that evaluate the visibility of
     targets in known cluttered environments. Two different techniques
     are adopted for visibility checking. The first is a ray casting
@@ -449,147 +605,6 @@ class VisibilityInformed2DSensor(SimpleSensor):
         return intersections
 
 
-class Generic2DSensor(VisibilityInformed2DSensor):
-    """
-    Generic :class:`~.SimpleSensor` implementation which takes a 2D input truth state and produces
-    measurements using a desired measurement model.
-    """
-    measurement_model_class: MeasurementModel = Property(
-        default=CartesianToBearingRange,
-        doc="The :class:`stonesoup.models.measurement.MeasurementModel` desired to make"
-            "measurements")
-    ndim_state: int = Property(
-        default=2,
-        doc="Number of state dimensions. This is utilised by (and follows in format) "
-            "the underlying measurement model")
-    position_mapping: tuple[int, int] = Property(
-        doc="Mapping between the target's state space and the sensor's "
-            "measurement capability")
-    velocity_mapping: tuple[int, int] = Property(default=None)
-    noise_covar: CovarianceMatrix = Property(
-        doc="The sensor noise covariance matrix. This is utilised by "
-            "(and follows in format) the underlying measurement model")
-
-    min_range: float = Property(default=0,
-                                doc="The minimum detection range of the radar (in meters)")
-    max_range: float = Property(default=np.inf,
-                                doc="The maximum detection range of the radar (in meters)")
-    fov_angle: float = Property(default=2*np.pi)
-
-    dwell_centre: StateVector = ActionableProperty(
-        doc="A `state_vector` property that describes the rotation angle of the centre of the "
-            "sensor's current FOV (i.e. the dwell centre) relative to the positive x-axis of the "
-            "sensor frame/orientation. The angle is positive if the rotation is in the "
-            "counter-clockwise direction when viewed by an observer looking down the z-axis of "
-            "the sensor frame, towards the origin. Angle units are in radians",
-        generator_cls=StationaryDwellActionsGenerator,
-        generator_kwargs_mapping={"rpm": "rpm", "resolution": "resolution",
-                                  "min_angle": "min_dwell", "max_angle": "max_dwell"})
-    min_dwell: float = Property(default=-np.inf)
-    max_dwell: float = Property(default=np.inf)
-
-    rpm: float = Property(
-        doc="The number of antenna rotations per minute (RPM)")
-    resolution: Angle = Property(
-        default=Angle(np.radians(1)),
-        doc="Resolution of the dwell_centre. Used by the :class:`~.DwellActionsGenerator` "
-            "during sensor management.")
-
-    def create_measurement_model(self, measurement_model=None, check_visibility=False
-                                 ) -> MeasurementModel:
-        """Method to generate a measurement model using the sensor's attributes
-
-        Parameters
-        ----------
-        measurement_model : MeasurementModel, optional
-            Measurement model to produce new model from, by default None
-        check_visibility : bool, optional
-            Boolean dictating whether this model is being used to check visibility,
-            by default False
-
-        Returns
-        -------
-        MeasurementModel
-        """
-
-        if measurement_model is None:
-            model_class = self.measurement_model_class
-            ndim_state = self.ndim_state
-            mapping = self.position_mapping
-            noise_covar = self.noise_covar
-            translation_offset = self.position
-            orientation = self.orientation
-            if orientation is None:
-                orientation = StateVector([0, 0, 0])
-            rotation_offset = StateVector([[orientation[0, 0]],
-                                           [orientation[1, 0]],
-                                           [orientation[2, 0] + self.dwell_centre[0, 0]]])
-            velocity_mapping = self.velocity_mapping
-            velocity = self.velocity
-        else:
-            model_class = type(measurement_model)
-            ndim_state = measurement_model.ndim_state
-            mapping = measurement_model.mapping
-            noise_covar = measurement_model.noise_covar
-            translation_offset = getattr(measurement_model, "translation_offset", None)
-            rotation_offset = getattr(measurement_model, "rotation_offset", None)
-            velocity_mapping = getattr(measurement_model, "velocity_mapping", None)
-            velocity = getattr(measurement_model, "velocity", None)
-
-        if check_visibility:
-            model_class = CartesianToBearingRange
-        if isinstance(model_class, LinearGaussian):
-            if self.velocity_mapping is not None and measurement_model is None:
-                mapping = tuple(*self.position_mapping, *self.velocity_mapping)
-            return LinearGaussian(ndim_state=ndim_state,
-                                  mapping=mapping,
-                                  noise_covar=self.noise_covar)
-        model = model_class(ndim_state=ndim_state,
-                            mapping=mapping,
-                            noise_covar=noise_covar,
-                            translation_offset=translation_offset,
-                            rotation_offset=rotation_offset)
-        model.velocity_mapping = velocity_mapping
-        model.velocity = velocity
-        return model
-
-    @property
-    def measurement_model(self):
-        return self.create_measurement_model()
-
-    def measure(self, ground_truths: set[GroundTruthState], noise: Union[np.ndarray, bool] = True,
-                **kwargs) -> set[TrueDetection]:
-
-        if self.timestamp is None:
-            # Read timestamp from ground truth
-            try:
-                self.timestamp = next(iter(ground_truths)).timestamp
-            except StopIteration:
-                # No ground truths to get timestamp from
-                return set()
-
-        return super().measure(ground_truths, noise, **kwargs)
-
-    def is_detectable(self, state, measurement_model=None):
-        measurement_model = self.create_measurement_model(measurement_model=measurement_model,
-                                                          check_visibility=True)
-        measurement_vector = measurement_model.function(state, noise=False)
-        return self._is_detectable(measurement_vector) & self.is_visible(state)
-
-    # TODO: Need way of making this method generic.
-    # Clutter is in measurement model state space and therefore the indices of e, b and r are not set
-    def is_clutter_detectable(self, state: Detection) -> bool:
-        measurement_vector = state.state_vector
-        return self._is_detectable(measurement_vector)
-
-    def _is_detectable(self, measurement_vector: StateVector) -> bool:
-        fov_min = -self.fov_angle / 2
-        fov_max = +self.fov_angle / 2
-
-        bearing_t = measurement_vector[0, :]
-        true_range = measurement_vector[1, :]
-        return (np.logical_and(fov_min <= bearing_t, bearing_t <= fov_max) &
-                np.logical_and(self.min_range <= true_range, true_range <= self.max_range))
 
 
 class Generic3DSensor(Generic2DSensor):
@@ -605,13 +620,6 @@ class Generic3DSensor(Generic2DSensor):
     velocity_mapping: tuple[int, int, int] = Property(default=None)
 
     vertical_extent: float = Property(default=np.pi)
-    tilt_centre: StateVector = ActionableProperty(
-        generator_cls=TiltActionsGenerator,
-        generator_kwargs_mapping={"rpm": "rpm", "resolution": "resolution",
-                                  "min_angle": "min_tilt", "max_angle": "max_tilt"}
-    )
-    min_tilt: float = Property(default=-np.pi/2)
-    max_tilt: float = Property(default=np.pi/2)
 
     def create_measurement_model(self, measurement_model=None, check_visibility=False):
         """Method to generate a measurement model using the sensor's attributes
@@ -634,12 +642,7 @@ class Generic3DSensor(Generic2DSensor):
             mapping = self.position_mapping
             noise_covar = self.noise_covar
             translation_offset = self.position
-            orientation = self.orientation
-            if orientation is None:
-                orientation = StateVector([0, 0, 0])
-            rotation_offset = StateVector([[orientation[0, 0]],
-                                           [orientation[1, 0] + self.tilt_centre[0, 0]],
-                                           [orientation[2, 0] + self.dwell_centre[0, 0]]])
+            rotation_offset = self._rotation_offset
             velocity_mapping = self.velocity_mapping
             velocity = self.velocity
         else:
@@ -647,8 +650,9 @@ class Generic3DSensor(Generic2DSensor):
             ndim_state = measurement_model.ndim_state
             mapping = measurement_model.mapping
             noise_covar = measurement_model.noise_covar
-            translation_offset = getattr(measurement_model, "translation_offset", None)
-            rotation_offset = getattr(measurement_model, "rotation_offset", None)
+            translation_offset = getattr(measurement_model, "translation_offset",
+                                         StateVector([0, 0, 0]))
+            rotation_offset = getattr(measurement_model, "rotation_offset", StateVector([0, 0, 0]))
             velocity_mapping = getattr(measurement_model, "velocity_mapping", None)
             velocity = getattr(measurement_model, "velocity", None)
 
@@ -670,12 +674,6 @@ class Generic3DSensor(Generic2DSensor):
         model.velocity = velocity
         return model
 
-    def is_detectable(self, state, measurement_model=None):
-        measurement_model = self.create_measurement_model(measurement_model=measurement_model,
-                                                          check_visibility=True)
-        measurement_vector = measurement_model.function(state, noise=False)
-        return self._is_detectable(measurement_vector)
-
     def _is_detectable(self, measurement_vector: StateVector) -> bool:
         ver_min = -self.vertical_extent / 2
         ver_max = +self.vertical_extent / 2
@@ -689,3 +687,20 @@ class Generic3DSensor(Generic2DSensor):
         return (np.logical_and(ver_min <= elevation_t, elevation_t <= ver_max) &
                 np.logical_and(fov_min <= bearing_t, bearing_t <= fov_max) &
                 np.logical_and(self.min_range <= true_range, true_range <= self.max_range))
+
+
+class Rotating3DSensor(Generic3DSensor, Rotating2DSensor):
+    tilt_centre: StateVector = ActionableProperty(
+        generator_cls=TiltActionsGenerator,
+        generator_kwargs_mapping={"rpm": "rpm", "resolution": "resolution",
+                                  "min_angle": "min_tilt", "max_angle": "max_tilt"}
+    )
+    min_tilt: float = Property(default=-np.pi/2)
+    max_tilt: float = Property(default=np.pi/2)
+
+    @property
+    def _rotation_offset(self):
+        orientation = self.orientation
+        if orientation is None:
+            orientation = StateVector([0, 0, 0])
+        return orientation + StateVector([0, self.tilt_centre[0, 0], self.dwell_centre[0, 0]])

--- a/stonesoup/sensor/sensor.py
+++ b/stonesoup/sensor/sensor.py
@@ -15,6 +15,7 @@ import numpy as np
 from .base import PlatformMountable
 from .action.dwell_action import StationaryDwellActionsGenerator
 from .action.tilt_action import TiltActionsGenerator
+from .detection_probability import DetectionProbability, ConstantDetectionProbability
 from ..base import Property
 from ..models.clutter.clutter import ClutterModel
 from ..models.measurement import MeasurementModel
@@ -605,6 +606,70 @@ class VisibilityInformed2DSensor(Generic2DSensor):
         return intersections
 
 
+class ProbabilityOfDetectionSensor(Generic2DSensor):
+    probability_of_detection: DetectionProbability = Property(
+        default_factory=ConstantDetectionProbability,
+        doc="A :class:`.DetectionProbability` used to determine the probability of making a "
+            "detection of a given target"
+    )
+
+    def measure(self, ground_truths: set[GroundTruthState], noise: Union[np.ndarray, bool] = True,
+                random_state=None, **kwargs) -> set[TrueDetection]:
+        if self.timestamp is None:
+            try:
+                self.timestamp = next(iter(ground_truths)).timestamp
+            except StopIteration:
+                return set()
+
+        measurement_model = self.measurement_model
+        p_d_measurement_model = self.create_measurement_model(check_visibility=True)
+
+        detectable_ground_truths = [truth for truth in ground_truths
+                                    if self.is_detectable(truth, measurement_model)]
+        random_state = random_state if random_state is not None else self.random_state
+
+        if noise is True:
+            if len(detectable_ground_truths) > 1:
+                noise_vectors_iter = iter(measurement_model.rvs(len(detectable_ground_truths),
+                                                                random_state=random_state,
+                                                                **kwargs))
+            else:
+                noise_vectors_iter = iter([measurement_model.rvs(random_state=random_state,
+                                                                 **kwargs)])
+
+        random_state = random_state if random_state is not None else np.random
+        detections = set()
+        for truth in detectable_ground_truths:
+            p_d = self.probability_of_detection(
+                p_d_measurement_model.function(truth, noise=False, **kwargs))
+            if random_state.random() > p_d:
+                continue
+
+            measurement_vector = measurement_model.function(truth, noise=False, **kwargs)
+
+            if noise is True:
+                measurement_noise = next(noise_vectors_iter)
+            else:
+                measurement_noise = noise
+
+            # Add in measurement noise to the measurement vector
+            measurement_vector += measurement_noise
+
+            detection = TrueDetection(measurement_vector,
+                                      measurement_model=measurement_model,
+                                      timestamp=truth.timestamp,
+                                      groundtruth_path=truth)
+            detections.add(detection)
+
+        # Generate clutter at this time step
+        if self.clutter_model is not None:
+            self.clutter_model.measurement_model = measurement_model
+            clutter = self.clutter_model.function(ground_truths)
+            detectable_clutter = [cltr for cltr in clutter
+                                  if self.is_clutter_detectable(cltr)]
+            detections = set.union(detections, detectable_clutter)
+
+        return detections
 
 
 class Generic3DSensor(Generic2DSensor):

--- a/stonesoup/sensor/sensor.py
+++ b/stonesoup/sensor/sensor.py
@@ -13,9 +13,17 @@ except ImportError:
 import numpy as np
 
 from .base import PlatformMountable
-from ..sensormanager.action import Actionable
+from .action.dwell_action import StationaryDwellActionsGenerator
+from .action.tilt_action import TiltActionsGenerator
 from ..base import Property
 from ..models.clutter.clutter import ClutterModel
+from ..models.measurement import MeasurementModel
+from ..models.measurement.nonlinear import (CartesianToBearingRange,
+                                            CartesianToElevationBearingRange)
+from ..models.measurement.linear import LinearGaussian
+from ..sensormanager.action import Actionable, ActionableProperty
+from ..types.angle import Angle
+from ..types.array import CovarianceMatrix
 from ..types.detection import TrueDetection, Detection
 from ..types.groundtruth import GroundTruthState
 from ..types.state import ParticleState, State, StateVector
@@ -439,3 +447,245 @@ class VisibilityInformed2DSensor(SimpleSensor):
                                                          beta <= 1))
 
         return intersections
+
+
+class Generic2DSensor(VisibilityInformed2DSensor):
+    """
+    Generic :class:`~.SimpleSensor` implementation which takes a 2D input truth state and produces
+    measurements using a desired measurement model.
+    """
+    measurement_model_class: MeasurementModel = Property(
+        default=CartesianToBearingRange,
+        doc="The :class:`stonesoup.models.measurement.MeasurementModel` desired to make"
+            "measurements")
+    ndim_state: int = Property(
+        default=2,
+        doc="Number of state dimensions. This is utilised by (and follows in format) "
+            "the underlying measurement model")
+    position_mapping: tuple[int, int] = Property(
+        doc="Mapping between the target's state space and the sensor's "
+            "measurement capability")
+    velocity_mapping: tuple[int, int] = Property(default=None)
+    noise_covar: CovarianceMatrix = Property(
+        doc="The sensor noise covariance matrix. This is utilised by "
+            "(and follows in format) the underlying measurement model")
+
+    min_range: float = Property(default=0,
+                                doc="The minimum detection range of the radar (in meters)")
+    max_range: float = Property(default=np.inf,
+                                doc="The maximum detection range of the radar (in meters)")
+    fov_angle: float = Property(default=2*np.pi)
+
+    dwell_centre: StateVector = ActionableProperty(
+        doc="A `state_vector` property that describes the rotation angle of the centre of the "
+            "sensor's current FOV (i.e. the dwell centre) relative to the positive x-axis of the "
+            "sensor frame/orientation. The angle is positive if the rotation is in the "
+            "counter-clockwise direction when viewed by an observer looking down the z-axis of "
+            "the sensor frame, towards the origin. Angle units are in radians",
+        generator_cls=StationaryDwellActionsGenerator,
+        generator_kwargs_mapping={"rpm": "rpm", "resolution": "resolution",
+                                  "min_angle": "min_dwell", "max_angle": "max_dwell"})
+    min_dwell: float = Property(default=-np.inf)
+    max_dwell: float = Property(default=np.inf)
+
+    rpm: float = Property(
+        doc="The number of antenna rotations per minute (RPM)")
+    resolution: Angle = Property(
+        default=Angle(np.radians(1)),
+        doc="Resolution of the dwell_centre. Used by the :class:`~.DwellActionsGenerator` "
+            "during sensor management.")
+
+    def create_measurement_model(self, measurement_model=None, check_visibility=False
+                                 ) -> MeasurementModel:
+        """Method to generate a measurement model using the sensor's attributes
+
+        Parameters
+        ----------
+        measurement_model : MeasurementModel, optional
+            Measurement model to produce new model from, by default None
+        check_visibility : bool, optional
+            Boolean dictating whether this model is being used to check visibility,
+            by default False
+
+        Returns
+        -------
+        MeasurementModel
+        """
+
+        if measurement_model is None:
+            model_class = self.measurement_model_class
+            ndim_state = self.ndim_state
+            mapping = self.position_mapping
+            noise_covar = self.noise_covar
+            translation_offset = self.position
+            orientation = self.orientation
+            if orientation is None:
+                orientation = StateVector([0, 0, 0])
+            rotation_offset = StateVector([[orientation[0, 0]],
+                                           [orientation[1, 0]],
+                                           [orientation[2, 0] + self.dwell_centre[0, 0]]])
+            velocity_mapping = self.velocity_mapping
+            velocity = self.velocity
+        else:
+            model_class = type(measurement_model)
+            ndim_state = measurement_model.ndim_state
+            mapping = measurement_model.mapping
+            noise_covar = measurement_model.noise_covar
+            translation_offset = getattr(measurement_model, "translation_offset", None)
+            rotation_offset = getattr(measurement_model, "rotation_offset", None)
+            velocity_mapping = getattr(measurement_model, "velocity_mapping", None)
+            velocity = getattr(measurement_model, "velocity", None)
+
+        if check_visibility:
+            model_class = CartesianToBearingRange
+        if isinstance(model_class, LinearGaussian):
+            if self.velocity_mapping is not None and measurement_model is None:
+                mapping = tuple(*self.position_mapping, *self.velocity_mapping)
+            return LinearGaussian(ndim_state=ndim_state,
+                                  mapping=mapping,
+                                  noise_covar=self.noise_covar)
+        model = model_class(ndim_state=ndim_state,
+                            mapping=mapping,
+                            noise_covar=noise_covar,
+                            translation_offset=translation_offset,
+                            rotation_offset=rotation_offset)
+        model.velocity_mapping = velocity_mapping
+        model.velocity = velocity
+        return model
+
+    @property
+    def measurement_model(self):
+        return self.create_measurement_model()
+
+    def measure(self, ground_truths: set[GroundTruthState], noise: Union[np.ndarray, bool] = True,
+                **kwargs) -> set[TrueDetection]:
+
+        if self.timestamp is None:
+            # Read timestamp from ground truth
+            try:
+                self.timestamp = next(iter(ground_truths)).timestamp
+            except StopIteration:
+                # No ground truths to get timestamp from
+                return set()
+
+        return super().measure(ground_truths, noise, **kwargs)
+
+    def is_detectable(self, state, measurement_model=None):
+        measurement_model = self.create_measurement_model(measurement_model=measurement_model,
+                                                          check_visibility=True)
+        measurement_vector = measurement_model.function(state, noise=False)
+        return self._is_detectable(measurement_vector) & self.is_visible(state)
+
+    # TODO: Need way of making this method generic.
+    # Clutter is in measurement model state space and therefore the indices of e, b and r are not set
+    def is_clutter_detectable(self, state: Detection) -> bool:
+        measurement_vector = state.state_vector
+        return self._is_detectable(measurement_vector)
+
+    def _is_detectable(self, measurement_vector: StateVector) -> bool:
+        fov_min = -self.fov_angle / 2
+        fov_max = +self.fov_angle / 2
+
+        bearing_t = measurement_vector[0, :]
+        true_range = measurement_vector[1, :]
+        return (np.logical_and(fov_min <= bearing_t, bearing_t <= fov_max) &
+                np.logical_and(self.min_range <= true_range, true_range <= self.max_range))
+
+
+class Generic3DSensor(Generic2DSensor):
+    """
+    Generic :class:`~.SimpleSensor` implementation which takes a 3D input truth state and produces
+    measurements using a desired measurement model.
+    """
+    measurement_model_class: MeasurementModel = Property(default=CartesianToElevationBearingRange)
+    ndim_state: int = Property(
+        default=3
+    )
+    position_mapping: tuple[int, int, int] = Property()
+    velocity_mapping: tuple[int, int, int] = Property(default=None)
+
+    vertical_extent: float = Property(default=np.pi)
+    tilt_centre: StateVector = ActionableProperty(
+        generator_cls=TiltActionsGenerator,
+        generator_kwargs_mapping={"rpm": "rpm", "resolution": "resolution",
+                                  "min_angle": "min_tilt", "max_angle": "max_tilt"}
+    )
+    min_tilt: float = Property(default=-np.pi/2)
+    max_tilt: float = Property(default=np.pi/2)
+
+    def create_measurement_model(self, measurement_model=None, check_visibility=False):
+        """Method to generate a measurement model using the sensor's attributes
+
+        Parameters
+        ----------
+        measurement_model : MeasurementModel, optional
+            Measurement model to produce new model from, by default None
+        check_visibility : bool, optional
+            Boolean dictating whether this model is being used to check visibility,
+            by default False
+
+        Returns
+        -------
+        MeasurementModel
+        """
+        if measurement_model is None:
+            model_class = self.measurement_model_class
+            ndim_state = self.ndim_state
+            mapping = self.position_mapping
+            noise_covar = self.noise_covar
+            translation_offset = self.position
+            orientation = self.orientation
+            if orientation is None:
+                orientation = StateVector([0, 0, 0])
+            rotation_offset = StateVector([[orientation[0, 0]],
+                                           [orientation[1, 0] + self.tilt_centre[0, 0]],
+                                           [orientation[2, 0] + self.dwell_centre[0, 0]]])
+            velocity_mapping = self.velocity_mapping
+            velocity = self.velocity
+        else:
+            model_class = type(measurement_model)
+            ndim_state = measurement_model.ndim_state
+            mapping = measurement_model.mapping
+            noise_covar = measurement_model.noise_covar
+            translation_offset = getattr(measurement_model, "translation_offset", None)
+            rotation_offset = getattr(measurement_model, "rotation_offset", None)
+            velocity_mapping = getattr(measurement_model, "velocity_mapping", None)
+            velocity = getattr(measurement_model, "velocity", None)
+
+        if check_visibility:
+            model_class = CartesianToElevationBearingRange
+        if issubclass(model_class, LinearGaussian):
+            mapping = self.position_mapping
+            if self.velocity_mapping is not None and measurement_model is None:
+                mapping = tuple(*self.position_mapping, *self.velocity_mapping)
+            return LinearGaussian(ndim_state=self.ndim_state,
+                                  mapping=mapping,
+                                  noise_covar=self.noise_covar)
+        model = model_class(ndim_state=ndim_state,
+                            mapping=mapping,
+                            noise_covar=noise_covar,
+                            translation_offset=translation_offset,
+                            rotation_offset=rotation_offset)
+        model.velocity_mapping = velocity_mapping
+        model.velocity = velocity
+        return model
+
+    def is_detectable(self, state, measurement_model=None):
+        measurement_model = self.create_measurement_model(measurement_model=measurement_model,
+                                                          check_visibility=True)
+        measurement_vector = measurement_model.function(state, noise=False)
+        return self._is_detectable(measurement_vector)
+
+    def _is_detectable(self, measurement_vector: StateVector) -> bool:
+        ver_min = -self.vertical_extent / 2
+        ver_max = +self.vertical_extent / 2
+
+        fov_min = -self.fov_angle / 2
+        fov_max = +self.fov_angle / 2
+
+        elevation_t = measurement_vector[0, :]
+        bearing_t = measurement_vector[1, :]
+        true_range = measurement_vector[2, :]
+        return (np.logical_and(ver_min <= elevation_t, elevation_t <= ver_max) &
+                np.logical_and(fov_min <= bearing_t, bearing_t <= fov_max) &
+                np.logical_and(self.min_range <= true_range, true_range <= self.max_range))

--- a/stonesoup/sensor/sensor.py
+++ b/stonesoup/sensor/sensor.py
@@ -284,9 +284,9 @@ class Generic2DSensor(SimpleSensor):
 
         if check_visibility:
             model_class = CartesianToBearingRange
-        if isinstance(model_class, LinearGaussian):
+        if issubclass(model_class, LinearGaussian):
             if self.velocity_mapping is not None and measurement_model is None:
-                mapping = tuple(*self.position_mapping, *self.velocity_mapping)
+                mapping = tuple([*self.position_mapping, *self.velocity_mapping])
             return LinearGaussian(ndim_state=ndim_state,
                                   mapping=mapping,
                                   noise_covar=self.noise_covar)
@@ -726,7 +726,7 @@ class Generic3DSensor(Generic2DSensor):
         if issubclass(model_class, LinearGaussian):
             mapping = self.position_mapping
             if self.velocity_mapping is not None and measurement_model is None:
-                mapping = tuple(*self.position_mapping, *self.velocity_mapping)
+                mapping = tuple([*self.position_mapping, *self.velocity_mapping])
             return LinearGaussian(ndim_state=self.ndim_state,
                                   mapping=mapping,
                                   noise_covar=self.noise_covar)

--- a/stonesoup/sensor/tests/test_sensor.py
+++ b/stonesoup/sensor/tests/test_sensor.py
@@ -5,7 +5,8 @@ import pytest
 
 from ...models.measurement.linear import LinearGaussian
 from ...models.measurement.nonlinear import CartesianToBearingRange, \
-    CartesianToElevationBearingRange
+    CartesianToElevationBearingRange, Cartesian2DToBearing, CartesianToElevationBearing, \
+    CartesianToBearingRangeRate2D, CartesianToElevationRateBearingRateRangeRate
 from ...movable import FixedMovable
 from ..radar.radar import RadarElevationBearingRangeRate, RadarBearingRange, \
     RadarElevationBearingRange
@@ -13,7 +14,7 @@ from ...platform import FixedPlatform
 from ...types.detection import Detection
 from ...types.groundtruth import GroundTruthPath, GroundTruthState
 from ..base import PlatformMountable
-from ..sensor import Sensor, SensorSuite, SimpleSensor
+from ..sensor import Sensor, SensorSuite, SimpleSensor, Generic2DSensor, Generic3DSensor
 from ...types.array import StateVector, CovarianceMatrix
 from ...types.state import State
 
@@ -262,3 +263,99 @@ def test_informative():
         else:
             assert np.allclose(metadata_position, position2.state_vector[(0, 2, 3), :])
             assert np.allclose(metadata_orientation, orientation2)
+
+
+@pytest.mark.parametrize("measurement_model_class", [CartesianToBearingRange, LinearGaussian,
+                                                     Cartesian2DToBearing])
+def test_generic_sensor_2d(measurement_model_class):
+    sensor = Generic2DSensor(measurement_model_class=measurement_model_class,
+                             ndim_state=4,
+                             position_mapping=(0, 2),
+                             noise_covar=np.diag([1, 1]),
+                             min_range=10,
+                             max_range=100,
+                             fov_angle=np.pi/6)
+    measurement_model = sensor.measurement_model
+    assert isinstance(measurement_model, measurement_model_class)
+    assert measurement_model.ndim_state == 4
+    assert measurement_model.mapping == (0, 2)
+    assert np.all(measurement_model.noise_covar == np.diag([1, 1]))
+
+    target_short = State([1, 0, 0, 0])
+    target_long = State([101, 0, 0, 0])
+    target_left = State([0, 0, 50, 0])
+    target_right = State([0, 0, -50, 0])
+    target_centre = State([50, 0, 0, 0])
+
+    assert not sensor.is_detectable(target_short)
+    assert not sensor.is_detectable(target_long)
+    assert not sensor.is_detectable(target_left)
+    assert not sensor.is_detectable(target_right)
+    assert sensor.is_detectable(target_centre)
+
+
+@pytest.mark.parametrize("measurement_model_class", [CartesianToElevationBearingRange,
+                                                     LinearGaussian,
+                                                     CartesianToElevationBearing])
+def test_generic_sensor_3d(measurement_model_class):
+    sensor = Generic3DSensor(measurement_model_class=measurement_model_class,
+                             ndim_state=6,
+                             position_mapping=(0, 2, 4),
+                             noise_covar=np.diag([1, 1, 1]),
+                             min_range=10,
+                             max_range=100,
+                             fov_angle=np.pi/6,
+                             vertical_extent=np.pi/6)
+    measurement_model = sensor.measurement_model
+    assert isinstance(measurement_model, measurement_model_class)
+    assert measurement_model.ndim_state == 6
+    assert measurement_model.mapping == (0, 2, 4)
+    assert np.all(measurement_model.noise_covar == np.diag([1, 1, 1]))
+
+    target_short = State([1, 0, 0, 0, 0, 0])
+    target_long = State([101, 0, 0, 0, 0, 0])
+    target_left = State([0, 0, 50, 0, 0, 0])
+    target_right = State([0, 0, -50, 0, 0, 0])
+    target_up = State([0, 0, 0, 0, 50, 0])
+    target_down = State([0, 0, 0, 0, -50, 0])
+    target_centre = State([50, 0, 0, 0, 0, 0])
+
+    assert not sensor.is_detectable(target_short)
+    assert not sensor.is_detectable(target_long)
+    assert not sensor.is_detectable(target_left)
+    assert not sensor.is_detectable(target_right)
+    assert not sensor.is_detectable(target_up)
+    assert not sensor.is_detectable(target_down)
+    assert sensor.is_detectable(target_centre)
+
+
+@pytest.mark.parametrize("measurement_model_class", [CartesianToBearingRangeRate2D,
+                                                     LinearGaussian])
+def test_generic_sensor_2d_velocity(measurement_model_class):
+    sensor = Generic2DSensor(measurement_model_class=measurement_model_class,
+                             ndim_state=4,
+                             position_mapping=(0, 2),
+                             velocity_mapping=(1, 3),
+                             noise_covar=np.diag([1, 1, 1, 1]))
+    measurement_model = sensor.measurement_model
+    if isinstance(measurement_model, LinearGaussian):
+        assert measurement_model.mapping == (0, 2, 1, 3)
+    else:
+        assert measurement_model.mapping == (0, 2)
+        assert measurement_model.velocity_mapping == (1, 3)
+
+
+@pytest.mark.parametrize("measurement_model_class", [CartesianToElevationRateBearingRateRangeRate,
+                                                     LinearGaussian])
+def test_generic_sensor_3d_velocity(measurement_model_class):
+    sensor = Generic2DSensor(measurement_model_class=measurement_model_class,
+                             ndim_state=6,
+                             position_mapping=(0, 2, 4),
+                             velocity_mapping=(1, 3, 5),
+                             noise_covar=np.diag([1, 1, 1, 1, 1, 1]))
+    measurement_model = sensor.measurement_model
+    if isinstance(measurement_model, LinearGaussian):
+        assert measurement_model.mapping == (0, 2, 4, 1, 3, 5)
+    else:
+        assert measurement_model.mapping == (0, 2, 4)
+        assert measurement_model.velocity_mapping == (1, 3, 5)

--- a/stonesoup/serialise.py
+++ b/stonesoup/serialise.py
@@ -44,7 +44,7 @@ import numpy as np
 import ruamel.yaml
 from ruamel.yaml.constructor import ConstructorError
 
-from .base import Base, Property
+from .base import Base, Property, BaseMeta
 from .types.angle import Angle
 from .types.array import Matrix, StateVector
 from .types.numeric import Probability
@@ -94,6 +94,9 @@ def init_typ(yaml):
     # Declarative classes
     yaml.representer.add_multi_representer(Base, declarative_to_yaml)
     yaml.constructor.add_multi_constructor('!stonesoup.', declarative_from_yaml)
+
+    yaml.representer.add_representer(BaseMeta, basemeta_to_yaml)
+    yaml.constructor.add_constructor("!class", basemeta_from_yaml)
 
 
 class YAML(ruamel.yaml.YAML):
@@ -267,3 +270,16 @@ def deque_from_yaml(constructor, node):
     """Convert YAML to collections.deque"""
     iterable, maxlen = constructor.construct_sequence(node, deep=True)
     return deque(iterable, maxlen)
+
+
+def basemeta_to_yaml(representer, node):
+    return representer.represent_scalar(
+        "!class", f"{node.__module__}.{node.__qualname__}"
+    )
+
+
+def basemeta_from_yaml(constructor, node):
+    path = constructor.construct_scalar(node)
+    module_name, class_name = path.rsplit(".", 1)
+    module = import_module(module_name)
+    return getattr(module, class_name)

--- a/stonesoup/tests/test_serialise.py
+++ b/stonesoup/tests/test_serialise.py
@@ -289,6 +289,15 @@ def test_sensor_serialisation(serialised_file):
     assert np.allclose(sensor.orientation, orientation)
 
 
+def test_basemeta_serialisation(serialised_file):
+    data = TestSensor
+    serialised_str = serialised_file.dumps(data)
+    recovered_data = serialised_file.load(serialised_str)
+    assert data == recovered_data
+    sensor = recovered_data()
+    assert isinstance(sensor, TestSensor)
+
+
 def test_dump(tmpdir, serialised_file):
     data = [1, 2, 3]
     with open(tmpdir.join('dump_file.yml'), 'w') as yaml_file:


### PR DESCRIPTION
Currently all the sensor models in Stone Soup are "Radar" Models with a lot of common logic to produce the measurement models and check if targets are visible.
This PR introduces "generic" sensor models for the 2D and 3D sensor which take in a Measurement Model Type to produce detections from.
Each of the Current Radar... Models have been Refactored to use these base classes in a way such that the functionality should remain identical.

Things to add to move this from draft:
- `is_clutter_detectable`: As clutter measurements are produced in the measurement space and then checked for if they are detectable it is harder to generalise this check across different sensor models. This will currently break if a non default measurement model is used due to the different measurement space
- type `class` is not serialisable by default and so storing a `GenericSensor` in a YAML file does not work  