### PR TITLE
Surface supported Python version in README and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 <h1><img valign="middle" alt="Stone Soup Logo" src="https://raw.githubusercontent.com/dstl/Stone-Soup/main/docs/source/_static/stone_soup_logo.svg" height="100"> Stone Soup</h1>
 
 [![PyPI](https://img.shields.io/pypi/v/stonesoup?style=flat)](https://pypi.org/project/stonesoup)
+[![Python](https://img.shields.io/badge/python-%3E%3D3.10-blue?style=flat)](https://github.com/dstl/Stone-Soup/blob/main/pyproject.toml)
 [![Conda Version](https://img.shields.io/conda/vn/conda-forge/stonesoup.svg)](https://anaconda.org/conda-forge/stonesoup)
 [![CircleCI branch](https://img.shields.io/circleci/project/github/dstl/Stone-Soup/main.svg?label=tests&style=flat)](https://circleci.com/gh/dstl/Stone-Soup)
 [![Codecov](https://img.shields.io/codecov/c/github/dstl/Stone-Soup.svg)](https://codecov.io/gh/dstl/Stone-Soup)

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -28,6 +28,8 @@ For community support, head over to the
 
 Installation
 ------------
+Stone Soup requires Python 3.10 or later.
+
 To install Stone Soup from PyPI with ``pip``:
 
 .. code::


### PR DESCRIPTION
## Summary

Makes Stone Soup's supported Python version immediately visible to users, addressing #1109.

The project already declares `requires-python = ">=3.10"` in `pyproject.toml`, but that requirement is easy to miss when checking compatibility from the README or the main documentation installation page.

## Change

- Add a Python 3.10+ badge to the repository README.
- State the Python 3.10+ requirement directly in the documentation's Installation section.

This keeps `pyproject.toml` as the authoritative package metadata while surfacing the same requirement in the two places users are most likely to check before installation.

## Scope

Documentation only. No package metadata, dependency constraints, runtime behaviour, or CI configuration are changed.

Closes #1109