### PR TITLE
Register combined linear Gaussian transition model

### DIFF
--- a/stonesoup/models/transition/__init__.py
+++ b/stonesoup/models/transition/__init__.py
@@ -1,3 +1,7 @@
 from .base import TransitionModel
+from .linear import LinearGaussianTransitionModel, CombinedLinearGaussianTransitionModel
+
+
+LinearGaussianTransitionModel.register(CombinedLinearGaussianTransitionModel)
 
 __all__ = ['TransitionModel']

--- a/stonesoup/models/transition/tests/test_registration.py
+++ b/stonesoup/models/transition/tests/test_registration.py
@@ -1,0 +1,5 @@
+from ..linear import CombinedLinearGaussianTransitionModel, LinearGaussianTransitionModel
+
+
+def test_combined_linear_gaussian_registered_as_linear_gaussian():
+    assert issubclass(CombinedLinearGaussianTransitionModel, LinearGaussianTransitionModel)


### PR DESCRIPTION
## Summary

Registers `CombinedLinearGaussianTransitionModel` as a virtual subclass of `LinearGaussianTransitionModel`, following the maintainer-proposed approach in #538.

## Change

- register the combined linear Gaussian model with `LinearGaussianTransitionModel`
- preserve the existing implementation and inheritance structure
- add regression coverage confirming `issubclass(CombinedLinearGaussianTransitionModel, LinearGaussianTransitionModel)`

This makes the model visible through the expected linear-Gaussian type relationship without inheriting additional implementation or properties.

Closes #538