### PR TITLE
Fix init_metadata not being shallow copied in Tracks

### DIFF
--- a/stonesoup/types/tests/test_track.py
+++ b/stonesoup/types/tests/test_track.py
@@ -235,7 +235,7 @@ def test_copy():
 
     assert track is not copied_track
     assert track.states is not copied_track.states
-    assert track.init_metadata is copied_track.init_metadata
+    assert track.init_metadata is not copied_track.init_metadata
     assert track.metadatas is not copied_track.metadatas
 
     for original_state, copied_state in zip(track.states, copied_track.states):
@@ -253,3 +253,10 @@ def test_copy():
 
     assert len(track.metadatas) == 3
     assert len(copied_track.metadatas) == 4
+
+    empty_track = Track()
+    empty_track.metadata['test'] = 10
+
+    copied_track = copy.copy(empty_track)
+    copied_track.metadata['test'] = 20
+    assert empty_track.metadata['test'] == 10

--- a/stonesoup/types/track.py
+++ b/stonesoup/types/track.py
@@ -46,6 +46,8 @@ class Track(StateMutableSequence):
 
     def __copy__(self):
         inst = super().__copy__()
+        init_metadata_name = type(self).init_metadata._property_name
+        inst.__dict__[init_metadata_name] = copy.copy(self.__dict__[init_metadata_name])
         inst.__dict__['metadatas'] = list(copy.copy(md) for md in self.__dict__['metadatas'])
         return inst
 


### PR DESCRIPTION
Initial track metadata wasn't shallow copied, causing unexpected changing on metadata on copied tracks in case of empty track.