### PR TITLE
Angle based measures

### DIFF
--- a/stonesoup/measures/state.py
+++ b/stonesoup/measures/state.py
@@ -548,12 +548,9 @@ class AngularDifference(Measure):
         state_vector1 = getattr(state1, "mean", state1.state_vector)
         state_vector2 = getattr(state2, "mean", state2.state_vector)
 
-        if self.mapping is not None:
-            angle1 = Angle(np.arctan2(*state_vector1[self.mapping, 0][::-1]))
-            angle2 = Angle(np.arctan2(*state_vector2[self.mapping, 0][::-1]))
-            return angle1 - angle2
-        else:
-            raise NotImplementedError('AngularDifference requires a mapping to be defined')
+        angle1 = Angle(np.arctan2(*state_vector1[self.mapping, 0][::-1]))
+        angle2 = Angle(np.arctan2(*state_vector2[self.mapping2, 0][::-1]))
+        return angle1 - angle2
 
 
 class AngularDifferenceWithLeftRightAmbiguity(AngularDifference):

--- a/stonesoup/measures/state.py
+++ b/stonesoup/measures/state.py
@@ -7,6 +7,7 @@ from scipy.spatial import distance
 
 from .base import BaseMeasure
 from ..base import Property
+from ..types.angle import Angle
 from ..types.state import State, ParticleState, GaussianState
 
 
@@ -506,3 +507,62 @@ class KLDivergence(Measure):
                                       'ParticleState or GaussianState types')
 
         return kld
+
+
+class AngularDifference(Measure):
+    r"""Angular Difference measure
+
+    This measure returns the difference in angles between a pair of :class:`~.State` objects.
+
+    The angular difference, :math:`\Delta\theta` between a pair of angles :math:`\theta_{1}` and
+    :math:`\theta_{2}` calculated from a mapping such as velocity is defined as:
+
+    .. math::
+        \theta_{1} = \arctan(\dot{y}_{1}, \dot{x}_{1}
+        \theta_{2} = \arctan(\dot{y}_{2}, \dot{x}_{2}
+        \Delta\theta = \theta_{1} - \theta_{2}
+    """
+
+    def __call__(self, state1, state2):
+        r"""Calculate the angular difference between a pair of state vectors
+
+        Parameters
+        ----------
+        state1 : :class:`~.State`
+        state2 : :class:`~.State`
+
+        Returns
+        -------
+        Angle
+            Angular difference between two input :class:`~.State`
+
+        """
+        state_vector1 = getattr(state1, "mean", state1.state_vector)
+        state_vector2 = getattr(state2, "mean", state2.state_vector)
+
+        if self.mapping is not None:
+            angle1 = Angle(np.arctan2(*state_vector1[self.mapping, 0][::-1]))
+            angle2 = Angle(np.arctan2(*state_vector2[self.mapping, 0][::-1]))
+            return angle1 - angle2
+        else:
+            raise NotImplementedError('AngularDifference requires a mapping to be defined')
+
+
+class AngularDifferenceWithLeftRightAmbiguity(AngularDifference):
+    r"""Angular Difference measure
+
+    This measure returns the difference in angles between a pair of :class:`~.State` objects with
+    :math:`180^{\degree}` ambiguity.
+
+    The angular difference with 180 ambiguity, :math:`\Delta\theta` between a pair of angles
+    :math:`\theta_{1}` and :math:`\theta_{2}` calculated from a mapping such as velocity is
+    defined as:
+
+    .. math::
+        \theta_{1} = \arctan(\dot{y}_{1}, \dot{x}_{1}
+        \theta_{2} = \arctan(\dot{y}_{2}, \dot{x}_{2}
+        \Delta\theta = \arcsin(|\sin(\theta_{1} - \theta_{2})|)
+    """
+    def __call__(self, state1, state2):
+        angle_diff = super().__call__(state1, state2)
+        return Angle(np.arcsin(np.abs(np.sin(angle_diff))))

--- a/stonesoup/measures/state.py
+++ b/stonesoup/measures/state.py
@@ -522,6 +522,14 @@ class AngularDifference(Measure):
         \theta_{2} = \arctan(\dot{y}_{2}, \dot{x}_{2}
         \Delta\theta = \theta_{1} - \theta_{2}
     """
+    mapping: np.ndarray = Property(
+        doc="Mapping array which specifies which elements within the"
+            " state vectors are to be used to calculate the heading.")
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if len(self.mapping) != 2:
+            raise IndexError("AngularDifference assumes 2 dimensions to calculate angle.")
 
     def __call__(self, state1, state2):
         r"""Calculate the angular difference between a pair of state vectors

--- a/stonesoup/measures/tests/test_state.py
+++ b/stonesoup/measures/tests/test_state.py
@@ -527,13 +527,8 @@ def test_angular_difference():
 
 
 def test_angular_difference_no_mapping():
-    state1 = State(StateVector([[1.], [0.]]))
-    state2 = State(StateVector([[0.], [1.]]))
-    measure = measures.AngularDifference()
-
-    assert measure.mapping is None
-    with pytest.raises(NotImplementedError):
-        measure(state1, state2)
+    with pytest.raises(TypeError):
+        measures.AngularDifference()
 
 
 def test_angular_difference_with_ambiguity():

--- a/stonesoup/measures/tests/test_state.py
+++ b/stonesoup/measures/tests/test_state.py
@@ -542,7 +542,7 @@ def test_angular_difference_with_ambiguity():
 
     assert isinstance(result1, Angle)
     assert isinstance(result2, Angle)
-    assert float(result2) == float(result2)
+    assert float(result1) == float(result2)
 
 
 def test_angular_difference_wrong_mapping():

--- a/stonesoup/measures/tests/test_state.py
+++ b/stonesoup/measures/tests/test_state.py
@@ -548,3 +548,8 @@ def test_angular_difference_with_ambiguity():
     assert isinstance(result1, Angle)
     assert isinstance(result2, Angle)
     assert float(result2) == float(result2)
+
+
+def test_angular_difference_wrong_mapping():
+    with pytest.raises(IndexError):
+        measures.AngularDifference(mapping=[1, 2, 3])

--- a/stonesoup/measures/tests/test_state.py
+++ b/stonesoup/measures/tests/test_state.py
@@ -7,6 +7,7 @@ from scipy.spatial import distance
 from scipy.stats import multivariate_normal
 
 from .. import state as measures
+from ...types.angle import Angle
 from ...types.array import StateVector, CovarianceMatrix, StateVectors
 from ...types.state import GaussianState, State, ParticleState, ASDState
 
@@ -512,3 +513,38 @@ def test_gaussian_kld_raise_errors():
 
     with pytest.raises(ValueError):
         measure(state1, state2)
+
+
+def test_angular_difference():
+    state1 = State(StateVector([[1.], [0.]]))
+    state2 = State(StateVector([[0.], [1.]]))
+    measure = measures.AngularDifference(mapping=[0, 1])
+
+    result = measure(state1, state2)
+
+    assert isinstance(result, Angle)
+    assert float(result) == pytest.approx(-np.pi / 2)
+
+
+def test_angular_difference_no_mapping():
+    state1 = State(StateVector([[1.], [0.]]))
+    state2 = State(StateVector([[0.], [1.]]))
+    measure = measures.AngularDifference()
+
+    assert measure.mapping is None
+    with pytest.raises(NotImplementedError):
+        measure(state1, state2)
+
+
+def test_angular_difference_with_ambiguity():
+    state = State(StateVector([0., 1.]))
+    state1 = State(StateVector([1., 1.]))
+    state2 = State(StateVector([-1., 1.]))
+    measure = measures.AngularDifferenceWithLeftRightAmbiguity(mapping=[0, 1])
+
+    result1 = measure(state, state1)
+    result2 = measure(state, state2)
+
+    assert isinstance(result1, Angle)
+    assert isinstance(result2, Angle)
+    assert float(result2) == float(result2)


### PR DESCRIPTION
This PR adds measures that focus on differences in angles by comparing the heading of one state with the heading of another. The options are `AngularDifference` that computes the angle difference between the two states, and `AngularDifferenceWithLeftRightAmbiguity` that calculates the absolute angle to the heading of `state2` from the heading of `state1` resulting in left-right ambiguity.