### PR TITLE
Add Stone Soup presentations and public resources page

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -126,6 +126,7 @@ Contents
     auto_tutorials/index
     auto_examples/index
     auto_demos/index
+    presentations
     contributing
     copyright
 

--- a/docs/source/presentations.rst
+++ b/docs/source/presentations.rst
@@ -1,0 +1,58 @@
+Presentations and public resources
+==================================
+
+Stone Soup has been presented and taught at tracking, sensor-fusion and defence research events
+since before its public release. This page collects public presentation and tutorial material that
+is useful for understanding the project's design, history and applications.
+
+Presentations and tutorials
+---------------------------
+
+2017 — An Open Source framework for Tracking and State Estimation (Stone Soup)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+`Paul A. Thomas's 2017 presentation <https://www.fkie.fraunhofer.de/content/dam/fkie/de/documents/11thSymposiumSDF2017/PaulThomas_StoneSoup_An%20Open%20Source%20Framework%20for%20Tracking%20and%20State%20Estimation.pdf>`_
+introduces the original Stone Soup concept, including the motivation for comparable tracking
+algorithms, the modular framework, data and metrics, and the intended collaborative development
+model.
+
+Sensor Signal Processing for Defence — Soup in the Souk
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+`Professor Paul Thomas's Stone Soup talk <https://sspd.eng.ed.ac.uk/professor-paul-thomas>`_
+discusses the open-source development model behind Stone Soup and its use as a collaborative
+framework for defence signal-processing innovation.
+
+FUSION 2025 — Practical multi-target tracking and sensor management with Stone Soup
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The `FUSION 2025 Stone Soup tutorial <https://fusion2025.org/tutorials/>`_ was delivered by
+Lyudmil Vladimirov, Steven Hiscocks and James Wright. It covered Stone Soup's component model and
+practical use for multi-target tracking and sensor management.
+
+FUSION 2026 — Practical multi-target tracking and sensor management with Stone Soup
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The `FUSION 2026 Stone Soup tutorial <https://www.ntnu.edu/fusion2026/tutorials>`_ was delivered by
+James Wright and Chris Sherman. The practical tutorial covered Stone Soup components, linear and
+nonlinear models, filtering, data association, track management and sensor management.
+
+Project background and impact
+-----------------------------
+
+The following Dstl material provides additional context on the project's public release and later
+use:
+
+* `Dstl shares new open-source framework initiative <https://www.gov.uk/government/news/dstl-shares-new-open-source-framework-initiative>`_
+  (2019), announcing the public Stone Soup framework and its collaborative tracking and state
+  estimation goals.
+* `Open source innovation driving defence advantage <https://www.gov.uk/government/case-studies/open-source-innovation-driving-defence-advantage>`_
+  (2026), a Dstl case study describing Stone Soup's use across defence, industry, academia and
+  international partners.
+
+Keeping this page current
+-------------------------
+
+This is intended as a curated list of public Stone Soup presentations and substantial tutorial
+material rather than an exhaustive bibliography. New public talks, tutorials or official project
+resources can be added through a pull request when stable links are available.


### PR DESCRIPTION
## Summary

Adds the documentation page requested in #199 for public Stone Soup presentations and related project material.

The issue has remained open because the repository documentation does not currently provide a single place to discover talks or tutorial material about Stone Soup. This change adds a curated page and links it from the main documentation toctree.

## Content

The page includes:

- Paul A. Thomas's 2017 presentation, *An Open Source framework for Tracking and State Estimation (Stone Soup)*;
- the Sensor Signal Processing for Defence talk *Soup in the Souk*;
- the practical Stone Soup tutorial from FUSION 2025;
- the practical Stone Soup tutorial from FUSION 2026;
- Dstl's 2019 public-release article;
- Dstl's 2026 Stone Soup impact case study.

The presentation list is intentionally curated rather than presented as an exhaustive bibliography. A short maintenance note invites future public talks and substantial tutorial resources to be added when stable links are available.

## Scope

Documentation only. No runtime behaviour, package metadata or existing examples are changed.

Closes #199