### PR TITLE
Add optional data storage to dictionary readers

### DIFF
--- a/stonesoup/reader/generic.py
+++ b/stonesoup/reader/generic.py
@@ -109,6 +109,14 @@ class _DictGroundTruthReader(GroundTruthReader, _DictReader):
     """An abstract reader for dictionaries containing truth data."""
 
     path_id_field: str = Property(doc='Name of column to be used as path ID')
+    store_data: bool = Property(
+        default=False,
+        doc='Keep the dictionary of ground truth paths after iteration')
+
+    @property
+    def groundtruth_dict(self) -> dict[str, GroundTruthPath] | None:
+        """Stored ground truth paths when :attr:`store_data` is enabled."""
+        return getattr(self, '_groundtruth_dict', None)
 
     @BufferedGenerator.generator_method
     def groundtruth_paths_gen(self) -> Iterator[tuple[datetime, set[GroundTruthPath]]]:
@@ -127,6 +135,7 @@ class _DictGroundTruthReader(GroundTruthReader, _DictReader):
         """
 
         groundtruth_dict = {}
+        self._groundtruth_dict = groundtruth_dict if self.store_data else None
         updated_paths = set()
         previous_time = None
         for row in self.dict_reader:
@@ -246,6 +255,14 @@ class _DictTrackReader(TrackReader, _DictReader):
     default_covar: np.ndarray = Property(doc="Default covariance matrix for the state.")
     covar_fields_index: dict[str, tuple[int]] = Property(
         doc="Dictionary mapping covariance field names to their indices in the covariance matrix.")
+    store_data: bool = Property(
+        default=False,
+        doc='Keep the dictionary of tracks after iteration')
+
+    @property
+    def track_dict(self) -> dict[str, Track] | None:
+        """Stored tracks when :attr:`store_data` is enabled."""
+        return getattr(self, '_track_dict', None)
 
     @property
     def _default_metadata_fields_to_ignore(self) -> set[str]:
@@ -256,6 +273,7 @@ class _DictTrackReader(TrackReader, _DictReader):
     def tracks_gen(self) -> Iterator[tuple[datetime, set[Track]]]:
 
         track_dict = {}
+        self._track_dict = track_dict if self.store_data else None
         updated_tracks = set()
         previous_time = None
         for row in self.dict_reader:

--- a/stonesoup/reader/tests/test_store_data.py
+++ b/stonesoup/reader/tests/test_store_data.py
@@ -1,0 +1,65 @@
+import numpy as np
+
+from ..generic import DictionaryGroundTruthReader, DictionaryTrackReader
+
+
+def _groundtruth_reader(store_data=False):
+    return DictionaryGroundTruthReader(
+        dictionaries=[
+            {'id': 'A', 'x': 0, 'y': 1, 'time': '2026-01-01T00:00:00'},
+            {'id': 'A', 'x': 1, 'y': 2, 'time': '2026-01-01T00:01:00'},
+            {'id': 'B', 'x': 3, 'y': 4, 'time': '2026-01-01T00:01:00'},
+        ],
+        state_vector_fields=['x', 'y'],
+        time_field='time',
+        path_id_field='id',
+        store_data=store_data,
+    )
+
+
+def _track_reader(store_data=False):
+    return DictionaryTrackReader(
+        dictionaries=[
+            {'id': 'A', 'x': 0, 'y': 1, 'time': '2026-01-01T00:00:00'},
+            {'id': 'A', 'x': 1, 'y': 2, 'time': '2026-01-01T00:01:00'},
+            {'id': 'B', 'x': 3, 'y': 4, 'time': '2026-01-01T00:01:00'},
+        ],
+        state_vector_fields=['x', 'y'],
+        time_field='time',
+        track_id_field='id',
+        default_covar=np.eye(2),
+        covar_fields_index={},
+        store_data=store_data,
+    )
+
+
+def test_groundtruth_reader_store_data():
+    reader = _groundtruth_reader(store_data=True)
+    list(reader)
+
+    assert set(reader.groundtruth_dict) == {'A', 'B'}
+    assert len(reader.groundtruth_dict['A']) == 2
+    assert len(reader.groundtruth_dict['B']) == 1
+
+
+def test_groundtruth_reader_does_not_store_data_by_default():
+    reader = _groundtruth_reader()
+    list(reader)
+
+    assert reader.groundtruth_dict is None
+
+
+def test_track_reader_store_data():
+    reader = _track_reader(store_data=True)
+    list(reader)
+
+    assert set(reader.track_dict) == {'A', 'B'}
+    assert len(reader.track_dict['A']) == 2
+    assert len(reader.track_dict['B']) == 1
+
+
+def test_track_reader_does_not_store_data_by_default():
+    reader = _track_reader()
+    list(reader)
+
+    assert reader.track_dict is None


### PR DESCRIPTION
## Summary

Adds opt-in retention of the internal path and track dictionaries built by dictionary-backed readers, addressing #470.

## Change

- Add `store_data=False` to ground-truth and track dictionary readers.
- Expose retained data through `groundtruth_dict` and `track_dict` when enabled.
- Keep the default behaviour unchanged so readers do not retain these dictionaries after iteration unless requested.
- Add focused tests for both enabled and default-disabled behaviour.

## Scope

No change to yielded reader data or existing defaults. The additional memory cost only applies when `store_data=True`.

Closes #470