### PR TITLE
Handle Mahalanobis roundoff before square root

### DIFF
--- a/stonesoup/measures/state.py
+++ b/stonesoup/measures/state.py
@@ -284,7 +284,10 @@ class Mahalanobis(SquaredMahalanobis):
             objects
 
         """
-        return np.sqrt(super().__call__(state1, state2))
+        squared_distance = super().__call__(state1, state2)
+        if np.any(squared_distance < -1e-10):
+            raise ValueError("Squared Mahalanobis distance shouldn't be less than 0")
+        return np.sqrt(np.maximum(squared_distance, 0))
 
 
 class SquaredGaussianHellinger(Measure):

--- a/stonesoup/measures/tests/test_mahalanobis_roundoff.py
+++ b/stonesoup/measures/tests/test_mahalanobis_roundoff.py
@@ -1,0 +1,27 @@
+import numpy as np
+import pytest
+
+from ..state import Mahalanobis, SquaredMahalanobis
+
+
+def test_mahalanobis_clamps_negative_roundoff(monkeypatch):
+    monkeypatch.setattr(
+        SquaredMahalanobis,
+        "__call__",
+        lambda self, state1, state2: np.array([-1e-12, 4.0]),
+    )
+
+    result = Mahalanobis()(None, None)
+
+    assert np.allclose(result, [0.0, 2.0])
+
+
+def test_mahalanobis_rejects_material_negative_distance(monkeypatch):
+    monkeypatch.setattr(
+        SquaredMahalanobis,
+        "__call__",
+        lambda self, state1, state2: -1e-6,
+    )
+
+    with pytest.raises(ValueError, match="Squared Mahalanobis distance"):
+        Mahalanobis()(None, None)


### PR DESCRIPTION
## Summary

Avoids `RuntimeWarning`/`NaN` when a squared Mahalanobis distance is a tiny negative value caused by floating-point roundoff.

## Change

- clamp tiny negative squared distances within numerical tolerance to zero before `sqrt`;
- raise a clear `ValueError` for materially negative squared distances;
- add regression coverage for both the roundoff case and a materially invalid negative result.

This follows the numerical guard already used by the Gaussian Hellinger measure.

Closes #847