### PR TITLE
Fix CircleSamplePositionActionGenerator membership checks

### DIFF
--- a/stonesoup/movable/action/move_position_action.py
+++ b/stonesoup/movable/action/move_position_action.py
@@ -173,6 +173,8 @@ class CircleSamplePositionActionGenerator(SamplePositionActionGenerator):
         "sampling area."
     )
 
+    epsilon = 1e-6
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
@@ -181,6 +183,12 @@ class CircleSamplePositionActionGenerator(SamplePositionActionGenerator):
                              f"not have 2 dimensions. "
                              f":class:`~.CircleSamplePositionActionGenerator` "
                              f"is designed for 2D action generation only.")
+
+    def __contains__(self, item):
+        if isinstance(item, MovePositionAction):
+            item = item.target_value
+        distance = np.sqrt(sum((item - self.current_value)**2))
+        return distance <= self.maximum_travel + self.epsilon
 
     def __iter__(self):
 

--- a/stonesoup/movable/action/tests/test_circle_sample_contains.py
+++ b/stonesoup/movable/action/tests/test_circle_sample_contains.py
@@ -1,0 +1,40 @@
+from datetime import datetime, timedelta
+
+import numpy as np
+
+from stonesoup.movable.action.move_position_action import (
+    CircleSamplePositionActionGenerator,
+    MovePositionAction,
+)
+from stonesoup.types.state import StateVector
+
+
+class _Owner:
+    def __init__(self, position):
+        self.position = position
+
+
+def test_circle_sample_contains_uses_travel_radius():
+    start_time = datetime.now()
+    end_time = start_time + timedelta(seconds=1)
+    owner = _Owner(StateVector([1.0, 2.0]))
+    generator = CircleSamplePositionActionGenerator(
+        owner=owner,
+        attribute="position",
+        start_time=start_time,
+        end_time=end_time,
+        maximum_travel=2.0,
+    )
+
+    inside = StateVector([2.5, 2.0])
+    outside = StateVector([3.1, 2.0])
+    action = MovePositionAction(
+        generator=generator,
+        end_time=end_time,
+        target_value=inside,
+    )
+
+    assert inside in generator
+    assert action in generator
+    assert outside not in generator
+    assert np.isclose(np.linalg.norm(inside - owner.position), 1.5)


### PR DESCRIPTION
Fixes #1179.

`CircleSamplePositionActionGenerator` inherited a membership check that iterated the generator. Because the generator samples random positions on each iteration, checking whether an existing action was contained in it was effectively a new random draw rather than a validation of the action.

This change gives the circle sampler a deterministic `__contains__` implementation based on `maximum_travel`, matching the constraint used when actions are generated. It accepts both `MovePositionAction` and `StateVector` inputs and uses the same small floating-point tolerance as `MaxSpeedPositionActionGenerator`.

A focused regression test covers an in-range state vector, an in-range action, and an out-of-range state vector.