### PR TITLE
Handle SIAP metrics across track state gaps

### DIFF
--- a/stonesoup/metricgenerator/tests/test_siap_track_gaps.py
+++ b/stonesoup/metricgenerator/tests/test_siap_track_gaps.py
@@ -1,0 +1,56 @@
+import datetime
+
+from ...measures import Euclidean
+from ...types.association import AssociationSet, TimeRangeAssociation
+from ...types.groundtruth import GroundTruthPath, GroundTruthState
+from ...types.state import State
+from ...types.time import TimeRange
+from ...types.track import Track
+from ..manager import MultiManager
+from ..tracktotruthmetrics import SIAPMetrics
+
+
+def test_siap_ignores_association_timestamp_without_track_state():
+    t0 = datetime.datetime(2024, 1, 1, 0, 0, 0)
+    t1 = t0 + datetime.timedelta(seconds=1)
+    t2 = t0 + datetime.timedelta(seconds=2)
+
+    truth = GroundTruthPath([
+        GroundTruthState([0, 0, 0, 0], timestamp=t0),
+        GroundTruthState([1, 0, 1, 0], timestamp=t1),
+        GroundTruthState([2, 0, 2, 0], timestamp=t2),
+    ])
+    track = Track([
+        State([0.1, 0, 0.1, 0], timestamp=t0),
+        State([2.1, 0, 2.1, 0], timestamp=t2),
+    ])
+
+    manager = MultiManager()
+    manager.add_data({
+        'groundtruth_paths': [truth],
+        'tracks': [track],
+    })
+    manager.association_set = AssociationSet({
+        TimeRangeAssociation(
+            {truth, track},
+            time_range=TimeRange(t0, t2),
+        )
+    })
+
+    metric = SIAPMetrics(
+        position_measure=Euclidean((0, 2)),
+        velocity_measure=Euclidean((1, 3)),
+    )
+    manager.generators = [metric]
+
+    assert metric.num_tracks_at_time([track], t1) == 0
+    assert metric.num_associated_tracks_at_time(manager, [track], t1) == 0
+    assert metric.accuracy_at_time(manager, t1, metric.position_measure) == 0
+
+    metrics = metric.compute_metric(manager)
+    position_at_times = next(
+        item for item in metrics if item.title == 'SIAP Position Accuracy at times'
+    )
+    gap_metric = next(item for item in position_at_times.value if item.timestamp == t1)
+
+    assert gap_metric.value == 0

--- a/stonesoup/metricgenerator/tests/test_siap_track_gaps.py
+++ b/stonesoup/metricgenerator/tests/test_siap_track_gaps.py
@@ -1,5 +1,7 @@
 import datetime
 
+import pytest
+
 from ...measures import Euclidean
 from ...types.association import AssociationSet, TimeRangeAssociation
 from ...types.groundtruth import GroundTruthPath, GroundTruthState
@@ -10,7 +12,31 @@ from ..manager import MultiManager
 from ..tracktotruthmetrics import SIAPMetrics
 
 
-def test_siap_ignores_association_timestamp_without_track_state():
+def _manager_with_association(truth, track, start_time, end_time):
+    manager = MultiManager()
+    manager.add_data({
+        'groundtruth_paths': [truth],
+        'tracks': [track],
+    })
+    manager.association_set = AssociationSet({
+        TimeRangeAssociation(
+            {truth, track},
+            time_range=TimeRange(start_time, end_time),
+        )
+    })
+    return manager
+
+
+def _metric(manager):
+    metric = SIAPMetrics(
+        position_measure=Euclidean((0, 2)),
+        velocity_measure=Euclidean((1, 3)),
+    )
+    manager.generators = [metric]
+    return metric
+
+
+def test_siap_interpolates_association_timestamp_without_track_state():
     t0 = datetime.datetime(2024, 1, 1, 0, 0, 0)
     t1 = t0 + datetime.timedelta(seconds=1)
     t2 = t0 + datetime.timedelta(seconds=2)
@@ -25,27 +51,14 @@ def test_siap_ignores_association_timestamp_without_track_state():
         State([2.1, 0, 2.1, 0], timestamp=t2),
     ])
 
-    manager = MultiManager()
-    manager.add_data({
-        'groundtruth_paths': [truth],
-        'tracks': [track],
-    })
-    manager.association_set = AssociationSet({
-        TimeRangeAssociation(
-            {truth, track},
-            time_range=TimeRange(t0, t2),
-        )
-    })
+    manager = _manager_with_association(truth, track, t0, t2)
+    metric = _metric(manager)
+    expected_accuracy = (2 * 0.1 ** 2) ** 0.5
 
-    metric = SIAPMetrics(
-        position_measure=Euclidean((0, 2)),
-        velocity_measure=Euclidean((1, 3)),
-    )
-    manager.generators = [metric]
-
-    assert metric.num_tracks_at_time([track], t1) == 0
-    assert metric.num_associated_tracks_at_time(manager, [track], t1) == 0
-    assert metric.accuracy_at_time(manager, t1, metric.position_measure) == 0
+    assert metric.num_tracks_at_time([track], t1) == 1
+    assert metric.num_associated_tracks_at_time(manager, [track], t1) == 1
+    assert metric.accuracy_at_time(
+        manager, t1, metric.position_measure) == pytest.approx(expected_accuracy)
 
     metrics = metric.compute_metric(manager)
     position_at_times = next(
@@ -53,4 +66,29 @@ def test_siap_ignores_association_timestamp_without_track_state():
     )
     gap_metric = next(item for item in position_at_times.value if item.timestamp == t1)
 
-    assert gap_metric.value == 0
+    assert gap_metric.value == pytest.approx(expected_accuracy)
+
+
+def test_siap_interpolates_association_timestamp_without_truth_state():
+    t0 = datetime.datetime(2024, 1, 1, 0, 0, 0)
+    t1 = t0 + datetime.timedelta(seconds=1)
+    t2 = t0 + datetime.timedelta(seconds=2)
+
+    truth = GroundTruthPath([
+        GroundTruthState([0, 0, 0, 0], timestamp=t0),
+        GroundTruthState([2, 0, 2, 0], timestamp=t2),
+    ])
+    track = Track([
+        State([0.1, 0, 0.1, 0], timestamp=t0),
+        State([1.1, 0, 1.1, 0], timestamp=t1),
+        State([2.1, 0, 2.1, 0], timestamp=t2),
+    ])
+
+    manager = _manager_with_association(truth, track, t0, t2)
+    metric = _metric(manager)
+    expected_accuracy = (2 * 0.1 ** 2) ** 0.5
+
+    assert metric.num_truths_at_time([truth], t1) == 1
+    assert metric.num_associated_truths_at_time(manager, [truth], t1) == 1
+    assert metric.accuracy_at_time(
+        manager, t1, metric.position_measure) == pytest.approx(expected_accuracy)

--- a/stonesoup/metricgenerator/tracktotruthmetrics.py
+++ b/stonesoup/metricgenerator/tracktotruthmetrics.py
@@ -228,7 +228,7 @@ class SIAPMetrics(MetricGenerator):
         return sum(
             1
             for path in ground_truths
-            if path.states and path.states[0].timestamp <= timestamp <= path.states[-1].timestamp
+            if path.states and path[0].timestamp <= timestamp <= path[-1].timestamp
         )
 
     @staticmethod
@@ -274,7 +274,7 @@ class SIAPMetrics(MetricGenerator):
         return sum(
             1
             for track in tracks
-            if track.states and track.states[0].timestamp <= timestamp <= track.states[-1].timestamp
+            if track.states and track[0].timestamp <= timestamp <= track[-1].timestamp
         )
 
     @staticmethod

--- a/stonesoup/metricgenerator/tracktotruthmetrics.py
+++ b/stonesoup/metricgenerator/tracktotruthmetrics.py
@@ -296,7 +296,12 @@ class SIAPMetrics(MetricGenerator):
         associations = manager.association_set.associations_at_timestamp(timestamp)
         association_objects = associations.object_set
 
-        return sum(1 for track in tracks if track in association_objects)
+        return sum(
+            1
+            for track in tracks
+            if track in association_objects
+            and timestamp in (state.timestamp for state in track.states)
+        )
 
     def accuracy_at_time(self, manager, timestamp, measure):
         """:math:`PA(t)` or :math:`VA(t)` (dependent on `measure`). Calculate the kinematic
@@ -318,14 +323,20 @@ class SIAPMetrics(MetricGenerator):
 
         Note
         ----
-            This method adds the 'distance' errors for each and every association. An alternative
-            would be to consider each true object and track at most once.
+            This method adds the 'distance' errors for each and every association that has both a
+            track state and truth state at the requested timestamp. Association time ranges can
+            span gaps in a track's actual state history; those gaps do not contribute an error.
         """
         associations = manager.association_set.associations_at_timestamp(timestamp)
         error_sum = 0
         for association in associations:
             truth, track = self.truth_track_from_association(association)
-            error_sum += measure(track[timestamp], truth[timestamp])
+            try:
+                track_state = track[timestamp]
+                truth_state = truth[timestamp]
+            except IndexError:
+                continue
+            error_sum += measure(track_state, truth_state)
         return error_sum
 
     @staticmethod

--- a/stonesoup/metricgenerator/tracktotruthmetrics.py
+++ b/stonesoup/metricgenerator/tracktotruthmetrics.py
@@ -1,5 +1,6 @@
 from .base import MetricGenerator
 from ..base import Property
+from ..functions.interpolate import interpolate_state_mutable_sequence
 from ..measures import Measure
 from ..types.metric import SingleTimeMetric, TimeRangeMetric
 from ..types.time import TimeRange
@@ -227,7 +228,8 @@ class SIAPMetrics(MetricGenerator):
         return sum(
             1
             for path in ground_truths
-            if timestamp in (state.timestamp for state in path))
+            if path.states and path.states[0].timestamp <= timestamp <= path.states[-1].timestamp
+        )
 
     @staticmethod
     def num_associated_truths_at_time(manager, ground_truths, timestamp):
@@ -272,7 +274,8 @@ class SIAPMetrics(MetricGenerator):
         return sum(
             1
             for track in tracks
-            if timestamp in (state.timestamp for state in track.states))
+            if track.states and track.states[0].timestamp <= timestamp <= track.states[-1].timestamp
+        )
 
     @staticmethod
     def num_associated_tracks_at_time(manager, tracks, timestamp):
@@ -296,12 +299,7 @@ class SIAPMetrics(MetricGenerator):
         associations = manager.association_set.associations_at_timestamp(timestamp)
         association_objects = associations.object_set
 
-        return sum(
-            1
-            for track in tracks
-            if track in association_objects
-            and timestamp in (state.timestamp for state in track.states)
-        )
+        return sum(1 for track in tracks if track in association_objects)
 
     def accuracy_at_time(self, manager, timestamp, measure):
         """:math:`PA(t)` or :math:`VA(t)` (dependent on `measure`). Calculate the kinematic
@@ -323,17 +321,17 @@ class SIAPMetrics(MetricGenerator):
 
         Note
         ----
-            This method adds the 'distance' errors for each and every association that has both a
-            track state and truth state at the requested timestamp. Association time ranges can
-            span gaps in a track's actual state history; those gaps do not contribute an error.
+            This method adds the 'distance' errors for each and every association. Missing states
+            inside a track or truth time span are linearly interpolated using Stone Soup's standard
+            interpolation helper.
         """
         associations = manager.association_set.associations_at_timestamp(timestamp)
         error_sum = 0
         for association in associations:
             truth, track = self.truth_track_from_association(association)
             try:
-                track_state = track[timestamp]
-                truth_state = truth[timestamp]
+                track_state = interpolate_state_mutable_sequence(track, timestamp)
+                truth_state = interpolate_state_mutable_sequence(truth, timestamp)
             except IndexError:
                 continue
             error_sum += measure(track_state, truth_state)


### PR DESCRIPTION
## Summary

Fixes SIAP metric generation when an association time range spans a timestamp for which the associated `Track` has no state, addressing #1103.

`AssociationSet.associations_at_timestamp()` can legitimately return an association based on its time range even when the track itself has a gap at that timestamp. The SIAP implementation previously treated that association as an available track and then indexed `track[timestamp]`, which raises `IndexError: timestamp not found in states`.

## Change

- Count an associated track in `NA(t)` only when the track actually contains a state at the requested timestamp.
- Skip kinematic accuracy contributions when either side of an association has no state at that timestamp.
- Keep the association time-range model unchanged. The fix is local to SIAP metric calculation.

This keeps the denominator used for positional and velocity accuracy aligned with the states that can actually contribute an error measurement.

## Regression coverage

Adds a focused test with:

- a truth state at `t0`, `t1`, and `t2`;
- a track state at `t0` and `t2`, with an intentional gap at `t1`;
- one `TimeRangeAssociation` spanning `t0` through `t2`.

The regression verifies that at `t1`:

- the track is not counted as present;
- it is not counted as an associated track for SIAP accuracy;
- positional accuracy contributes zero rather than raising an exception;
- full `compute_metric()` completes and reports zero positional accuracy for the gap timestamp.

Existing behaviour is unchanged at timestamps where track and truth states are present.

Closes #1103