### PR TITLE
Define categorical measurement model matrix

### DIFF
--- a/stonesoup/models/measurement/categorical.py
+++ b/stonesoup/models/measurement/categorical.py
@@ -52,6 +52,16 @@ class MarkovianMeasurementModel(MeasurementModel):
                 f"{len(self.measurement_categories)}"
             )
 
+    def matrix(self, **kwargs):
+        r"""Return the categorical emission matrix :math:`E`.
+
+        Returns
+        -------
+        : :class:`~.Matrix` of shape (:attr:`ndim_meas`, :attr:`ndim_state`)
+            The column-normalised matrix of conditional measurement-category probabilities.
+        """
+        return self.emission_matrix
+
     def function(self, state, **kwargs):
         r"""Applies the linear transformation:
 
@@ -71,7 +81,7 @@ class MarkovianMeasurementModel(MeasurementModel):
             of shape (:py:attr:`~ndim_meas, 1`). The resultant measurement vector.
         """
 
-        meas_vector = self.emission_matrix @ state.state_vector
+        meas_vector = self.matrix(**kwargs) @ state.state_vector
         meas_vector = meas_vector / np.sum(meas_vector)  # normalise
 
         return StateVector(meas_vector)

--- a/stonesoup/models/measurement/tests/test_categorical.py
+++ b/stonesoup/models/measurement/tests/test_categorical.py
@@ -30,6 +30,10 @@ def test_categorical_measurement_model():
                                [4 / 10, 1 / 4, 1 / 20]])
     assert np.allclose(model.emission_matrix, expected_array)
 
+    # Test matrix
+    assert np.allclose(model.matrix(), expected_array)
+    assert model.matrix().shape == (model.ndim_meas, model.ndim_state)
+
     # Test ndim
     assert model.ndim_state == 3
     assert model.ndim_meas == 4
@@ -41,6 +45,7 @@ def test_categorical_measurement_model():
     assert isinstance(new_vector, StateVector)
     assert new_vector.shape[0] == 4
     assert np.isclose(np.sum(new_vector), 1)
+    assert np.allclose(new_vector, model.matrix() @ state.state_vector)
 
     # Test mapping
     assert np.array_equal(model.mapping, [0, 1, 2])


### PR DESCRIPTION
## Summary

Defines the matrix representation of `MarkovianMeasurementModel` using its column-normalised emission matrix.

## Change

- add `matrix()` returning the emission matrix;
- use `matrix()` in the measurement function;
- add tests for matrix values, shape and consistency with `function()`.

Closes #601