### PR TITLE
Vectorise inverse_function on measurement models

### DIFF
--- a/stonesoup/models/base.py
+++ b/stonesoup/models/base.py
@@ -183,7 +183,8 @@ class ReversibleModel(Model):
     of the relevant linear-to-non-linear function"""
 
     @abstractmethod
-    def inverse_function(self, detection: 'Detection', **kwargs) -> StateVector:
+    def inverse_function(self, detection: 'Detection', **kwargs) \
+            -> Union[StateVector, StateVectors]:
         """Takes in the result of the function and
         computes the inverse function, returning the initial
         input of the function.
@@ -191,12 +192,16 @@ class ReversibleModel(Model):
         Parameters
         ----------
         detection: :class:`~.Detection`
-            Input state (non-linear format)
+            Input state (non-linear format). This may hold a single
+            :class:`~.StateVector`, or a :class:`~.StateVectors` of multiple
+            measurements, which are converted together.
 
         Returns
         -------
-        StateVector
-            The linear co-ordinates
+        :class:`~.StateVector` or :class:`~.StateVectors`
+            The linear co-ordinates. A :class:`~.StateVector` is returned for a
+            single measurement, and a :class:`~.StateVectors` of matching width
+            for multiple measurements.
         """
         raise NotImplementedError
 

--- a/stonesoup/models/measurement/nonlinear.py
+++ b/stonesoup/models/measurement/nonlinear.py
@@ -68,10 +68,10 @@ class CombinedReversibleGaussianMeasurementModel(ReversibleModel, GaussianModel,
 
         return inv_model_matrix @ state.state_vector
 
-    def inverse_function(self, detection, **kwargs) -> StateVector:
+    def inverse_function(self, detection, **kwargs) -> Union[StateVector, StateVectors]:
         state = copy.copy(detection)
         ndim_count = 0
-        state_vector = np.zeros((self.ndim_state, 1)).view(StateVector)
+        state_vector = np.zeros((self.ndim_state, detection.state_vector.shape[1]))
         for model in self.model_list:
             state.state_vector = detection.state_vector[ndim_count:model.ndim_meas + ndim_count, :]
             if isinstance(model, ReversibleModel):
@@ -83,7 +83,7 @@ class CombinedReversibleGaussianMeasurementModel(ReversibleModel, GaussianModel,
                     "Model {!r} not reversible".format(type(model)))
             ndim_count += model.ndim_meas
 
-        return state_vector
+        return StateVectors(state_vector)
 
     def covar(self, **kwargs) -> CovarianceMatrix:
         return block_diag(
@@ -271,18 +271,19 @@ class CartesianToElevationBearingRange(_AngleNonLinearGaussianMeasurement, Rever
 
         return StateVectors([theta, phi, rho]) + noise
 
-    def inverse_function(self, detection, **kwargs) -> StateVector:
-
-        theta, phi, rho = detection.state_vector
-        xyz = StateVector(sphere2cart(rho, phi, theta))
+    def inverse_function(self, detection, **kwargs) -> Union[StateVector, StateVectors]:
+        # Cast to float to drop the angle types, which don't survive the conversion below
+        state_vector = detection.state_vector.astype(np.float64)
+        theta, phi, rho = state_vector[0, :], state_vector[1, :], state_vector[2, :]
+        xyz = np.array(sphere2cart(rho, phi, theta))
 
         inv_rotation_matrix = inv(self.rotation_matrix)
         xyz = inv_rotation_matrix @ xyz
 
-        res = np.zeros((self.ndim_state, 1)).view(StateVector)
+        res = np.zeros((self.ndim_state, state_vector.shape[1]))
         res[self.mapping, :] = xyz + self.translation_offset
 
-        return res
+        return StateVectors(res)
 
     @staticmethod
     def _typed_vector():
@@ -369,24 +370,26 @@ class CartesianToBearingRange(_AngleNonLinearGaussianMeasurement, ReversibleMode
 
         return 2
 
-    def inverse_function(self, detection, **kwargs) -> StateVector:
+    def inverse_function(self, detection, **kwargs) -> Union[StateVector, StateVectors]:
         if not ((self.rotation_offset[0] == 0)
                 and (self.rotation_offset[1] == 0)):
             raise RuntimeError(
                 "Measurement model assumes 2D space. \
                 Rotation in 3D space is unsupported at this time.")
 
-        x, y = pol2cart(detection.state_vector[1, :], detection.state_vector[0, :])
+        # Cast to float to drop the angle types, which don't survive the conversion below
+        state_vector = detection.state_vector.astype(np.float64)
+        x, y = pol2cart(state_vector[1, :], state_vector[0, :])
 
-        xyz = np.array([x, y, np.zeros(detection.state_vector.shape[1])])
+        xyz = np.array([x, y, np.zeros(state_vector.shape[1])])
         inv_rotation_matrix = inv(self.rotation_matrix)
         xyz = inv_rotation_matrix @ xyz
         xy = xyz[0:2]
 
-        res = np.zeros((self.ndim_state, detection.state_vector.shape[1])).view(StateVector)
+        res = np.zeros((self.ndim_state, state_vector.shape[1]))
         res[self.mapping[:2], :] = xy + self.translation_offset[:2, :]
 
-        return res
+        return StateVectors(res)
 
     def _function(self, state, noise=False, **kwargs):
         if isinstance(noise, bool) or noise is None:
@@ -933,29 +936,24 @@ class CartesianToElevationBearingRangeRate(_AngleNonLinearGaussianMeasurement, R
                              rho,
                              rr]) + noise
 
-    def inverse_function(self, detection, **kwargs) -> StateVector:
-        theta, phi, rho, rho_rate = detection.state_vector
+    def inverse_function(self, detection, **kwargs) -> Union[StateVector, StateVectors]:
+        # Cast to float to drop the angle types, which don't survive the conversion below
+        state_vector = detection.state_vector.astype(np.float64)
+        theta, phi, rho, rho_rate = (state_vector[0, :], state_vector[1, :],
+                                     state_vector[2, :], state_vector[3, :])
 
-        x, y, z = sphere2cart(rho, phi, theta)
+        xyz = np.array(sphere2cart(rho, phi, theta))
         # because only rho_rate is known, only the components in
         # x,y and z of the range rate can be found.
-        x_rate, y_rate, z_rate = sphere2cart(rho_rate, phi, theta)
+        xyz_rate = np.array(sphere2cart(rho_rate, phi, theta))
 
         inv_rotation_matrix = inv(self.rotation_matrix)
 
-        out_vector = StateVector(np.zeros((self.ndim_state)))
-        out_vector[self.mapping, 0] = x, y, z
-        out_vector[self.velocity_mapping, 0] = x_rate, y_rate, z_rate
+        out_vector = np.zeros((self.ndim_state, state_vector.shape[1]))
+        out_vector[self.mapping, :] = inv_rotation_matrix @ xyz + self.translation_offset
+        out_vector[self.velocity_mapping, :] = inv_rotation_matrix @ xyz_rate + self.velocity
 
-        out_vector[self.mapping, :] = inv_rotation_matrix @ out_vector[self.mapping, :]
-        out_vector[self.velocity_mapping, :] = \
-            inv_rotation_matrix @ out_vector[self.velocity_mapping, :]
-
-        out_vector[self.mapping, :] = out_vector[self.mapping, :] + self.translation_offset
-        out_vector[self.velocity_mapping, :] = out_vector[self.velocity_mapping, :] \
-            + self.velocity
-
-        return out_vector
+        return StateVectors(out_vector)
 
     @staticmethod
     def _typed_vector():
@@ -1171,8 +1169,9 @@ class CartesianToElevationRateBearingRateRangeRate(_AngleNonLinearGaussianMeasur
         rxy = np.linalg.norm(pos[:2], axis=0)  # norm
         rxy2 = rxy ** 2  # squared norm
 
-        rDot = np.dot(pos.flatten(), vel.flatten()) / r  # Radial velocity (dot product)
-        rxyDot = np.dot(pos[:2].flatten(), vel[:2].flatten()) / rxy  # rxy dot
+        # Column-wise dot products, so multiple states are handled independently
+        rDot = np.einsum('ij,ij->j', pos, vel) / r  # Radial velocity (dot product)
+        rxyDot = np.einsum('ij,ij->j', pos[:2], vel[:2]) / rxy  # rxy dot
         azimuthDot = (vel[1] * pos[0] - vel[0] * pos[1]) / rxy2  # Azimuth rate of change
         elevationDot = (vel[2] * rxy - rxyDot * pos[2]) / r2  # Elevation rate of change
 
@@ -1183,13 +1182,17 @@ class CartesianToElevationRateBearingRateRangeRate(_AngleNonLinearGaussianMeasur
                              azimuthDot,
                              rDot]) + noise
 
-    def inverse_function(self, detection, **kwargs) -> StateVector:
+    def inverse_function(self, detection, **kwargs) -> Union[StateVector, StateVectors]:
         # Theta: elevation
         # Phi: azimuth
         # Rho: range
-        theta, phi, rho, theta_rate, phi_rate, rho_rate = detection.state_vector
+        # Cast to float to drop the angle types, which don't survive the conversion below
+        state_vector = detection.state_vector.astype(np.float64)
+        theta, phi, rho, theta_rate, phi_rate, rho_rate = (
+            state_vector[0, :], state_vector[1, :], state_vector[2, :],
+            state_vector[3, :], state_vector[4, :], state_vector[5, :])
 
-        x, y, z = sphere2cart(rho, phi, theta)
+        xyz = np.array(sphere2cart(rho, phi, theta))
 
         x_rate = (rho_rate * np.cos(theta) * np.cos(phi) -
                   rho * theta_rate * np.sin(theta) * np.cos(phi) -
@@ -1201,21 +1204,15 @@ class CartesianToElevationRateBearingRateRangeRate(_AngleNonLinearGaussianMeasur
 
         z_rate = rho_rate * np.sin(theta) + rho * theta_rate * np.cos(theta)
 
+        xyz_rate = np.array([x_rate, y_rate, z_rate])
+
         inv_rotation_matrix = inv(self.rotation_matrix)
 
-        out_vector = StateVector([[0.], [0.], [0.], [0.], [0.], [0.]])
-        out_vector[self.mapping, 0] = x, y, z
-        out_vector[self.velocity_mapping, 0] = x_rate, y_rate, z_rate
+        out_vector = np.zeros((self.ndim_state, state_vector.shape[1]))
+        out_vector[self.mapping, :] = inv_rotation_matrix @ xyz + self.translation_offset
+        out_vector[self.velocity_mapping, :] = inv_rotation_matrix @ xyz_rate + self.velocity
 
-        out_vector[self.mapping, :] = inv_rotation_matrix @ out_vector[self.mapping, :]
-        out_vector[self.velocity_mapping, :] = \
-            inv_rotation_matrix @ out_vector[self.velocity_mapping, :]
-
-        out_vector[self.mapping, :] = out_vector[self.mapping, :] + self.translation_offset
-        out_vector[self.velocity_mapping, :] = out_vector[self.velocity_mapping, :] \
-            + self.velocity
-
-        return out_vector
+        return StateVectors(out_vector)
 
     @staticmethod
     def _typed_vector():
@@ -1521,21 +1518,21 @@ class CartesianToAzimuthElevationRange(_AngleNonLinearGaussianMeasurement, Rever
 
         return StateVectors([phi, theta, rho]) + noise
 
-    def inverse_function(self, detection, **kwargs) -> StateVector:
-
-        phi, theta, rho = detection.state_vector
+    def inverse_function(self, detection, **kwargs) -> Union[StateVector, StateVectors]:
+        # Cast to float to drop the angle types, which don't survive the conversion below
+        state_vector = detection.state_vector.astype(np.float64)
+        phi, theta, rho = state_vector[0, :], state_vector[1, :], state_vector[2, :]
 
         # convert to cartesian
-        x, y, z = az_el_rg2cart(phi, theta, rho)
-        xyz = StateVector([x, y, z])
+        xyz = np.array(az_el_rg2cart(phi, theta, rho))
 
         inv_rotation_matrix = inv(self.rotation_matrix)
         xyz = inv_rotation_matrix @ xyz
 
-        res = np.zeros((self.ndim_state, 1)).view(StateVector)
+        res = np.zeros((self.ndim_state, state_vector.shape[1]))
         res[self.mapping, :] = xyz + self.translation_offset
 
-        return res
+        return StateVectors(res)
 
     @staticmethod
     def _typed_vector():

--- a/stonesoup/models/measurement/tests/test_combined.py
+++ b/stonesoup/models/measurement/tests/test_combined.py
@@ -74,7 +74,22 @@ def test_inverse(model):
     state = State(StateVector([[0.1], [10], [0], [0.2], [20]]))
     meas_state = model.function(state)
 
-    assert model.inverse_function(State(meas_state)) == approx(state.state_vector)
+    inv_state = model.inverse_function(State(meas_state))
+    assert isinstance(inv_state, StateVector)
+    assert inv_state == approx(state.state_vector)
+
+
+def test_inverse_state_vectors(model):
+    states = State(StateVectors([[0.1, 1, -5], [10, 20, 30], [0, 0, 0],
+                                 [0.2, 2, -10], [20, 40, 60]]))
+    meas_states = model.function(states)
+
+    inv_states = model.inverse_function(State(meas_states))
+
+    assert isinstance(inv_states, StateVectors)
+    assert not isinstance(inv_states, StateVector)
+    assert inv_states.shape == states.state_vector.shape
+    assert inv_states == approx(np.asarray(states.state_vector, dtype=np.float64))
 
 
 def test_rvs(model):
@@ -117,6 +132,25 @@ def test_non_linear_and_linear():
     assert model.inverse_function(State(meas_vector)) == approx(state.state_vector)
 
     assert model.covar() == approx(np.diag([1, 10, 20]))
+
+
+def test_non_linear_and_linear_state_vectors():
+    """Exercise the ``_linear_inverse_function`` branch with multiple measurements."""
+    model = CombinedReversibleGaussianMeasurementModel([
+        CartesianToBearingRange(3, [0, 1], np.diag([1, 10])),
+        LinearGaussian(3, [2], np.array([[20]])),
+    ])
+
+    states = State(StateVectors([[0, 10, -5], [10, 0, -5], [20, 30, 40]]))
+    meas_vectors = model.function(states)
+    assert isinstance(meas_vectors, StateVectors)
+
+    inv_states = model.inverse_function(State(meas_vectors))
+
+    assert isinstance(inv_states, StateVectors)
+    assert not isinstance(inv_states, StateVector)
+    assert inv_states.shape == states.state_vector.shape
+    assert inv_states == approx(np.asarray(states.state_vector, dtype=np.float64))
 
 
 def test_mismatch_ndim_state():

--- a/stonesoup/models/measurement/tests/test_models.py
+++ b/stonesoup/models/measurement/tests/test_models.py
@@ -98,6 +98,32 @@ def az_el_rng(state_vector, pos_map, translation_offset, rotation_offset):
     return StateVector([Azimuth(phi), Elevation(theta), rho])
 
 
+def assert_inverse_function_vectorised(model, state_vec):
+    """Check ``inverse_function`` handles multiple measurements at once.
+
+    Inverting a :class:`~.StateVectors` of measurements must give the same answer, column by
+    column, as inverting each measurement individually, and must return a
+    :class:`~.StateVectors` rather than a :class:`~.StateVector`.
+    """
+    # Perturb the states, so the measurements aren't all trivially identical. Generating them
+    # through the model keeps them valid, which scaling a measurement directly would not.
+    state_vecs = StateVectors([state_vec, state_vec*0.9, state_vec*1.1])
+    measurements = model.function(State(state_vecs), noise=False)
+
+    multiple = model.inverse_function(State(measurements))
+    assert isinstance(multiple, StateVectors)
+    assert not isinstance(multiple, StateVector)
+    assert multiple.shape == (model.ndim_state, 3)
+
+    for column, measurement in zip(multiple, measurements):
+        single = model.inverse_function(State(measurement))
+        # Single measurements must still give a StateVector, not a one column StateVectors
+        assert isinstance(single, StateVector)
+        assert single.shape == (model.ndim_state, 1)
+        assert np.allclose(np.asarray(column, dtype=np.float64),
+                           np.asarray(single, dtype=np.float64))
+
+
 @pytest.mark.parametrize(
     "model_class",
     [LinearGaussian,
@@ -281,6 +307,7 @@ def test_models(h, ModelClass, state_vec, R,
     if isinstance(model, ReversibleModel):
         J = model.inverse_function(State(meas_pred_wo_noise))
         assert np.allclose(J, state_vec)
+        assert_inverse_function_vectorised(model, state_vec)
 
     # Ensure ```lg.covar()``` returns R
     assert np.array_equal(R, model.covar())
@@ -710,6 +737,7 @@ def test_rangeratemodels(h, modelclass, state_vec, ndim_state, pos_mapping, vel_
     if isinstance(model, ReversibleModel):
         J = model.inverse_function(State(meas_pred_wo_noise))
         assert np.allclose(J, state_vec)
+        assert_inverse_function_vectorised(model, state_vec)
 
     # Ensure ```lg.covar()``` returns R
     assert np.array_equal(noise_covar, model.covar())
@@ -1076,6 +1104,17 @@ def test_inverse_function():
     assert approx(inv_measure_state[3], 0.02) == 17.10
     assert approx(inv_measure_state[4], 0.02) == 1736.48
     assert approx(inv_measure_state[5], 0.02) == 17.36
+
+    # Same measurement repeated should give the same answer in every column
+    measured_states = State(StateVectors([measured_state.state_vector]*3))
+
+    inv_measure_states = measure_model.inverse_function(measured_states)
+
+    assert isinstance(inv_measure_states, StateVectors)
+    assert inv_measure_states.shape == (6, 3)
+    for column in inv_measure_states:
+        assert np.allclose(np.asarray(column, dtype=np.float64),
+                           np.asarray(inv_measure_state, dtype=np.float64))
 
 
 def test_binning():
@@ -1595,6 +1634,28 @@ def test_inverse_rates(input_state):
     inv_state = measurement_model.inverse_function(measurement)
 
     assert np.allclose(input_state.state_vector, inv_state)
+
+
+def test_inverse_rates_state_vectors():
+    """Invert every case of :data:`position_input_sets` in a single call."""
+    input_states = State(StateVectors([StateVector(input_state)
+                                       for input_state in position_input_sets]))
+    measurement_model = CartesianToElevationRateBearingRateRangeRate(
+        ndim_state=6,
+        mapping=np.array([0, 1, 2]),
+        velocity_mapping=np.array([3, 4, 5]),
+        noise_covar=np.array([[0, 0, 0, 0],
+                              [0, 0, 0, 0],
+                              [0, 0, 0, 0],
+                              [0, 0, 0, 0]]))
+
+    measurements = Detection(measurement_model.function(input_states), timestamp=None)
+    inv_states = measurement_model.inverse_function(measurements)
+
+    assert isinstance(inv_states, StateVectors)
+    assert inv_states.shape == (6, len(position_input_sets))
+    assert np.allclose(np.asarray(input_states.state_vector, dtype=np.float64),
+                       np.asarray(inv_states, dtype=np.float64))
 
 
 def test_state_vectors():


### PR DESCRIPTION
Unlike the forward `function`, `inverse_function` only handled a single StateVector, forcing callers to loop a detection at a time. Each of the six ReversibleModel implementations now casts the measurement to float (angle types left rows as object dtype), indexes rows explicitly (StateVectors iterates by column, so tuple unpacking was wrong), sizes its output from the input width, and returns via StateVectors, which gives back a StateVector for a single column. Single measurement behaviour is unchanged.

CartesianToBearingRange already handled N columns, but returned them as a StateVector of invalid shape; it now returns StateVectors like the rest.

Also fixes the forward `function` of CartesianToElevationRateBearingRateRangeRate, which used np.dot on flattened arrays and so collapsed every column into one scalar. A pre-existing bug, but it blocked round-trip testing of that inverse.

Fixes #792