### PR TITLE
Document optional dependency extras

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -48,6 +48,58 @@ the latest version from the GitHub repository:
 
     python -m pip install git+https://github.com/dstl/Stone-Soup.git#egg=stonesoup
 
+Optional dependencies
+^^^^^^^^^^^^^^^^^^^^^
+Some Stone Soup features use dependencies that are not required by the core
+package. These can be installed with ``pip`` extras. Multiple extras can be
+installed together, for example:
+
+.. code::
+
+    python -m pip install "stonesoup[video,optuna]"
+
+The currently available feature extras are:
+
+.. list-table::
+    :header-rows: 1
+    :widths: 20 50 30
+
+    * - Extra
+      - Feature
+      - Optional dependencies
+    * - ``video``
+      - Video reading, processing and related demonstrations
+      - ffmpeg-python, moviepy, OpenCV, yt-dlp
+    * - ``tensorflow``
+      - TensorFlow integrations
+      - TensorFlow
+    * - ``ultralytics``
+      - Ultralytics object detection
+      - ultralytics
+    * - ``mfa``
+      - Multi-frame assignment data association
+      - OR-Tools
+    * - ``ehm``
+      - Efficient hypothesis management data association
+      - pyehm
+    * - ``optuna``
+      - Optuna-based sensor management
+      - optuna
+    * - ``ode``
+      - ODE-based functionality and examples
+      - PyTorch
+    * - ``roadnet``
+      - Road-network functionality
+      - GeoPandas, NetworkX
+    * - ``architectures``
+      - Architecture graph visualisation
+      - Graphviz, NetworkX, pydot
+
+The ``dev`` extra installs the dependencies used for development and testing,
+and the ``docs`` extra installs additional dependencies required when building
+the documentation. The authoritative list of extras and packages is maintained
+in ``pyproject.toml``.
+
 
 Developing
 ^^^^^^^^^^


### PR DESCRIPTION
## Summary

Documents Stone Soup's optional dependency groups and how users can install them, addressing #767.

Stone Soup exposes several feature-specific extras in `pyproject.toml`, but the main installation documentation currently only shows the base and development installs. Users therefore have to inspect package metadata to determine which extra enables a particular feature.

## Change

Adds an Optional dependencies section to the main installation documentation that:

- shows the `stonesoup[extra]` installation syntax;
- explains that multiple extras can be combined;
- documents the current feature extras: `video`, `tensorflow`, `ultralytics`, `mfa`, `ehm`, `optuna`, `ode`, `roadnet`, and `architectures`;
- also identifies the `dev` and `docs` groups for contributor/documentation environments.

The names are taken directly from the current `[project.optional-dependencies]` table in `pyproject.toml`.

## Scope

Documentation only. No dependency definitions or package behaviour are changed.

Closes #767