### PR TITLE
Keep mounted sensor controllers in sync with platform

### DIFF
--- a/stonesoup/platform/base.py
+++ b/stonesoup/platform/base.py
@@ -108,6 +108,12 @@ class Platform(Base):
     def _tuple_or_none(value):
         return None if value is None else tuple(value)
 
+    @movement_controller.setter
+    def movement_controller(self, value):
+        self._property_movement_controller = value
+        for sensor in getattr(self, '_property_sensors', ()):
+            sensor.movement_controller = value
+
     @sensors.getter
     def sensors(self):
         return self._tuple_or_none(self._property_sensors)

--- a/stonesoup/platform/tests/test_platform_controller_sync.py
+++ b/stonesoup/platform/tests/test_platform_controller_sync.py
@@ -1,0 +1,40 @@
+import datetime
+
+from stonesoup.movable import FixedMovable, MovingMovable
+from stonesoup.platform import MovingPlatform
+from stonesoup.sensor.sensor import Sensor
+from stonesoup.types.array import StateVector
+from stonesoup.types.state import State
+
+
+class DummySensor(Sensor):
+    @property
+    def measurement_model(self):
+        raise NotImplementedError
+
+    def measure(self, **kwargs):
+        pass
+
+
+def test_replacing_platform_movement_controller_updates_mounted_sensors():
+    timestamp = datetime.datetime.now()
+    fixed = FixedMovable(
+        states=State(StateVector([2, 2, 0]), timestamp),
+        position_mapping=(0, 1, 2),
+    )
+    moving = MovingMovable(
+        states=State(StateVector([2, 1, 2, -1, 2, 0]), timestamp),
+        position_mapping=(0, 2, 4),
+        transition_model=None,
+    )
+    platform = MovingPlatform(movement_controller=fixed)
+    sensors = [DummySensor(), DummySensor()]
+
+    for sensor in sensors:
+        platform.add_sensor(sensor)
+        assert sensor.movement_controller is fixed
+
+    platform.movement_controller = moving
+
+    assert platform.movement_controller is moving
+    assert all(sensor.movement_controller is moving for sensor in sensors)


### PR DESCRIPTION
## Summary

Keeps sensors mounted on a `Platform` synchronized when the platform's `movement_controller` is replaced after construction.

`Platform.add_sensor()` assigns the current movement controller to a sensor when it is mounted, and construction performs the same synchronization for sensors supplied initially. Replacing `platform.movement_controller` later, however, only changes the platform property and leaves existing sensors referencing the old controller.

This change adds a `movement_controller` property setter on `Platform`. The setter stores the replacement controller and propagates it to every currently mounted sensor, preserving the controller-sharing invariant already established during mounting.

A regression test mounts two sensors on a platform using a fixed controller, replaces it with a moving controller, and verifies that the platform and both sensors reference the replacement.

Closes #1025

## Validation

- Production change is six lines in `stonesoup/platform/base.py`.
- New focused regression test covers controller replacement after sensors are mounted.
- Sensor mounting behaviour itself is unchanged.
- Platform construction remains safe because the setter tolerates the sensor backing list not yet being initialized.
- The branch is one commit based directly on current `main`.