### PR TITLE
Document PyTorch detector integration pattern

### DIFF
--- a/docs/source/stonesoup.detector.rst
+++ b/docs/source/stonesoup.detector.rst
@@ -7,6 +7,25 @@ Detectors
 .. automodule:: stonesoup.detector.base
     :show-inheritance:
 
+Integrating other object-detection frameworks
+---------------------------------------------
+
+Stone Soup currently provides a TensorFlow object detector, but detectors based on other machine
+learning frameworks can use the same integration pattern. For a video/image detector, the key
+contract is to consume a frame and return Stone Soup :class:`~stonesoup.types.detection.Detection`
+objects carrying the frame timestamp.
+
+The existing :class:`~stonesoup.detector.tensorflow.TensorFlowBoxObjectDetector` is a useful
+reference implementation. Its framework-specific work is isolated in
+``_get_detections_from_frame(frame)``: it reads ``frame.pixels``, invokes the model, converts the
+model outputs into Stone Soup state vectors and metadata, and returns a set of detections. A
+PyTorch-backed detector can follow the same pattern by replacing the TensorFlow inference and
+output conversion with the corresponding PyTorch model calls.
+
+For reusable external integrations, prefer implementing the public :class:`~stonesoup.detector.base.Detector`
+interface. The video helper used internally by the TensorFlow detector is private and may change
+between releases.
+
 TensorFlow
 ----------
 .. automodule:: stonesoup.detector.tensorflow


### PR DESCRIPTION
## Summary

Documents the integration pattern for PyTorch and other external object-detection frameworks, following the maintainer guidance in #1072.

## Change

- point users to `TensorFlowBoxObjectDetector` as the existing reference implementation
- explain the frame-to-`Detection` contract used by video object detectors
- identify `_get_detections_from_frame(frame)` as the framework-specific inference/conversion step
- describe replacing TensorFlow inference with PyTorch model calls while retaining Stone Soup `Detection` outputs
- recommend the public `Detector` interface for reusable external integrations, noting that the video helper is private

## Scope

Documentation only. No PyTorch dependency is added and no detector runtime behaviour changes.

Addresses #1072