### PR TITLE
Fix OpenSky ground truths without ICAO24

### DIFF
--- a/stonesoup/reader/opensky.py
+++ b/stonesoup/reader/opensky.py
@@ -167,6 +167,6 @@ class OpenSkyNetworkGroundTruthReader(_OpenSkyNetworkReader, GroundTruthReader):
                     path = groundtruth_dict[path_id]
 
                 path.append(GroundTruthState(state.state_vector, state.timestamp, metadata))
-                updated_paths.add(groundtruth_dict[path_id])
+                updated_paths.add(path)
 
             yield time, updated_paths

--- a/stonesoup/reader/tests/test_opensky_missing_icao24.py
+++ b/stonesoup/reader/tests/test_opensky_missing_icao24.py
@@ -1,0 +1,30 @@
+import datetime
+
+import pytest
+
+pytest.importorskip('requests')
+
+from ..opensky import OpenSkyNetworkGroundTruthReader  # noqa: E402
+from ...types.state import State  # noqa: E402
+
+
+def test_opensky_groundtruth_without_icao24_is_yielded(monkeypatch):
+    timestamp = datetime.datetime(2026, 1, 1)
+    state = State([[1.0], [2.0], [3.0]], timestamp=timestamp)
+    metadata = {'icao24': None, 'callsign': 'TEST'}
+
+    reader = OpenSkyNetworkGroundTruthReader()
+    monkeypatch.setattr(
+        reader,
+        'data_gen',
+        lambda: iter([(timestamp, [(state, metadata)])]),
+    )
+
+    time, paths = next(reader.groundtruth_paths_gen())
+
+    assert time == timestamp
+    assert len(paths) == 1
+    path = next(iter(paths))
+    assert len(path) == 1
+    assert path[0].state_vector.tolist() == [[1.0], [2.0], [3.0]]
+    assert path[0].metadata['icao24'] is None


### PR DESCRIPTION
## Summary

Fix `OpenSkyNetworkGroundTruthReader` when OpenSky returns a state without an ICAO24 identifier.

For missing `icao24`, the reader correctly creates a standalone `GroundTruthPath`, but after appending the state it tries to add `groundtruth_dict[path_id]` to the current results. With `path_id is None`, no such dictionary entry exists and the reader raises `KeyError`.

## Change

- add the local `path` object to `updated_paths`
- preserve the existing dictionary-backed path behaviour for states that do have ICAO24 identifiers
- add a regression test for an unidentified OpenSky state

This only affects the existing missing-ICAO24 fallback path.