### PR TITLE
Fix deprecation errors and warnings in tests

### DIFF
--- a/stonesoup/functions/__init__.py
+++ b/stonesoup/functions/__init__.py
@@ -81,7 +81,7 @@ def grid_creation(xp_aux, Pp_aux, sFactor, nx, Npa):
 
     """
 
-    eigVal, eigVect = LA.eig(
+    eigVal, eigVect = LA.eigh(
         Pp_aux
     )  # eigenvalue and eigenvectors for setting up the grid
     gridBound = np.sqrt(eigVal) * sFactor  # Boundaries of grid

--- a/stonesoup/functions/tests/test_functions.py
+++ b/stonesoup/functions/tests/test_functions.py
@@ -48,7 +48,7 @@ def test_grid_creation():
 
     mean_diffs = np.array([np.mean(np.diff(sublist)) for sublist in gridDimOld])
 
-    eigVal, eigVect = LA.eig(varX0)
+    eigVect = np.real(LA.eig(varX0)[1])
 
     assert np.allclose(meanX0, np.mean(predGrid, axis=1), 0, atol=1.0e-1)
     assert np.all(meanX0 == xOld.ravel())

--- a/stonesoup/platform/tests/test_platform_simple.py
+++ b/stonesoup/platform/tests/test_platform_simple.py
@@ -308,7 +308,7 @@ expected_2d = [
 
 
 @pytest.mark.parametrize(
-    'state, expected', zip(testdata_2d, expected_2d),
+    'state, expected', list(zip(testdata_2d, expected_2d)),
     ids=["Static", "pos offset", "x vel", "y vel", "-x vel", "-y vel",
          "x,y vel", "-x,-y vel", "x,-y vel", "-x,y vel"])
 def test_2d_platform(state, expected, move, radars_2d,
@@ -541,8 +541,8 @@ def expected_orientations_2d():
 
 
 @pytest.mark.parametrize('state, expected_platform_orientation, expected_sensor_orientations',
-                         zip(*zip(*test_platform_base.orientation_tests_2d),
-                             expected_orientations_2d()))
+                         list(zip(*zip(*test_platform_base.orientation_tests_2d),
+                                  expected_orientations_2d())))
 def test_rotation_offsets_2d(state, expected_platform_orientation, expected_sensor_orientations,
                              move, radars_2d, rotation_offsets_2d):
     # Define time related variables
@@ -572,8 +572,8 @@ def test_rotation_offsets_2d(state, expected_platform_orientation, expected_sens
 
 
 @pytest.mark.parametrize('state, expected_platform_orientation, expected_sensor_orientations',
-                         zip(*zip(*test_platform_base.orientation_tests_3d),
-                             expected_orientations_3d()))
+                         list(zip(*zip(*test_platform_base.orientation_tests_3d),
+                                  expected_orientations_3d())))
 def test_rotation_offsets_3d(state, expected_platform_orientation, expected_sensor_orientations,
                              move, radars_3d, rotation_offsets_3d):
     # Define time related variables

--- a/stonesoup/tests/test_plotter.py
+++ b/stonesoup/tests/test_plotter.py
@@ -1,4 +1,3 @@
-import warnings
 from datetime import datetime, timedelta
 
 import matplotlib.pyplot as plt
@@ -237,6 +236,7 @@ def test_plot_density_equal_x_y():
         plotter.plot_density({truth}, index=None)
 
 
+@pytest.mark.filterwarnings("ignore:Animation was deleted without rendering anything")
 def test_animation_plotter():
     animation_plotter = AnimationPlotter()
     animation_plotter.plot_ground_truths(truth, [0, 2])
@@ -247,13 +247,6 @@ def test_animation_plotter():
     animation_plotter_with_title.plot_ground_truths(truth, [0, 2])
     animation_plotter_with_title.plot_tracks(track, [0, 2])
     animation_plotter_with_title.run()
-    with warnings.catch_warnings():
-        warnings.filterwarnings(
-            'ignore',
-            "Animation was deleted without rendering anything"
-        )
-        del animation_plotter
-        del animation_plotter_with_title
 
 
 def test_animated_plotterly():


### PR DESCRIPTION
Includes suppressing warning similar to issue in #1290 due to complex numbers now returned on newer versions of NumPy with eig