### PR TITLE
Add optional Sobol sampling for circle actions

### DIFF
--- a/stonesoup/movable/action/move_position_action.py
+++ b/stonesoup/movable/action/move_position_action.py
@@ -3,6 +3,7 @@ from collections.abc import Iterator, Sequence
 from itertools import product
 
 import numpy as np
+from scipy.stats import qmc
 
 from ...base import Property
 from ...sensormanager.action import ActionGenerator, Action
@@ -173,6 +174,11 @@ class CircleSamplePositionActionGenerator(SamplePositionActionGenerator):
         "sampling area."
     )
 
+    use_qmc: bool = Property(
+        default=False,
+        doc="Use a Sobol quasi-random sequence instead of pseudorandom sampling."
+    )
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
@@ -182,13 +188,28 @@ class CircleSamplePositionActionGenerator(SamplePositionActionGenerator):
                              f":class:`~.CircleSamplePositionActionGenerator` "
                              f"is designed for 2D action generation only.")
 
+    @staticmethod
+    def _generate_samples(n_samples, qmc_engine=None):
+        if qmc_engine is None:
+            return np.random.uniform([0, 0], [1, 2*np.pi], (n_samples, 2))
+
+        radius_angle_samples = qmc_engine.random(n_samples)
+        radius_angle_samples[:, 1] *= 2*np.pi
+        return radius_angle_samples
+
     def __iter__(self):
 
         yield MovePositionAction(generator=self,
                                  end_time=self.end_time,
                                  target_value=self.current_value)
 
-        radius_angle_samples = np.random.uniform([0, 0], [1, 2*np.pi], (self.n_samples, 2))
+        qmc_engine = None
+        if self.use_qmc:
+            qmc_engine = qmc.Sobol(d=2, scramble=False)
+            # The first Sobol point is the origin, which duplicates the default action.
+            qmc_engine.random(1)
+
+        radius_angle_samples = self._generate_samples(self.n_samples, qmc_engine)
 
         sample_values = self.maximum_travel*np.sqrt(radius_angle_samples[:, 0]) *\
             np.array([np.sin(radius_angle_samples[:, 1]), np.cos(radius_angle_samples[:, 1])])
@@ -204,7 +225,7 @@ class CircleSamplePositionActionGenerator(SamplePositionActionGenerator):
                 _, idx = np.where(np.logical_or(
                     target_values[self.action_mapping, :] > self.action_space[:, [1]],
                     target_values[self.action_mapping, :] < self.action_space[:, [0]]))
-                radius_angle_samples = np.random.uniform([0, 0], [1, 2*np.pi], (len(idx), 2))
+                radius_angle_samples = self._generate_samples(len(idx), qmc_engine)
                 sample_values = self.maximum_travel*np.sqrt(radius_angle_samples[:, 0]) *\
                     np.array([np.sin(radius_angle_samples[:, 1]),
                               np.cos(radius_angle_samples[:, 1])])

--- a/stonesoup/movable/action/tests/test_qmc_action.py
+++ b/stonesoup/movable/action/tests/test_qmc_action.py
@@ -1,0 +1,81 @@
+from datetime import datetime, timedelta
+
+import numpy as np
+from numpy.testing import assert_allclose
+
+from ....platform import FixedPlatform
+from ....types.state import State, StateVector, StateVectors
+from ...sample import CircleSampleActionableMovable
+
+
+def test_circle_sample_sobol_actions():
+    start_time = datetime.now()
+    state = StateVector([0., 0.])
+    platform = FixedPlatform(
+        movement_controller=CircleSampleActionableMovable(
+            states=[State(state, timestamp=start_time)],
+            position_mapping=(0, 1),
+            n_samples=4,
+            maximum_travel=2.,
+            use_qmc=True,
+        )
+    )
+
+    generator = platform.actions(start_time + timedelta(seconds=1)).pop()
+    actions = [action.target_value for action in generator]
+
+    assert generator.use_qmc
+    assert len(actions) == 5
+    assert_allclose(actions[0], state)
+
+    # The origin of the Sobol sequence is skipped because the generator already
+    # yields a default action that remains at the current position.
+    sobol_samples = np.array([
+        [0.5, 0.5],
+        [0.75, 0.25],
+        [0.25, 0.75],
+        [0.375, 0.375],
+    ])
+    radii = 2 * np.sqrt(sobol_samples[:, 0])
+    angles = 2 * np.pi * sobol_samples[:, 1]
+    expected = np.column_stack((radii * np.sin(angles), radii * np.cos(angles)))
+    observed = np.array([np.asarray(action).ravel() for action in actions[1:]])
+
+    assert_allclose(observed, expected, atol=1e-12)
+
+
+def test_circle_sample_sobol_respects_action_space():
+    start_time = datetime.now()
+    action_space = StateVectors([[-1., 1.], [-1., 1.]])
+    platform = FixedPlatform(
+        movement_controller=CircleSampleActionableMovable(
+            states=[State(StateVector([0., 0.]), timestamp=start_time)],
+            position_mapping=(0, 1),
+            n_samples=4,
+            maximum_travel=2.,
+            action_space=action_space,
+            use_qmc=True,
+        )
+    )
+
+    generator = platform.actions(start_time + timedelta(seconds=1)).pop()
+    actions = [action.target_value for action in generator]
+    observed = np.hstack(actions)
+
+    assert len(actions) == 5
+    assert np.all(observed >= action_space[:, [0]])
+    assert np.all(observed <= action_space[:, [1]])
+
+
+def test_circle_sample_uses_pseudorandom_sampling_by_default():
+    start_time = datetime.now()
+    platform = FixedPlatform(
+        movement_controller=CircleSampleActionableMovable(
+            states=[State(StateVector([0., 0.]), timestamp=start_time)],
+            position_mapping=(0, 1),
+        )
+    )
+
+    generator = platform.actions(start_time + timedelta(seconds=1)).pop()
+
+    assert not generator.use_qmc

--- a/stonesoup/movable/sample.py
+++ b/stonesoup/movable/sample.py
@@ -90,10 +90,15 @@ class CircleSampleActionableMovable(_SampleActionableMovable):
     with :class:`~.CircleSamplePositionActionGenerator` """
 
     generator = CircleSamplePositionActionGenerator
-    _generator_kwargs = _SampleActionableMovable._generator_kwargs | {'maximum_travel'}
+    _generator_kwargs = _SampleActionableMovable._generator_kwargs | {'maximum_travel', 'use_qmc'}
 
     maximum_travel: float = Property(
         default=1.0,
         doc="Maximum possible travel distance. Specifies the radius of "
         "sampling area."
+    )
+
+    use_qmc: bool = Property(
+        default=False,
+        doc="Use a Sobol quasi-random sequence instead of pseudorandom sampling."
     )


### PR DESCRIPTION
## Summary

Adds opt-in Sobol quasi-random sampling to `CircleSamplePositionActionGenerator`, addressing #1180.

## Change

- Add `use_qmc=False` to circle position sampling and expose it through `CircleSampleActionableMovable`.
- Use a deterministic 2D Sobol sequence when enabled while preserving the existing pseudorandom default.
- Skip the Sobol origin because the generator already yields a stay-put default action.
- Continue the Sobol sequence when samples outside `action_space` need replacement.
- Add regression tests for exact Sobol samples, bounded action spaces, and default behaviour.

## Scope

Existing behaviour is unchanged unless `use_qmc=True`.

Closes #1180