### PR TITLE
Fix OpenSky zero-valued position filtering

### DIFF
--- a/stonesoup/reader/opensky.py
+++ b/stonesoup/reader/opensky.py
@@ -79,8 +79,8 @@ class _OpenSkyNetworkReader(Reader):
                 for state in data['states']:
                     if state[8]:  # On ground
                         continue
-                    # Must have position (lon, lat, geo-alt)
-                    if not all(state[index] for index in (5, 6, 13)):
+                    # Must have position (lon, lat, geo-alt). Zero is a valid coordinate/value.
+                    if any(state[index] is None for index in (5, 6, 13)):
                         continue
                     timestamp = datetime.datetime.fromtimestamp(
                         state[3], datetime.timezone.utc).replace(tzinfo=None)

--- a/stonesoup/reader/tests/test_opensky_position_values.py
+++ b/stonesoup/reader/tests/test_opensky_position_values.py
@@ -1,0 +1,63 @@
+import datetime
+
+import numpy as np
+import pytest
+
+pytest.importorskip('requests')
+
+from .. import opensky  # noqa: E402
+from ..opensky import OpenSkyNetworkDetectionReader  # noqa: E402
+
+
+class _Response:
+    def __init__(self, payload):
+        self.payload = payload
+
+    def raise_for_status(self):
+        pass
+
+    def json(self):
+        return self.payload
+
+
+class _Session:
+    def __init__(self, payload):
+        self.payload = payload
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        pass
+
+    def get(self, *args, **kwargs):
+        return _Response(self.payload)
+
+
+def _state_vector(longitude, latitude, geo_altitude):
+    return [
+        'abc123', 'TEST123', 'United Kingdom', 1704067199, 1704067199,
+        longitude, latitude, 0.0, False, 120.0, 90.0, 0.0, None,
+        geo_altitude, '7000', False, 0,
+    ]
+
+
+def test_opensky_accepts_zero_position_values_and_rejects_missing_values(monkeypatch):
+    payload = {
+        'time': 1704067200,
+        'states': [
+            _state_vector(0.0, 0.0, 0.0),
+            _state_vector(None, 1.0, 100.0),
+        ],
+    }
+    monkeypatch.setattr(opensky.requests, 'Session', lambda: _Session(payload))
+
+    reader = OpenSkyNetworkDetectionReader()
+    time, states_and_metadata = next(reader.data_gen())
+
+    assert time == datetime.datetime(2024, 1, 1, 0, 0)
+    assert len(states_and_metadata) == 1
+
+    state, metadata = states_and_metadata[0]
+    assert np.array_equal(state.state_vector, [[0.0], [0.0], [0.0]])
+    assert metadata['icao24'] == 'abc123'


### PR DESCRIPTION
## Summary

Fixes OpenSky state filtering so valid zero-valued longitude, latitude, and geometric altitude values are retained.

`_OpenSkyNetworkReader.data_gen()` currently checks position availability with `all(...)`. That treats numeric zero as missing, so an otherwise valid state is dropped whenever longitude, latitude, or geometric altitude is exactly `0.0`.

This is particularly visible around the Greenwich meridian and equator, and can also affect zero-altitude values.

## Change

- Treat only `None` as missing for longitude, latitude, and geometric altitude.
- Preserve existing rejection of incomplete position records.
- Leave on-ground filtering, timestamp handling, metadata, and state-vector layout unchanged.

## Regression coverage

Adds an offline unit test with a mocked OpenSky response that verifies:

- a state at longitude `0.0`, latitude `0.0`, and geometric altitude `0.0` is accepted;
- a state with a genuinely missing (`None`) longitude is still rejected;
- the accepted state retains the expected `[longitude, latitude, altitude]` state vector and metadata.

No network access is required for the regression test.