### PR TITLE
Document intermediate prediction timing

### DIFF
--- a/docs/source/stonesoup.predictor.rst
+++ b/docs/source/stonesoup.predictor.rst
@@ -4,6 +4,19 @@ Predictors
 .. automodule:: stonesoup.predictor
     :no-members:
 
+Prediction timing in trackers
+-----------------------------
+
+A predictor can evaluate a state at any timestamp supplied to its ``predict`` method. When a
+predictor is used inside a tracker, however, prediction times are normally driven by the timestamps
+yielded by the tracker's detector. The tracker does not automatically insert extra prediction
+states between two detector timestamps.
+
+If denser predicted states are required across a measurement gap, either call the predictor at the
+intermediate timestamps explicitly, or have the detector/input generator yield those intermediate
+timestamps with an empty detection set. The tracker will then advance existing tracks using their
+prediction when no detection is associated at that timestep.
+
 .. automodule:: stonesoup.predictor.base
     :show-inheritance:
 


### PR DESCRIPTION
## Summary

Clarifies how to obtain denser predictions across measurement gaps, addressing the question in #848.

## Change

- explain that a predictor can be called for any requested timestamp
- document that tracker prediction times are normally driven by detector/input timestamps
- make explicit that trackers do not automatically insert intermediate prediction states
- describe two ways to obtain denser predictions:
  - call the predictor directly at intermediate timestamps
  - yield intermediate tracker timestamps with empty detection sets so existing tracks advance using predictions

## Scope

Documentation only. Tracker and predictor behaviour is unchanged.

Addresses #848