### PR TITLE
Document requirements for downloaded demonstrations

### DIFF
--- a/docs/demos/README.rst
+++ b/docs/demos/README.rst
@@ -3,3 +3,32 @@ Demonstrations
 
 Here are a selection of demonstrations of Stone Soup against real data sets.
 
+Running downloaded demonstrations
+---------------------------------
+
+The Sphinx-Gallery download links are useful for taking a demonstration into a
+local notebook, but some demonstrations also depend on data files, generated
+assets, optional Python packages, or external downloads that are not contained
+in every generated archive. Before running a downloaded demonstration, check
+its documentation page for the complete setup instructions.
+
+The repository data files used by the demonstrations can be downloaded directly:
+
+* `Solent AIS data <https://raw.githubusercontent.com/dstl/Stone-Soup/main/docs/demos/SolentAIS_20160112_130211.csv>`_
+  for ``AIS_Solent_Tracker``;
+* `OpenSky plane-state data <https://raw.githubusercontent.com/dstl/Stone-Soup/main/docs/demos/OpenSky_Plane_States.csv>`_
+  for ``OpenSky_Demo``; and
+* `UAV rotation data <https://raw.githubusercontent.com/dstl/Stone-Soup/main/docs/demos/UAV_Rot.csv>`_
+  for ``UAV_tutorial``.
+
+``AIS_Solent_Tracker`` and ``OpenSky_Demo`` use ``folium``. It is included in
+Stone Soup's ``dev`` extra for a development checkout. ``Video_Processing`` has
+additional multimedia and object-detection requirements; follow that demo's
+setup instructions and install the ``video`` and ``ultralytics`` extras. The
+video demonstration also downloads its example video, and Ultralytics may
+download model weights on first use, so those steps require network access.
+
+For the most reproducible setup, particularly on an isolated or restricted
+network, clone the repository so the demonstration sources and repository data
+files are available together, and obtain any externally downloaded video or
+model assets before moving into the restricted environment.


### PR DESCRIPTION
## Summary

Improves the documentation around downloaded Stone Soup demonstrations, addressing the remaining usability problem described in #1050.

Sphinx-Gallery makes the generated notebook/source downloads convenient, but some demonstrations depend on repository data files, optional packages, generated assets, or external downloads that are not present in every generated archive. This can leave a locally downloaded demo looking self-contained when it is not.

The issue discussion already suggested adding guidance alongside the demonstration downloads so users know to check the full demo page and obtain the additional resources. This change adds that guidance to the demonstrations gallery introduction.

## Change

The demonstrations landing page now:

- explains that generated downloads may require supporting data, assets, packages, or network downloads;
- links directly to the repository data used by `AIS_Solent_Tracker`, `OpenSky_Demo`, and `UAV_tutorial`;
- notes that the AIS and OpenSky demos use `folium`, which is available through the development extra;
- points `Video_Processing` users to the `video` and `ultralytics` extras;
- makes the network requirements of the video download and first-use model-weight download explicit;
- recommends a repository checkout, plus pre-fetching external assets, for restricted or isolated environments.

This complements #1051, which added the OpenSky CSV/icon links, by providing the gallery-level guidance suggested in the discussion on #1050.

## Scope

Documentation only. The Sphinx-Gallery archive generation itself is unchanged.

Addresses #1050