### PR TITLE
Add citation guide to the documentation

### DIFF
--- a/docs/source/citing.rst
+++ b/docs/source/citing.rst
@@ -1,0 +1,47 @@
+Citing Stone Soup
+=================
+
+If you use Stone Soup in research or a publication, please cite both the
+software and the preferred Stone Soup publication. This follows the citation
+request recorded in the repository's ``CITATION.cff`` file.
+
+Software citation
+-----------------
+
+The persistent DOI for the Stone Soup software is:
+
+* `10.5281/zenodo.4663993 <https://doi.org/10.5281/zenodo.4663993>`_
+
+The repository's ``CITATION.cff`` file is the authoritative source for the
+current software citation metadata, including the contributor list, release
+metadata, licence, repository URL and preferred publication.
+
+On GitHub, the **Cite this repository** control reads this file and can be used
+to copy or export a formatted citation. This is preferable to maintaining a
+second, potentially stale, author list in the documentation.
+
+Preferred publication
+---------------------
+
+In addition to the software citation, please cite:
+
+    Steven Hiscocks, Jordi Barr, Nicola Perree, James Wright, Henry Pritchett,
+    Oliver Rosoman, Michael Harris, Roisín Gorman, Sam Pike, Peter Carniglia,
+    Lyudmil Vladimirov and Benedict Oakes, "Stone Soup: No Longer Just an
+    Appetiser", *2023 26th International Conference on Information Fusion
+    (FUSION)*, 2023. DOI:
+    `10.23919/FUSION52260.2023.10224185
+    <https://doi.org/10.23919/FUSION52260.2023.10224185>`_.
+
+Why cite both?
+--------------
+
+The software citation provides credit to the wider contributor community and
+identifies Stone Soup as the research software used in the work. The preferred
+publication provides the peer-reviewed description of the framework. Citing
+both therefore gives readers a persistent software reference as well as the
+scientific context for Stone Soup.
+
+For the latest citation metadata, always refer to ``CITATION.cff`` in the
+repository rather than copying author or release information from an older
+publication.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -74,6 +74,7 @@ Contents
     auto_tutorials/index
     auto_examples/index
     auto_demos/index
+    citing
     contributing
     copyright
 


### PR DESCRIPTION
## Summary

Completes the documentation side of #986 by adding a dedicated guide explaining how to cite Stone Soup.

The repository already contains `CITATION.cff` from #987, including the software DOI and the preferred FUSION 2023 publication, but that information is not surfaced in the main documentation. Users therefore still need to discover the repository metadata themselves.

## Change

- Add a `Citing Stone Soup` documentation page.
- Follow the existing `CITATION.cff` instruction to cite both the software and the preferred publication.
- Surface the Stone Soup software DOI `10.5281/zenodo.4663993`.
- Surface the preferred paper, *Stone Soup: No Longer Just an Appetiser*, DOI `10.23919/FUSION52260.2023.10224185`.
- Explain that `CITATION.cff` remains the authoritative source for the current contributor and release metadata.
- Point users to GitHub's **Cite this repository** control rather than duplicating the full evolving software author list in documentation.
- Add the page to the main documentation toctree.

## Scope

Documentation only. The existing citation metadata and DOI records are unchanged.

Closes #986