### PR TITLE
Fix PCRB multiple sensor location handling

### DIFF
--- a/stonesoup/metricgenerator/pcrbmetric.py
+++ b/stonesoup/metricgenerator/pcrbmetric.py
@@ -8,7 +8,7 @@ from .base import MetricGenerator
 from ..base import Property
 from ..types.state import GaussianState
 from ..types.groundtruth import GroundTruthState, GroundTruthPath
-from ..types.array import StateVectors
+from ..types.array import StateVector, StateVectors
 from ..models.transition import TransitionModel
 from ..models.measurement import MeasurementModel
 from ..types.metric import TimeRangeMetric
@@ -186,7 +186,7 @@ class PCRBMetric(MetricGenerator):
         num_sensors = sensor_locations.shape[1]
         for i in range(num_sensors):
 
-            sensor_location = sensor_locations[:, i]
+            sensor_location = StateVector(sensor_locations[:, i])
             measurement_model_cp = copy(measurement_model)
             if hasattr(measurement_model_cp, 'translation_offset'):
                 measurement_model_cp.translation_offset = sensor_location

--- a/stonesoup/metricgenerator/tests/test_pcrbmetric.py
+++ b/stonesoup/metricgenerator/tests/test_pcrbmetric.py
@@ -5,6 +5,7 @@ import pytest
 
 from ..manager import MultiManager
 from ..pcrbmetric import PCRBMetric
+from ...models.measurement.nonlinear import CartesianToBearingRange
 from ...types.groundtruth import GroundTruthState
 from ...types.array import StateVector, StateVectors, CovarianceMatrix
 from ...types.state import GaussianState
@@ -55,6 +56,24 @@ def test_calculate_j_z(state, sensor_locations, measurement_model, irf):
                                               [0., 0., 0., 0.],
                                               [0., 0., 0.2, 0.],
                                               [0., 0., 0., 0.]]))
+
+
+def test_calculate_j_z_multiple_sensor_locations():
+    state = GroundTruthState(StateVector([0., 0., 0., 0.]))
+    sensor_locations = StateVectors([
+        StateVector([[-1.], [0.]]),
+        StateVector([[1.], [0.]]),
+    ])
+    measurement_model = CartesianToBearingRange(
+        ndim_state=4,
+        mapping=[0, 2],
+        noise_covar=CovarianceMatrix(np.eye(2)),
+    )
+
+    overall_j_z = PCRBMetric._calculate_j_z(
+        state, sensor_locations, measurement_model, np.ones(2))
+
+    assert np.allclose(overall_j_z, np.diag([2., 0., 2., 0.]))
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

Fixes PCRB information-matrix calculation when more than one sensor location is supplied.

`StateVectors[:, i]` does not preserve the `StateVector` shape for a single column in this case. The resulting one-dimensional value can be assigned to nonlinear measurement models such as `CartesianToBearingRange`, where it broadcasts against the state vector and produces an incorrect Jacobian/information contribution.

Each sensor location is now explicitly normalized to `StateVector` before assigning it to a copied measurement model.

A regression test uses two nonlinear bearing/range sensor locations and verifies the combined information matrix numerically.

Addresses #1269

## Validation

- Regression covers two sensor locations.
- Uses `CartesianToBearingRange`, exercising `translation_offset`.
- Expected combined information matrix is asserted numerically.
- Existing single-sensor behaviour is unchanged.
- Patch is isolated to the PCRB implementation and its unit tests.


## Scope

This PR intentionally fixes the existing multiple-location `StateVector` shape bug only. Support for heterogeneous measurement models and mobile sensor histories is broader design work and is not introduced here.
