### PR TITLE
Fix slicing for bounded track histories

### DIFF
--- a/stonesoup/initiator/tests/test_wrapper.py
+++ b/stonesoup/initiator/tests/test_wrapper.py
@@ -62,3 +62,11 @@ def test_states_length_limiter(max_len):
 
     assert len(track) == max_len
     assert len(track.metadatas) == max_len
+    assert track.states.maxlen == max_len
+    assert track.metadatas.maxlen == max_len
+
+    expected_timestamps = [state.timestamp for state in list(track.states)[1:]]
+    assert [state.timestamp for state in track[1:]] == expected_timestamps
+    assert [state.timestamp for state in track[::-1]] == [
+        state.timestamp for state in reversed(track.states)]
+    assert track.metadatas[:-1].maxlen == max_len

--- a/stonesoup/initiator/wrapper.py
+++ b/stonesoup/initiator/wrapper.py
@@ -3,6 +3,15 @@ from .base import Initiator
 from ..base import Property
 
 
+class _SliceableDeque(collections.deque):
+    """Bounded deque with list-compatible slice access."""
+
+    def __getitem__(self, index):
+        if isinstance(index, slice):
+            return type(self)(list(self)[index], maxlen=self.maxlen)
+        return super().__getitem__(index)
+
+
 class StatesLengthLimiter(Initiator):
     """Wrapper that defines the length of track history stored in memory
 
@@ -26,6 +35,6 @@ class StatesLengthLimiter(Initiator):
     def initiate(self, *args, **kwargs):
         tracks = self.initiator.initiate(*args, **kwargs)
         for track in tracks:
-            track.states = collections.deque(track.states, self.max_length)
-            track.metadatas = collections.deque(track.metadatas, self.max_length)
+            track.states = _SliceableDeque(track.states, self.max_length)
+            track.metadatas = _SliceableDeque(track.metadatas, self.max_length)
         return tracks


### PR DESCRIPTION
## Summary

Restores normal slicing behaviour for tracks wrapped by `StatesLengthLimiter` while preserving bounded history storage.

`StatesLengthLimiter` converts `track.states` and `track.metadatas` to `collections.deque` objects with `maxlen`. `StateMutableSequence.__getitem__()` delegates ordinary slices to its backing sequence, but `deque` does not support slice indices, so expressions such as `track[1:]` raise `TypeError` after the limiter is applied.

This change introduces a small bounded deque subclass that supports slices by returning another bounded deque with the same `maxlen`. `StatesLengthLimiter` uses it for both states and metadata, retaining constant-time append/expiry behaviour and the existing memory bound while restoring list-compatible slice access.

Closes #1018

## Validation

The existing `StatesLengthLimiter` test now verifies:

- state and metadata histories retain the configured `maxlen`;
- forward slicing such as `track[1:]` returns the expected states;
- reverse slicing such as `track[::-1]` works;
- sliced metadata remains bounded with the original `maxlen`.

The branch contains one commit and is based directly on current `main`.