### PR TITLE
Document array inputs for angle wrapping functions

### DIFF
--- a/stonesoup/functions/__init__.py
+++ b/stonesoup/functions/__init__.py
@@ -761,13 +761,13 @@ def mod_bearing(x):
 
     Parameters
     ----------
-    x: float
-        bearing angle in radians
+    x : float or numpy.ndarray
+        Bearing angle or array of bearing angles in radians.
 
     Returns
     -------
-    float
-        Angle in radians in the range math: :math:`-\pi` to :math:`+\pi`
+    float or numpy.ndarray
+        Angle or array of angles in radians in the range :math:`-\pi` to :math:`+\pi`.
     """
 
     x = (x+np.pi) % (2.0*np.pi)-np.pi
@@ -781,13 +781,13 @@ def mod_elevation(x):
 
     Parameters
     ----------
-    x: float
-        elevation angle in radians
+    x : float or numpy.ndarray
+        Elevation angle or array of elevation angles in radians.
 
     Returns
     -------
-    float
-        Angle in radians in the range math: :math:`-\pi/2` to :math:`+\pi/2`
+    float or numpy.ndarray
+        Angle or array of angles in radians in the range :math:`-\pi/2` to :math:`+\pi/2`.
 
     Note
     ----


### PR DESCRIPTION
## Summary

Updates the angle-wrapping function docstrings so they reflect the array inputs already supported by the implementation, addressing #1171.

## Change

- document `mod_bearing` as accepting and returning either a scalar or NumPy array
- document the same behavior for `mod_elevation`

## Scope

Documentation only. Function behaviour is unchanged.

Closes #1171