### PR TITLE
Prioritise API objects in documentation search

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -260,9 +260,8 @@ html_css_files = ['css/custom.css']
 # Now only 'ja' uses this config value
 # html_search_options = {'type': 'default'}
 
-# The name of a javascript file (relative to the configuration directory) that
-# implements a search results scorer. If empty, the default will be used.
-# html_search_scorer = 'scorer.js'
+# Prefer exact API object matches over pages that only mention the query.
+html_search_scorer = 'search_scorer.js'
 
 # Output file base name for HTML help builder.
 htmlhelp_basename = 'StoneSoupdoc'

--- a/docs/source/search_scorer.js
+++ b/docs/source/search_scorer.js
@@ -1,0 +1,20 @@
+const Scorer = {
+  // API documentation is most useful when an exact component/type search lands
+  // on that object's own entry before pages which merely mention it.
+  objNameMatch: 50,
+  objPartialMatch: 20,
+
+  // Preserve Sphinx's normal ordering between documented-object priorities.
+  objPrio: {
+    0: 15,
+    1: 5,
+    2: -5,
+  },
+  objPrioDefault: 0,
+
+  // Keep the standard weights for ordinary page-title and text matches.
+  title: 15,
+  partialTitle: 7,
+  term: 5,
+  partialTerm: 2,
+};


### PR DESCRIPTION
## Summary

Improves the ordering of Stone Soup documentation search results so exact API object matches rank ahead of pages that merely mention the same term, addressing #1198.

The reported example is a search for `TrueDetection`, where the most useful result is the API entry for the type itself. Sphinx's default search weights give an exact object-name match a lower score than a title match, which can allow surrounding documentation pages to appear before the requested component.

## Change

- Configure Sphinx's supported `html_search_scorer` hook.
- Add a small custom scorer that raises the weight for exact API object-name matches from the default `11` to `50`.
- Raise partial object-name matches from `6` to `20`, so searches using the final component/type name still favour API entries.
- Preserve Sphinx's default object-priority, title, partial-title, term and partial-term weights.

This is deliberately a ranking-only change. It does not alter the generated search index, stemming, documented objects, or page content.

## Rationale

Stone Soup's documentation is strongly API-oriented. When a query exactly matches a documented class or component name, that object's own API entry is normally the most useful first result. General page-title and text matches remain unchanged and continue to rank normally when there is no strong object match.

The implementation uses Sphinx's documented search-scorer interface rather than patching generated search JavaScript or theme files.

## Scope

Documentation build/search configuration only. Runtime Stone Soup behaviour is unchanged.

Closes #1198