### PR TITLE
Clarify Kalman updater measurement model requirements

### DIFF
--- a/docs/source/stonesoup.updater.rst
+++ b/docs/source/stonesoup.updater.rst
@@ -10,6 +10,15 @@ Updaters
 Kalman
 ------
 
+.. note::
+    :class:`~stonesoup.updater.kalman.KalmanUpdater` requires a linear measurement model that
+    provides a :meth:`~stonesoup.models.base.LinearModel.matrix` method. Non-linear measurement
+    models, such as bearing-range models, should instead be used with an
+    :class:`~stonesoup.updater.kalman.ExtendedKalmanUpdater` or
+    :class:`~stonesoup.updater.kalman.UnscentedKalmanUpdater`. To use a standard Kalman filter,
+    measurements must be represented by a compatible linear model, for example Cartesian position
+    measurements.
+
 .. automodule:: stonesoup.updater.kalman
     :show-inheritance:
 


### PR DESCRIPTION
## Summary

Clarifies why a standard `KalmanUpdater` cannot be used directly with the nonlinear bearing-range detections described in #911.

## Change

- document that `KalmanUpdater` requires a linear measurement model with a `matrix()` method
- direct nonlinear bearing-range users to `ExtendedKalmanUpdater` or `UnscentedKalmanUpdater`
- explain that a standard Kalman filter requires measurements represented by a compatible linear model, such as Cartesian position measurements

## Scope

Documentation only. Runtime behaviour is unchanged.

Closes #911