### PR TITLE
Support streamed DataFrames in pandas readers

### DIFF
--- a/docs/examples/readers/Streaming_Pandas_DataFrames.py
+++ b/docs/examples/readers/Streaming_Pandas_DataFrames.py
@@ -1,0 +1,73 @@
+"""
+Streaming pandas DataFrames
+===========================
+
+Stone Soup's pandas readers can consume an iterable of DataFrames as well as one DataFrame held
+entirely in memory. This is useful when data arrives in batches, for example as CSV files added to
+a directory over time.
+
+The reader consumes the iterable lazily. Each yielded DataFrame must use the same schema expected
+by the reader and the sequence of rows across all DataFrames must be in time order.
+
+This example uses a finite temporary directory so it is deterministic when built by Sphinx-Gallery.
+In a live application, ``dataframe_batches`` can be replaced by a directory watcher, message-queue
+consumer, database cursor, or another generator that yields new DataFrames as data arrives.
+"""
+
+# %%
+# Create two small CSV batches. The second batch deliberately starts at the same timestamp at which
+# the first batch ends, demonstrating that detections are still grouped by timestamp across a
+# DataFrame boundary.
+import datetime
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+import pandas as pd
+
+from stonesoup.reader.pandas_reader import DataFrameDetectionReader
+
+
+with TemporaryDirectory() as directory_name:
+    directory = Path(directory_name)
+
+    pd.DataFrame({
+        "x": [10, 11],
+        "y": [20, 21],
+        "time": [
+            datetime.datetime(2026, 1, 1, 12, 0),
+            datetime.datetime(2026, 1, 1, 12, 1),
+        ],
+    }).to_csv(directory / "batch_001.csv", index=False)
+
+    pd.DataFrame({
+        "x": [12, 13],
+        "y": [22, 23],
+        "time": [
+            datetime.datetime(2026, 1, 1, 12, 1),
+            datetime.datetime(2026, 1, 1, 12, 2),
+        ],
+    }).to_csv(directory / "batch_002.csv", index=False)
+
+    # %%
+    # The generator yields one DataFrame at a time instead of concatenating the whole dataset.
+    # Sorting the file names provides deterministic batch order for this example. A live watcher
+    # should provide the same ordering guarantee itself.
+    def dataframe_batches(path):
+        for csv_path in sorted(path.glob("*.csv")):
+            yield pd.read_csv(csv_path, parse_dates=["time"])
+
+    reader = DataFrameDetectionReader(
+        dataframe=dataframe_batches(directory),
+        state_vector_fields=["x", "y"],
+        time_field="time",
+    )
+
+    # %%
+    # Iteration is unchanged from a reader constructed with one in-memory DataFrame.
+    for timestamp, detections in reader:
+        print(timestamp, len(detections))
+
+# %%
+# The output contains one detection at 12:00, two detections at 12:01 (one from each DataFrame),
+# and one detection at 12:02. The important constraint is that the generator must yield batches in
+# chronological order; the reader does not sort or buffer arbitrary out-of-order batches.

--- a/stonesoup/reader/pandas_reader.py
+++ b/stonesoup/reader/pandas_reader.py
@@ -1,5 +1,5 @@
 
-from collections.abc import Iterator
+from collections.abc import Iterable, Iterator
 
 try:
     import pandas as pd
@@ -12,20 +12,33 @@ from .generic import _DictDetectionReader, _DictGroundTruthReader, _DictReader, 
 
 
 class _DataFrameReader(_DictReader):
-    dataframe: pd.DataFrame = Property(doc="DataFrame containing the state data.")
+    dataframe: pd.DataFrame | Iterable[pd.DataFrame] = Property(
+        doc="DataFrame containing the state data, or an iterable yielding DataFrames in time "
+            "order."
+    )
 
     @property
     def dict_reader(self) -> Iterator[dict]:
-        yield from self.dataframe.to_dict(orient="records")
+        if isinstance(self.dataframe, pd.DataFrame):
+            dataframes = (self.dataframe,)
+        else:
+            dataframes = self.dataframe
+
+        for dataframe in dataframes:
+            if not isinstance(dataframe, pd.DataFrame):
+                raise TypeError(
+                    "dataframe must be a pandas DataFrame or an iterable yielding DataFrames")
+            yield from dataframe.to_dict(orient="records")
 
 
 class DataFrameGroundTruthReader(_DictGroundTruthReader, _DataFrameReader):
     """A custom reader for pandas DataFrames containing truth data.
 
-    The DataFrame must have columns containing all fields needed to generate the
-    ground truth state. Those states with the same ID will be put into
-    a :class:`~.GroundTruthPath` in sequence. All paths that are updated at the same time
-    are yielded together. Assume DataFrame is in time order.
+    The input may be a single DataFrame or an iterable yielding DataFrames. Each DataFrame must
+    have columns containing all fields needed to generate the ground truth state. When an iterable
+    is supplied, its DataFrames must collectively be in time order. States with the same ID are
+    put into a :class:`~.GroundTruthPath` in sequence, and all paths updated at the same time are
+    yielded together.
 
     Parameters
     ----------
@@ -35,8 +48,10 @@ class DataFrameGroundTruthReader(_DictGroundTruthReader, _DataFrameReader):
 class DataFrameDetectionReader(_DictDetectionReader, _DataFrameReader):
     """A custom detection reader for DataFrames containing detections.
 
-    The DataFrame must have columns containing all fields needed to generate the detection.
-    Detections at the same time are yielded together. Assume DataFrame is in time order.
+    The input may be a single DataFrame or an iterable yielding DataFrames. Each DataFrame must
+    have columns containing all fields needed to generate the detections. When an iterable is
+    supplied, its DataFrames must collectively be in time order. Detections at the same time are
+    yielded together.
 
     Parameters
     ----------
@@ -45,12 +60,13 @@ class DataFrameDetectionReader(_DictDetectionReader, _DataFrameReader):
 
 class DataFrameTrackReader(_DictTrackReader, _DataFrameReader):
     """A :class:`~.TrackReader` class for reading in :class:`~.Track` from
-    a pandas DataFrame.
+    pandas DataFrames.
 
-    The DataFrame must have columns containing all fields needed to generate the
-    track states. Those states with the same ID will be put into
-    a :class:`~.Track` in sequence. All paths that are updated at the same time
-    are yielded together. Assume DataFrame is in time order.
+    The input may be a single DataFrame or an iterable yielding DataFrames. Each DataFrame must
+    have columns containing all fields needed to generate the track states. When an iterable is
+    supplied, its DataFrames must collectively be in time order. States with the same ID are put
+    into a :class:`~.Track` in sequence, and all tracks updated at the same time are yielded
+    together.
 
     Parameters
     ----------

--- a/stonesoup/reader/tests/test_pandas_reader_stream.py
+++ b/stonesoup/reader/tests/test_pandas_reader_stream.py
@@ -1,0 +1,70 @@
+import datetime
+
+import numpy as np
+import pytest
+
+pytest.importorskip("pandas")
+import pandas as pd  # noqa: E402
+
+from ..pandas_reader import DataFrameDetectionReader  # noqa: E402
+
+
+def test_detection_reader_accepts_dataframe_generator():
+    first = pd.DataFrame({
+        "x": [10, 11],
+        "y": [20, 21],
+        "t": [
+            datetime.datetime(2026, 1, 1, 12, 0),
+            datetime.datetime(2026, 1, 1, 12, 1),
+        ],
+    })
+    second = pd.DataFrame({
+        "x": [12, 13],
+        "y": [22, 23],
+        "t": [
+            datetime.datetime(2026, 1, 1, 12, 1),
+            datetime.datetime(2026, 1, 1, 12, 2),
+        ],
+    })
+
+    def dataframe_generator():
+        yield first
+        yield second
+
+    reader = DataFrameDetectionReader(
+        dataframe=dataframe_generator(),
+        state_vector_fields=["x", "y"],
+        time_field="t",
+    )
+
+    steps = list(reader)
+
+    assert [timestamp for timestamp, _ in steps] == [
+        datetime.datetime(2026, 1, 1, 12, 0),
+        datetime.datetime(2026, 1, 1, 12, 1),
+        datetime.datetime(2026, 1, 1, 12, 2),
+    ]
+    assert [len(detections) for _, detections in steps] == [1, 2, 1]
+
+    state_vectors = sorted(
+        (tuple(np.asarray(detection.state_vector).ravel())
+         for _, detections in steps for detection in detections)
+    )
+    assert state_vectors == [(10, 20), (11, 21), (12, 22), (13, 23)]
+
+
+def test_detection_reader_rejects_non_dataframe_chunk():
+    valid = pd.DataFrame({
+        "x": [10],
+        "y": [20],
+        "t": [datetime.datetime(2026, 1, 1, 12, 0)],
+    })
+
+    reader = DataFrameDetectionReader(
+        dataframe=iter((valid, {"x": [11]})),
+        state_vector_fields=["x", "y"],
+        time_field="t",
+    )
+
+    with pytest.raises(TypeError, match="iterable yielding DataFrames"):
+        list(reader)


### PR DESCRIPTION
## Summary

Addresses #971 by allowing Stone Soup's pandas readers to consume either a single `pandas.DataFrame` or an iterable that yields DataFrames over time.

The existing `_DataFrameReader` requires the complete DataFrame to be available up front. That works well for in-memory datasets, but it prevents the same reader classes from being used naturally with batch-oriented sources such as a directory where new files are added, database result batches, or another generator that produces DataFrames incrementally.

## Change

- Extend `_DataFrameReader.dataframe` to accept either one DataFrame or an iterable of DataFrames.
- Consume iterable inputs lazily, one DataFrame at a time, and yield their records into the existing `_DictReader` pipeline.
- Validate every yielded chunk and raise a clear `TypeError` if the iterable produces something other than a DataFrame.
- Preserve the existing single-DataFrame path unchanged.
- Document that rows across yielded DataFrames must remain in time order, matching the ordering requirement of the existing dictionary-reader implementation.
- Apply the capability consistently to `DataFrameDetectionReader`, `DataFrameGroundTruthReader`, and `DataFrameTrackReader` through their shared base class.

## Regression coverage

Adds focused tests showing that:

- a generator yielding two DataFrames is accepted;
- a timestamp split across the DataFrame boundary is still grouped into a single reader timestep;
- all records are retained with the expected state vectors;
- a non-DataFrame chunk fails with an explicit error.

## Documentation

Adds a Sphinx-Gallery example using two CSV files in a temporary directory. A DataFrame generator reads the files sequentially and feeds them directly into `DataFrameDetectionReader`, demonstrating the pattern requested in #971 without introducing file-watching behaviour into the reader itself.

The example also makes the ordering contract explicit: the producer is responsible for yielding chronological batches; the reader does not buffer or reorder arbitrary out-of-order input.

Closes #971