### PR TITLE
Fix GNN associators with infinite missed distance

### DIFF
--- a/stonesoup/dataassociator/neighbour.py
+++ b/stonesoup/dataassociator/neighbour.py
@@ -1,4 +1,5 @@
 import itertools
+from math import isfinite
 
 import numpy as np
 from scipy.optimize import linear_sum_assignment
@@ -6,8 +7,52 @@ from scipy.optimize import linear_sum_assignment
 from .base import DataAssociator
 from ..base import Property
 from ..hypothesiser import Hypothesiser
-from ..types.hypothesis import SingleHypothesis, JointHypothesis, \
-    ProbabilityHypothesis
+from ..types.hypothesis import SingleDistanceHypothesis, SingleHypothesis, \
+    JointHypothesis, ProbabilityHypothesis
+
+
+def _finite_missed_distances(hypotheses):
+    """Replace infinite missed detection distances with a finite distance.
+
+    The default missed distance of :class:`~.DistanceHypothesiser` is infinite. As a
+    result, the total distance of every joint hypothesis containing a missed detection
+    is also infinite, such that these joint hypotheses cannot be distinguished from one
+    another. This affects any association where a missed detection is unavoidable, such
+    as when there are more tracks than (gated) detections.
+
+    Infinite missed detection distances are therefore replaced with a distance
+    marginally greater than the greatest finite distance, keeping a missed detection
+    less favourable than any detection, whilst allowing joint hypotheses to be compared.
+
+    Note this modifies the hypotheses in place.
+
+    Parameters
+    ----------
+    hypotheses : dict of :class:`~.Track`: :class:`~.MultipleHypothesis`
+        Hypotheses, including missed detections, for each track
+    """
+    # Single pass: gather the infinite missed detection hypotheses, whilst tracking the
+    # greatest finite detection distance. There is typically only one missed detection
+    # hypothesis per track, so only these need be held on to.
+    missed_hypotheses = []
+    max_distance = -np.inf
+    for track_hypotheses in hypotheses.values():
+        for hypothesis in track_hypotheses:
+            if not isinstance(hypothesis, SingleDistanceHypothesis):
+                continue
+            distance = hypothesis.distance
+            if not hypothesis:
+                if not isfinite(distance):
+                    missed_hypotheses.append(hypothesis)
+            elif distance > max_distance and isfinite(distance):
+                max_distance = distance
+
+    # Nothing to do without both a missed detection hypothesis to replace, and a
+    # detection hypothesis for it to be less favourable than
+    if missed_hypotheses and isfinite(max_distance):
+        missed_distance = np.nextafter(max_distance, np.inf)
+        for hypothesis in missed_hypotheses:
+            hypothesis.distance = missed_distance
 
 
 class NearestNeighbour(DataAssociator):
@@ -58,6 +103,12 @@ class GlobalNearestNeighbour(DataAssociator):
 
     Scores and associates detections to a predicted state using the Global
     Nearest Neighbour method, assuming a distance-based hypothesis score.
+
+    Note
+    ----
+    Infinite missed detection distances (the default of :class:`~.DistanceHypothesiser`)
+    are replaced with a distance marginally greater than the greatest finite distance,
+    so that joint hypotheses including a missed detection remain comparable.
     """
 
     hypothesiser: Hypothesiser = Property(
@@ -67,6 +118,7 @@ class GlobalNearestNeighbour(DataAssociator):
 
         # Generate a set of hypotheses for each track on each detection
         hypotheses = self.generate_hypotheses(tracks, detections, timestamp, **kwargs)
+        _finite_missed_distances(hypotheses)
 
         # Link hypotheses into a set of joint_hypotheses and evaluate
         joint_hypotheses = self.enumerate_joint_hypotheses(hypotheses)
@@ -140,6 +192,12 @@ class GNNWith2DAssignment(DataAssociator):
     Associates detections to a predicted state using the
     Global Nearest Neighbour method, utilising a 2D matrix of
     distances and a "shortest path" assignment algorithm.
+
+    Note
+    ----
+    Infinite missed detection distances (the default of :class:`~.DistanceHypothesiser`)
+    are replaced with a distance marginally greater than the greatest finite distance,
+    so that an assignment including a missed detection remains feasible.
     """
 
     hypothesiser: Hypothesiser = Property(
@@ -165,6 +223,7 @@ class GNNWith2DAssignment(DataAssociator):
 
         # Generate a set of hypotheses for each track on each detection
         hypotheses = self.generate_hypotheses(tracks, detections, timestamp, **kwargs)
+        _finite_missed_distances(hypotheses)
 
         # Create dictionary for associations
         associations = {}

--- a/stonesoup/dataassociator/tests/test_neighbour.py
+++ b/stonesoup/dataassociator/tests/test_neighbour.py
@@ -5,6 +5,8 @@ import numpy as np
 
 from ..neighbour import (
     NearestNeighbour, GlobalNearestNeighbour, GNNWith2DAssignment)
+from ...hypothesiser.distance import DistanceHypothesiser
+from ...measures import Mahalanobis
 from ...types.detection import Detection
 from ...types.state import GaussianState
 from ...types.track import Track
@@ -57,6 +59,29 @@ def test_missed_detection_nearest_neighbour(associator):
     # Best hypothesis should be missed detection hypothesis
     assert all(not hypothesis.measurement
                for hypothesis in associations.values())
+
+
+@pytest.mark.parametrize(
+    'associator_class', [NearestNeighbour, GlobalNearestNeighbour, GNNWith2DAssignment])
+def test_infinite_missed_distance(associator_class, predictor, updater):
+    # Default missed distance is infinite, such that every joint hypothesis has an
+    # infinite distance where a missed detection is unavoidable: #824
+    associator = associator_class(
+        DistanceHypothesiser(predictor, updater, Mahalanobis()))
+
+    timestamp = datetime.datetime.now()
+    tracks = [
+        Track([GaussianState(np.array([[x, 0, x, 0]]), np.diag([1, 0.1, 1, 0.1]), timestamp)])
+        for x in (0, 3, 6)]
+    detection = Detection(np.array([[6, 6]]), timestamp)
+
+    # Tracks passed in order, nearest last, so that an arbitrary (first) choice is wrong
+    associations = associator.associate(tracks, {detection}, timestamp)
+
+    # Detection must be associated to the nearest (last) track, not an arbitrary one
+    assert associations[tracks[-1]].measurement is detection
+    assert not associations[tracks[0]]
+    assert not associations[tracks[1]]
 
 
 def test_probability_gnn(probability_associator):


### PR DESCRIPTION
The default missed distance of DistanceHypothesiser is infinite. Where a missed detection is unavoidable, such as when there are more tracks than gated detections, every joint hypothesis then has an infinite total distance. GlobalNearestNeighbour could not distinguish between these, so returned an arbitrary (first enumerated) association, and GNNWith2DAssignment raised "Assignment was not feasible".

Infinite missed detection distances are now replaced with a distance marginally greater than the greatest finite distance, keeping a missed detection less favourable than any detection, whilst allowing joint hypotheses to be compared.

Fixes #824