### PR TITLE
Fix broken MathJax equations

### DIFF
--- a/stonesoup/metricgenerator/tracktotruthmetrics.py
+++ b/stonesoup/metricgenerator/tracktotruthmetrics.py
@@ -59,6 +59,8 @@ class SIAPMetrics(MetricGenerator):
         r"""Compute metrics:
 
         .. math::
+            :no-wrap:
+
             \begin{alignat*}{3}
                 \textrm{Name} &\quad \textrm{At Time} &&\quad \textrm{TimeRange}\\
                 C &\quad \frac{JT({t})}{J({t})} &&\quad \frac{\sum_{t_{start}}^{t_{end}}JT({t})}
@@ -534,6 +536,8 @@ class IDSIAPMetrics(SIAPMetrics):
         r"""Compute metrics:
 
         .. math::
+            :no-wrap:
+
             \begin{alignat*}{3}
                 \textrm{Name} &\quad \textrm{At Time} &&\quad \textrm{TimeRange}\\
                 C &\quad \frac{JT({t})}{J({t})} &&\quad \frac{\sum_{t_{start}}^{t_{end}}JT({t})}

--- a/stonesoup/models/measurement/gas.py
+++ b/stonesoup/models/measurement/gas.py
@@ -49,6 +49,8 @@ class IsotropicPlume(GaussianModel, MeasurementModel):
     The concentration is calculated according to
 
     .. math::
+        :no-wrap:
+
         \begin{multline}
         \mathcal{M}(\vec{x}_k, \Theta_k) = \frac{Q}{4\pi\Vert\vec{x}_k-\vec{p}^s\Vert}
         \cdot\text{exp}\left[\frac{-\Vert\vec{x}_k-\vec{p}^s\Vert}{\lambda}\right]\cdot\\


### PR DESCRIPTION
Changes in MathJax 4+ means some double nested equations do not render. Adding no wrap stops this double nesting.

For example:
<img width="1046" height="200" alt="image" src="https://github.com/user-attachments/assets/9d363a0e-988d-4d03-9119-6a60d817f90c" />
